### PR TITLE
add implementation for hook customClassName

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -471,9 +471,13 @@ class ServiceGenerator {
             controllerName: fileName,
           });
         }
+        let className = fileName;
+        if(this.config.hook && this.config.hook.customClassName) {
+          className = this.config.hook.customClassName(tag)
+        }
         return {
           genType: 'ts',
-          className: fileName,
+          className,
           instanceName: `${fileName[0].toLowerCase()}${fileName.substr(1)}`,
           list: genParams,
         };


### PR DESCRIPTION
Seems the customClassName is defined but not used yet. But this is required in my case. I got all tags written with Chinese, that's horrible to import services with Chinese. 