### PR TITLE
perf: improve import perf

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -4,7 +4,6 @@
 /* eslint-disable no-param-reassign */
 import path from 'path';
 import fs from 'fs';
-import * as prettier from 'prettier';
 import { camelCase, upperFirst } from 'lodash';
 
 const { prettier: defaultPrettierOptions } = require('@umijs/fabric');
@@ -27,6 +26,7 @@ export const prettierFile = (content: string): [string, boolean] => {
   let result = content;
   let hasError = false;
   try {
+    const prettier = require('prettier');
     result = prettier.format(content, {
       singleQuote: true,
       trailingComma: 'all',


### PR DESCRIPTION
See https://github.com/umijs/umi/issues/10645

这解决了 esm 模块预加载过程中，没使用到这个函数，但是仍然加载了 prettier 这个较重的依赖耗费的时间瓶颈问题。