### PR TITLE
feat: add buildForSinglePackage config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,12 @@ export type GenerateServiceProps = {
    * 模板文件的文件路径
    */
   templatesFolder?: string;
+
+  /**
+   * 支持作为独立的 npm package 发布
+   * 解决类型定义文件 declare namespace 与 d.ts 无法在独立 package 模式下良好使用的问题
+   */
+  buildForSinglePackage?: boolean;
 };
 
 const converterSwaggerToOpenApi = (swagger: any) => {

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -311,10 +311,13 @@ class ServiceGenerator {
       Log(`🚥 serves 生成失败: ${error}`);
     }
 
+    const typingFileName = this.config.buildForSinglePackage ? 'typings.ts' : 'typings.d.ts'
+
     // 生成 ts 类型声明
-    this.genFileFromTemplate('typings.d.ts', 'interface', {
+    this.genFileFromTemplate(typingFileName, 'interface', {
       namespace: this.config.namespace,
       // namespace: 'API',
+      buildForSinglePackage: this.config.buildForSinglePackage,
       list: this.getInterfaceTP(),
       disableTypeCheck: false,
     });
@@ -330,6 +333,7 @@ class ServiceGenerator {
         {
           namespace: this.config.namespace,
           requestImportStatement: this.config.requestImportStatement,
+          buildForSinglePackage: this.config.buildForSinglePackage,
           disableTypeCheck: false,
           ...tp,
         },

--- a/templates/interface.njk
+++ b/templates/interface.njk
@@ -1,7 +1,9 @@
-declare namespace {{ namespace }} {
+{% if buildForSinglePackage !== true %}
+  declare namespace {{ namespace }} {
+{% endif %}
   {% for type in list -%}
 {%- if type.props.length %}
-  type {{ type.typeName | safe }} =
+  {%- if buildForSinglePackage %} export {%- endif %} type {{ type.typeName | safe }} =
   {%- for prop in type.props %}
      {%- if (prop[0].$ref !== undefined) and (prop | length === 1) %}
       {{ prop[0].type }}
@@ -21,4 +23,6 @@ declare namespace {{ namespace }} {
   type {{ type.typeName | safe }} = {{ type.type }};
 {%- endif %}
 {% endfor %}
-}
+{% if buildForSinglePackage !== true %}
+    }
+{% endif %}

--- a/templates/serviceController.njk
+++ b/templates/serviceController.njk
@@ -1,6 +1,7 @@
 // @ts-ignore
 /* eslint-disable */
 {{ requestImportStatement }}
+{% if buildForSinglePackage %}import * as {{namespace}} from './typings';{% endif %}
 
 {% for api in list -%}
 /** {{ api.desc if api.desc else '此处后端没有提供注释' }} {{api.method | upper}} {{ api.pathInComment | safe }} */
@@ -81,7 +82,7 @@ files
     {% endif %}
     if (item !== undefined && item !== null) {
       {% if genType === "ts" %}
-      formData.append(ele, (typeof item === 'object' && !(item instanceof File)) ? JSON.stringify(item) : item); 
+      formData.append(ele, (typeof item === 'object' && !(item instanceof File)) ? JSON.stringify(item) : item);
       {% else %}
       formData.append(ele, typeof item === 'object' ? JSON.stringify(item) : item);
       {% endif %}
@@ -124,7 +125,7 @@ files
     data: formData,
     {%- if api.body.mediaType === "multipart/form-data" %}
     requestType: 'form',
-    {%- endif %} 
+    {%- endif %}
     {%- else %}
     {%- if api.body %}
     data: body,

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ const gen = async () => {
     requestLibPath: "import request  from '@/request';",
     schemaPath: `${__dirname}/example-files/swagger-custom-hook.json`,
     serversPath: './servers',
+    buildForSinglePackage: true,
     hook: {
         // 自定义类名
         customClassName: (tagName) => {


### PR DESCRIPTION
在多端开发的（electron、rn、web）monorepo架构下，生成的services适合作为独立的包在多项目内共享，单独生成的typings.d.ts无法很好的直接被tsc编译，只能另外拷贝

此外，declare namespace 的方式很难在 package 与 app之间达到一致的使用体验（特别是 非d.ts + isolatedModules 模式下，当然，也许存在更好的方式）。

此新增配置仅为可选项，不影响原有功能