### PR TITLE
Fix generating inherited object code

### DIFF
--- a/templates/interface.njk
+++ b/templates/interface.njk
@@ -4,7 +4,7 @@
 declare namespace {{ namespace }} {
   {% for type in list -%}
 {%- if type.props.length %}
-  type {{ type.typeName | safe }}{{ '' if type.parent === undefined else ' extends ' + type.parent }} = {
+  type {{ type.typeName | safe }} = {{ '' if type.parent === undefined else type.parent + ' & '  }} {
     {%- for prop in type.props %}
     {%- if prop.desc %}
     /** {{ prop.desc }} */


### PR DESCRIPTION
When you generate service from openapi, if you have an inherited object the result code is:

```
  type JoinResponse extends ApiResponse = {
    'data'
    ?: JoinResponseData;
  }
```
but it isn't a valid typescript code.
The valid one is:
```
  type LoginResponse = ApiResponse & {
    data?: LoginResponseData;
  };
```