### PR TITLE
feat: support data fields config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ npm run openapi
 | mockFolder  | 否 | mock目录 | string | - |
 | enumStyle  | 否 | 枚举样式 | string-literal \| enum | string-literal |
 | nullable | 否 | 使用null代替可选 | boolean | false |
+| dataFields | 否 | response中数据字段 | string[] | - |

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,12 @@ export type GenerateServiceProps = {
    * 枚举样式
    */
   enumStyle?: 'string-literal' | 'enum';
+
+  /**
+   * response中数据字段
+   * example: ['result', 'res']
+   */
+  dataFields?: string[];
 };
 
 const converterSwaggerToOpenApi = (swagger: any) => {

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -641,7 +641,7 @@ class ServiceGenerator {
       const refPaths = schema.$ref.split('/');
       const refName = refPaths[refPaths.length - 1];
       const childrenSchema = components.schemas[refName] as SchemaObject;
-      if (childrenSchema.type === 'object' && 'properties' in childrenSchema && this.config.dataFields) {
+      if (childrenSchema?.type === 'object' && 'properties' in childrenSchema && this.config.dataFields) {
         schema = this.config.dataFields.map(field => childrenSchema.properties[field]).filter(Boolean)?.[0] || resContent[mediaType].schema || DEFAULT_SCHEMA;
       }
     }


### PR DESCRIPTION
### 背景
后端swagger文档中response返回的是包含统一的结构体，比如
```
{
 "success": true,
 "error": "",
 "data": xxxxxx
}
```
但是前端工程中会在请求中进行封装统一返回数据字段，在业务代码中实际请求拿到的数据即为data字段数据，但是目前`openapi2typescript`中是原封不动还原swagger 文档中的response，直接使用会导致类型提示和运行结果不一致的问题

### 解决
新增`dataFields`配置，拿到response中的数据字段

