### PR TITLE
add customTypeName hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ export type GenerateServiceProps = {
   hook?: {
     /** 自定义函数名称 */
     customFunctionName?: (data: OperationObject) => string;
+    /** 自定义类型名称 */
+    customTypeName?: (data: OperationObject) => string;
     /** 自定义类名 */
     customClassName?: (tagName: string) => string;
   };

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -355,6 +355,15 @@ class ServiceGenerator {
     return c.length > 0 ? c : null;
   };
 
+  public getTypeName(operationObject: OperationObject) {
+    const namespace = this.config.namespace ? `${this.config.namespace}.` : '';
+    const customeTypeName = this.config?.hook?.customTypeName || this.config?.hook?.customFunctionName;
+
+    return resolveTypeName(
+      `${namespace}${customeTypeName?.(operationObject) ?? operationObject.operationId}Params`,
+    );
+  }
+
   public getServiceTP() {
     // 获取路径相同部分
     const pathBasePrefix = this.getBasePrefix(Object.keys(this.openAPIData.paths));
@@ -477,6 +486,7 @@ class ServiceGenerator {
               return {
                 ...newApi,
                 functionName,
+                typeName: this.getTypeName(newApi),
                 path: getPrefixPath(),
                 pathInComment: formattedPath.replace(/\*/g, '&#42;'),
                 hasPathVariables: formattedPath.includes('{'),
@@ -730,20 +740,11 @@ class ServiceGenerator {
             });
           });
         }
-        let namespace = '';
-        if (this.config.namespace) {
-          namespace = `${this.config.namespace}.`;
-        }
 
         if (props.length > 0) {
           data && data.push([
             {
-              typeName: resolveTypeName(
-                `${namespace}${
-                  this.config?.hook?.customFunctionName?.(operationObject) ??
-                  operationObject.operationId
-                }Params`,
-              ),
+              typeName: this.getTypeName(operationObject),
               type: 'Record<string, any>',
               parent: undefined,
               props: [props],

--- a/templates/serviceController.njk
+++ b/templates/serviceController.njk
@@ -9,7 +9,7 @@ export async function {{ api.functionName }}(
   // 叠加生成的Param类型 (非body参数swagger默认没有生成对象)
   params
   {%- if genType === "ts" -%}
-  : {{namespace}}.{{api.functionName}}Params
+  : {{namespace}}.{{api.typeName}}
     {# header 入参 -#}
     {% if api.params.header -%}
     & { // header

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,16 @@ const gen = async () => {
                 funName = funName.substring(0, funName.lastIndexOf(suffix));
             }
             return funName;
+        },
+        // 自定义类型名
+        customTypeName: (data) => {
+          const { operationId } = data;
+          const funName = operationId
+            ? operationId[0].toUpperCase() + operationId.substring(1)
+            : '';
+          const tag = operationObject.tags && operationObject.tags[0];
+
+          return `${tag ? tag : ''}${funName}`;
         }
     }
   });


### PR DESCRIPTION
增加自定义参数类型名称hook。

目前“叠加生成的Param类型”名称与函数名称相同，但是类型名称统一放在了namespace下面，很容易冲突。
比如`PetController.query`，就直接生成了`API.queryParams`类型，如果其他controller有同名的query函数，就会用这同一个类型名称。

一种解决办法是让后端改函数名，比如`PetController.queryPets`、`ShopController.queryShops`，而且还必须保证函数名全局唯一。另一种是将这些类型放在各自的模块里面。

但是都比较麻烦，所以可以考虑用hook的方式进行自定义，就可以生成类似`API.PetQueryParams`的名称，参考test/test.js

如果可行的话还需要在@umi/plugin-openapi 加上`customTypeName: joi.function()`验证。