### PR TITLE
fix: generate IntersectionTypes by inherited class

### DIFF
--- a/templates/interface.njk
+++ b/templates/interface.njk
@@ -1,28 +1,32 @@
 declare namespace {{ namespace }} {
   {% for type in list -%}
-{%- if type.props.length %}
-  {%- if type.isEnum %}
-   enum {{ type.typeName | safe }} 
-  {%- else %}
-    type {{ type.typeName | safe }} =
-  {%- endif %}
-  {%- for prop in type.props %}
-     {
-     {%- for p in prop %}
-      {%- if p.desc %}
-      /** {{ p.desc }} */
+    {%- if type.props.length %}
+      {%- if type.isEnum %}
+        enum {{ type.typeName | safe }} 
+      {%- else %}
+        type {{ type.typeName | safe }} =
       {%- endif %}
-      '{{ p.name }}'{{ '' if p.required else '?' }}: {{ p.type | safe }};
-     {%- endfor %}
-     }
-    {{ '' if loop.last === true else ' & '  }}
-  {%- endfor %}
-{%- else %}
-  {%- if type.isEnum  %}
-   enum {{ type.typeName | safe }} {{ type.type }};
-  {%- else %}
-    type {{ type.typeName | safe }} = {{ type.type }};
-  {%- endif %}
-{%- endif %}
-{% endfor %}
+      {%- for prop in type.props %}
+        {%- if prop[0].$ref  %}
+          {{ prop[0].type }}
+        {%- else %}
+          {
+          {%- for p in prop %}
+            {%- if p.desc %}
+              /** {{ p.desc }} */
+            {%- endif %}
+            '{{ p.name }}'{{ '' if p.required else '?' }}: {{ p.type | safe }};
+          {%- endfor %}
+          }
+        {%- endif %}
+        {{ '' if loop.last === true else ' & '  }}
+      {%- endfor %}
+    {%- else %}
+      {%- if type.isEnum  %}
+        enum {{ type.typeName | safe }} {{ type.type }};
+      {%- else %}
+        type {{ type.typeName | safe }} = {{ type.type }};
+      {%- endif %}
+    {%- endif %}
+  {% endfor %}
 }


### PR DESCRIPTION
#66

AuditFields作为审计字段被Car继承，此时生成的Car错误

```
// 错误示例
declare namespace API {
  type AuditFields = {
    lastUpdatedOn?: string;
    createdOn?: string;
  };

  type Car = {
    ""?: AuditFields;
  } & {
    no: string;
    name?: string;
    userInfo?: UserInfo;
  };

  type UserInfo = {
    id?: string;
    name?: string;
  };
}

```
```
// 正确示例
declare namespace API {
  type AuditFields = {
    lastUpdatedOn?: string;
    createdOn?: string;
  };

  type Car = AuditFields & {
    no: string;
    name?: string;
    userInfo?: UserInfo;
  };

  type UserInfo = {
    id?: string;
    name?: string;
  };
}

```