### PR TITLE
修复无operationId时，生成的functionName未达到预期的bug

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -855,12 +855,17 @@ class ServiceGenerator {
         })
     })
 
-    const res = arr
-        .map(item => Array.from(new Set(item)))
-        .filter(item => item.length === 1)
-        .join('/')
+    const res = []
+    arr.map(item => Array.from(new Set(item)))
+        .every(item => {
+          const b = item.length === 1
+          if (b){
+            res.push(item)
+          }
+          return b
+        })
 
-    return `${res}/`
+    return `${res.join('/')}/`
   }
 
   private resolveRefObject(refObject: any): any {


### PR DESCRIPTION
bug描述：
/api/order/{id}
/api/account/{id}
实际生成：getApiOrderById，getApiAccountById
预期：getOrderById，getAccountById


