### PR TITLE
fix:使用customFunctionName重新定义名称后，对应的typing.d.ts没有变更，导致类型报红

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -720,7 +720,7 @@ class ServiceGenerator {
 
             if(props.length>0){
               data.push([{
-                typeName: resolveTypeName(`${namespace}${operationObject.operationId}Params`),
+                typeName: resolveTypeName(`${namespace}${this.config?.hook?.customFunctionName?.(operationObject)??operationObject.operationId}Params`),
                 type: 'Record<string, any>',
                 parent: undefined,
                 props:[props],


### PR DESCRIPTION
### 配置项
```typescript
  openAPI: [
    {
      requestLibPath: "import { request } from 'umi'",
      // 或者使用在线的版本
      schemaPath: 'http://localhost:3006/docs-json',
      mock: false,
      projectName: '.',
      hook: {
        customFunctionName(operationObject: OperationObject) {
          const newOperationId = operationObject.operationId
            ?.replace(/controller/i, '')
            .replace(/[-_ .](\w)/g, (_all, letter) => letter.toUpperCase());
          operationObject.operationId = 'newOperationId';
          return newOperationId;
        },
      },
    },
  ],
```
### 生成service
```typescript

/** 文章列表 GET /api/article */
export async function ArticleFindAll(
  // 叠加生成的Param类型 (非body参数swagger默认没有生成对象)
  params: API.ArticleFindAllParams & {
    // query
    /** 当前页面 */
    current?: number;
    /** 页面数据量 */
    pageSize?: number;
    /** 排序 */
    orderBy?: 'createTime' | 'like' | 'topicCount' | 'id';
    /** 排序方式 */
    order?: 'DESC' | 'ASC';
    keyword?: string;
  },
  options?: { [key: string]: any },
) 
```

### 生成 typing.d.ts
```typescript
  type ArticleControllerFindAllParams = {
    /** 当前页面 */
    current?: number;
    /** 页面数据量 */
    pageSize?: number;
    /** 排序 */
    orderBy?: 'createTime' | 'like' | 'topicCount' | 'id';
    /** 排序方式 */
    order?: 'DESC' | 'ASC';
    keyword?: string;
  };
```
生成的控制器名称改变，但是对应的typing.d.ts没有变动，导致编辑器报红