### PR TITLE
pref: 生成的ts文件名和api函数改为驼峰命名

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -14,6 +14,7 @@ import type {
   SchemaObject,
 } from 'openapi3-ts';
 import { join } from 'path';
+import { camelCase } from 'lodash';
 import ReservedDict from 'reserved-words';
 import rimraf from 'rimraf';
 import pinyin from 'tiny-pinyin';
@@ -318,7 +319,7 @@ class ServiceGenerator {
         }
 
         tags.forEach((tagString) => {
-          const tag = resolveTypeName(tagString);
+          const tag = camelCase(resolveTypeName(tagString));
 
           if (!this.apiData[tag]) {
             this.apiData[tag] = [];
@@ -529,7 +530,7 @@ class ServiceGenerator {
 
               return {
                 ...newApi,
-                functionName,
+                functionName: camelCase(functionName),
                 typeName: this.getTypeName(newApi),
                 path: getPrefixPath(),
                 pathInComment: formattedPath.replace(/\*/g, '&#42;'),


### PR DESCRIPTION
后端接口命名不规范时，前端格式化api函数命名为：驼峰命名