### PR TITLE
fix: (serviceGenerator.ts) 解决原正则只处理了10以内的，超过10个中文依旧无法解析问题

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -61,7 +61,7 @@ const resolveTypeName = (typeName: string) => {
     .replace(/[^\w^\s^\u4e00-\u9fa5]/gi, '');
 
   // 当model名称是number开头的时候，ts会报错。这种场景一般发生在后端定义的名称是中文
-  if (name === '_' || /^\d$/.test(name)) {
+  if (name === '_' || /^\d+$/.test(name)) {
     Log('⚠️  models不能以number开头，原因可能是Model定义名称为中文, 建议联系后台修改');
     return `Pinyin_${name}`
   }


### PR DESCRIPTION
当model名称是number开头的时候，ts会报错。这种场景一般发生在后端定义的名称是中文
上一个PR的正则， 只解决只处理了10以内的，超过10个中文依旧无法解析问题