### PR TITLE
perf: 新增isCamelCase参数, 支持小驼峰命名或者默认命名

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ npm run openapi
 | enumStyle  | 否 | 枚举样式 | string-literal \| enum | string-literal |
 | nullable | 否 | 使用null代替可选 | boolean | false |
 | dataFields | 否 | response中数据字段 | string[] | - |
+| isCamelCase | 否 | 小驼峰命名文件和请求函数 | boolean | true |

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,7 @@ export const generateService = async ({
       requestImportStatement,
       enumStyle: 'string-literal',
       nullable,
+      isCamelCase: true,
       ...rest,
     },
     openAPI,

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,11 @@ export type GenerateServiceProps = {
    * example: ['result', 'res']
    */
   dataFields?: string[];
+
+  /**
+   * 模板文件、请求函数采用小驼峰命名
+   */
+  isCamelCase?: boolean;
 };
 
 const converterSwaggerToOpenApi = (swagger: any) => {

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -298,7 +298,6 @@ class ServiceGenerator {
     this.config = {
       projectName: 'api',
       templatesFolder: join(__dirname, '../', 'templates'),
-      isCamelCase: true,
       ...config,
     };
     this.openAPIData = openAPIData;

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -298,6 +298,7 @@ class ServiceGenerator {
     this.config = {
       projectName: 'api',
       templatesFolder: join(__dirname, '../', 'templates'),
+      isCamelCase: true,
       ...config,
     };
     this.openAPIData = openAPIData;
@@ -319,7 +320,7 @@ class ServiceGenerator {
         }
 
         tags.forEach((tagString) => {
-          const tag = camelCase(resolveTypeName(tagString));
+          const tag = this.config.isCamelCase ? camelCase(resolveTypeName(tagString)) : resolveTypeName(tagString);
 
           if (!this.apiData[tag]) {
             this.apiData[tag] = [];
@@ -531,7 +532,7 @@ class ServiceGenerator {
 
               return {
                 ...newApi,
-                functionName: camelCase(functionName),
+                functionName: this.config.isCamelCase ? camelCase(functionName) : functionName,
                 typeName: this.getTypeName(newApi),
                 path: getPrefixPath(),
                 pathInComment: formattedPath.replace(/\*/g, '&#42;'),


### PR DESCRIPTION
强制小驼峰命名未考虑历史包袱，未考虑使用者的迁移意愿，遂加入新参数isCamelCase。
默认为小驼峰命名，不愿迁移的使用者使用isCamelCase: false保持默认命名