### PR TITLE
fix: 修复requestBody中properties属性键值存在特殊符号导致报错解析文件失败

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -896,6 +896,8 @@ class ServiceGenerator {
       ? Object.keys(schemaObject.properties).map((propName) => {
           const schema: SchemaObject =
             (schemaObject.properties && schemaObject.properties[propName]) || DEFAULT_SCHEMA;
+          // 剔除属性键值中的特殊符号，因为函数入参变量存在特殊符号会导致解析文件失败
+          propName = propName.replace(/[\[|\]]/g, '');
           return {
             ...schema,
             name: propName,


### PR DESCRIPTION
fixed bug: [#122](https://github.com/chenshuai2144/openapi2typescript/issues/122)