### PR TITLE
API注释中增加应答的默认描述

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepublishOnly": "npm run build && np --no-cleanup --yolo --no-publish --any-branch",
     "start": "tsc -w",
     "test": "rm -rf ./test/servers/ ./test/file-servers/ &&  npm run build && cd ./test && node ./test.js && cd ..",
-    "test:windows": "rimraf ./test/servers/ ./test/file-servers/ &&  ts-node ./test/test.ts --project tsconfig.json && cd .."
+    "test:windows": "rimraf ./test/servers/ ./test/servers-allof/ ./test/file-servers/ && npm run build && cd ./test && ts-node ./test.js --project tsconfig.json && cd .."
   },
   "dependencies": {
     "@umijs/fabric": "^2.5.6",

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -510,7 +510,11 @@ class ServiceGenerator {
                 desc:
                   functionName === newApi.summary
                     ? newApi.description
-                    : [newApi.summary, newApi.description].filter((s) => s).join(' '),
+                    : [
+                      newApi.summary, 
+                      newApi.description, 
+                      (newApi.responses?.default as ResponseObject)?.description ? `返回值: ${(newApi.responses?.default as ResponseObject).description}` : ''
+                    ].filter((s) => s).join(' '),
                 hasHeader: !!(params && params.header) || !!(body && body.mediaType),
                 params: finalParams,
                 hasParams: Boolean(Object.keys(finalParams || {}).length),

--- a/test/example-files/swagger-custom-hook.json
+++ b/test/example-files/swagger-custom-hook.json
@@ -110,6 +110,7 @@
           "帐号 租户帐号 UserAccount"
         ],
         "summary": "登录 - 帐密登录",
+        "description":"参数：account",
         "operationId": "accountLoginUsingPOST",
         "requestBody": {
           "content": {
@@ -121,6 +122,10 @@
           }
         },
         "responses": {
+          "default":{
+            "description":"true代表登录成功，否则为提示信息",
+            "content":{"*/*":{"schema":{"type":"string"}}}
+          },
           "200": {
             "description": "OK",
             "content": {


### PR DESCRIPTION
生成API注释时，增加了应答的默认描述，以看到对返回值的说明。顺便解决了运行 npm run test:windows 时的问题。
修改前：
/** 登录 - 帐密登录 参数：account POST /api/v1/user/account/login.json */
export async function accountLogin(body: API.AccountLoginReq, options?: { [key: string]: any }) {
修改后：
/** 登录 - 帐密登录 参数：account 返回值: true代表登录成功，否则为提示信息 POST /api/v1/user/account/login.json */
export async function accountLogin(body: API.AccountLoginReq, options?: { [key: string]: any }) {
