### PR TITLE
fix: 类型属性为空时的错误

### DIFF
--- a/templates/interface.njk
+++ b/templates/interface.njk
@@ -38,6 +38,9 @@ declare namespace {{ namespace }} {
           }
           {%- endif %}
         {%- endif %}
+        {%- if prop.length == 0 %}
+          {}
+        {%- endif %}
         {{ '' if loop.last === true else ' & '  }}
       {%- endfor %}
     {%- else %}


### PR DESCRIPTION
```
"AuthLogout": {"type": "object", "properties": {}}
```

before
![1669713595642](https://user-images.githubusercontent.com/23520283/204492934-7cff0051-fb19-440e-a3ef-13e1408d00df.jpg)

after
![1669714458987](https://user-images.githubusercontent.com/23520283/204493021-ef4a1a39-c2ec-4471-b5ca-9ee52817e831.jpg)
