### PR TITLE
解决 swagger 的 schema 中包含空格等特殊字符时生成的 type name 包含空格

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -63,8 +63,8 @@ const resolveTypeName = (typeName: string) => {
   if (!/[\u3220-\uFA29]/.test(name)) {
     return name;
   }
-
-  return pinyin.convertToPinyin(name, '', true);
+  const noBlankName = name.replace(/ +/g, '' )
+  return pinyin.convertToPinyin(noBlankName, '', true);
 };
 
 function getRefName(refObject: any): string {

--- a/test/example-files/swagger-schema-contain-blank-symbol.json
+++ b/test/example-files/swagger-schema-contain-blank-symbol.json
@@ -1,0 +1,187 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Swagger Petstore",
+    "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v2"
+    },
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/electricity/classification/time-sharing-electricity": {
+      "post": {
+        "tags": ["分项用电模块{6C76B49E435F7713E0531F0B10AC7013}"],
+        "summary": "分时电量查询",
+        "operationId": "timeSharingElectricityUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/分项、设备 自然时间 统计查询 dto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatisticsQueryVo"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "分项、设备 自然时间 统计查询 dto": {
+        "title": "分项、设备 自然时间 统计查询 dto",
+        "type": "object",
+        "properties": {
+          "businessType": {
+            "type": "string",
+            "description": "业务类型",
+            "enum": ["CLASSIFICATION", "DEVICE", "INSTRUMENT"]
+          },
+          "endTime": {
+            "type": "string",
+            "description": "结束时间",
+            "format": "date-time"
+          },
+          "energyType": {
+            "type": "string",
+            "description": "能源类型"
+          },
+          "ids": {
+            "type": "array",
+            "description": "根据业务类型传勾选id",
+            "items": {
+              "type": "string"
+            }
+          },
+          "startTime": {
+            "type": "string",
+            "description": "开始时间",
+            "format": "date-time"
+          },
+          "timeInterval": {
+            "type": "string",
+            "description": "时间粒度",
+            "enum": ["DAY", "HALFHOUR", "HOUR", "MINUTE", "MONTH", "QUARTERHOUR", "YEAR"]
+          },
+          "timeQueryType": {
+            "type": "string",
+            "description": "查询类型 自然时间-NATURAL,班制时间-SHIFT",
+            "enum": ["NATURAL", "SHIFT"]
+          },
+          "vsEndTime": {
+            "type": "string",
+            "description": "对比结束时间",
+            "format": "date-time"
+          },
+          "vsStartTime": {
+            "type": "string",
+            "description": "对比开始时间",
+            "format": "date-time"
+          },
+          "vsType": {
+            "type": "string",
+            "description": "比较类型",
+            "enum": ["CLASSIFICATION", "DEVICE", "TIME"]
+          }
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,11 @@ const gen = async () => {
   });
 
   await openAPI.generateService({
+    schemaPath: `${__dirname}/example-files/swagger-schema-contain-blank-symbol.json`,
+    serversPath: './servers/blank-symbol-servers',
+  });
+
+  await openAPI.generateService({
     schemaPath: `${__dirname}/example-files/swagger-file-convert.json`,
     serversPath: './file-servers',
   });

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ const gen = async () => {
           const funName = operationId
             ? operationId[0].toUpperCase() + operationId.substring(1)
             : '';
-          const tag = operationObject.tags && operationObject.tags[0];
+          const tag = data?.tags?.[0];
 
           return `${tag ? tag : ''}${funName}`;
         }


### PR DESCRIPTION
schema 为这样的

<img width="735" alt="image" src="https://user-images.githubusercontent.com/9244211/172981410-4e139b34-517e-47fb-b6d7-998dce241423.png">


*修改之前生成的 type name*
<img width="778" alt="image" src="https://user-images.githubusercontent.com/9244211/172982089-443b9eb8-9c02-4315-bd9b-3890daf64301.png">

*修改之后生成的 type name*

<img width="770" alt="image" src="https://user-images.githubusercontent.com/9244211/172982184-c3474791-4abd-4b8a-82a0-892d3c8854c1.png">


