### PR TITLE
fix: 修复operationObject.parameters可能为空导致报错

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -747,7 +747,7 @@ class ServiceGenerator {
         if (!operationObject) {
           return;
         }
-        operationObject.parameters = operationObject.parameters.filter(
+        operationObject.parameters = operationObject.parameters?.filter(
           (item) => (item as ParameterObject)?.in !== 'header',
         );
         const props = [];


### PR DESCRIPTION
修复将header参数放入params的功能#111，未兼容operationObject.parameters可能为空的情况，导致报错，影响正常使用
报错如下：
/Users/alexander/code/create-vite-react-app/node_modules/.pnpm/@umijs+openapi@1.8.4/node_modules/@umijs/openapi/dist/serviceGenerator.js:560
        Object.keys(this.openAPIData.paths || {}).forEach((p) => {
                                                          ^
TypeError: Cannot read properties of undefined (reading 'filter')
    at /Users/alexander/code/create-vite-react-app/node_modules/.pnpm/@umijs+openapi@1.8.4/node_modules/@umijs/openapi/dist/serviceGenerator.js:567:73
    at Array.forEach (<anonymous>)
    at /Users/alexander/code/create-vite-react-app/node_modules/.pnpm/@umijs+openapi@1.8.4/node_modules/@umijs/openapi/dist/serviceGenerator.js:562:55
    at Array.forEach (<anonymous>)
    at ServiceGenerator.getInterfaceTP (/Users/alexander/code/create-vite-react-app/node_modules/.pnpm/@umijs+openapi@1.8.4/node_modules/@umijs/openapi/dist/serviceGenerator.js:560:59)
    at ServiceGenerator.genFile (/Users/alexander/code/create-vite-react-app/node_modules/.pnpm/@umijs+openapi@1.8.4/node_modules/@umijs/openapi/dist/serviceGenerator.js:246:24)
    at /Users/alexander/code/create-vite-react-app/node_modules/.pnpm/@umijs+openapi@1.8.4/node_modules/@umijs/openapi/dist/index.js:72:22
    at Generator.next (<anonymous>)
    at fulfilled (/Users/alexander/code/create-vite-react-app/node_modules/.pnpm/tslib@2.6.0/node_modules/tslib/tslib.js:166:62)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)