### PR TITLE
feat: 新增isSingleQuote参数, 支持生成文件的字符串选择使用单引号或双引号

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ npm run openapi
 | enumStyle  | 否 | 枚举样式 | string-literal \| enum | string-literal |
 | nullable | 否 | 使用null代替可选 | boolean | false |
 | dataFields | 否 | response中数据字段 | string[] | - |
+| isCamelCase | 否 | 小驼峰命名文件和请求函数 | boolean | true |

--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ npm run openapi
 | nullable | 否 | 使用null代替可选 | boolean | false |
 | dataFields | 否 | response中数据字段 | string[] | - |
 | isCamelCase | 否 | 小驼峰命名文件和请求函数 | boolean | true |
+| isSingleQuote | 否 | 字符串使用单引号 或 双引号 | boolean | true |

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,7 @@ export const generateService = async ({
       requestImportStatement,
       enumStyle: 'string-literal',
       nullable,
+      isCamelCase: true,
       ...rest,
     },
     openAPI,

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,14 @@ export type GenerateServiceProps = {
    * 模板文件、请求函数采用小驼峰命名
    */
   isCamelCase?: boolean;
+
+  /**
+   * 字符串使用单引号or双引号
+   */
+  isSingleQuote?: boolean;
 };
+
+export type ISingleQuote = Pick<GenerateServiceProps, "isSingleQuote">
 
 const converterSwaggerToOpenApi = (swagger: any) => {
   if (!swagger.swagger) {
@@ -186,6 +193,7 @@ export const generateService = async ({
   schemaPath,
   mockFolder,
   nullable = false,
+  isSingleQuote = true,
   ...rest
 }: GenerateServiceProps) => {
   const openAPI = await getOpenAPIConfig(schemaPath);
@@ -197,6 +205,7 @@ export const generateService = async ({
       enumStyle: 'string-literal',
       nullable,
       isCamelCase: true,
+      isSingleQuote,
       ...rest,
     },
     openAPI,
@@ -207,6 +216,7 @@ export const generateService = async ({
     await mockGenerator({
       openAPI,
       mockFolder: mockFolder || './mocks/',
+      isSingleQuote,
     });
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,11 @@ export type GenerateServiceProps = {
    * example: ['result', 'res']
    */
   dataFields?: string[];
+
+  /**
+   * 模板文件、请求函数采用小驼峰命名
+   */
+  isCamelCase?: boolean;
 };
 
 const converterSwaggerToOpenApi = (swagger: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,12 +136,12 @@ export type GenerateServiceProps = {
   isCamelCase?: boolean;
 
   /**
-   * 字符串使用单引号or双引号
+   * 字符串使用单引号 或 双引号
    */
   isSingleQuote?: boolean;
 };
 
-export type ISingleQuote = Pick<GenerateServiceProps, "isSingleQuote">
+export type ISingleQuote = Pick<GenerateServiceProps, "isSingleQuote">;
 
 const converterSwaggerToOpenApi = (swagger: any) => {
   if (!swagger.swagger) {

--- a/src/mockGenerator.ts
+++ b/src/mockGenerator.ts
@@ -160,8 +160,9 @@ const genMockFiles = (mockFunction: string[]) => {
       import { Request, Response } from 'express';
       
       export default {
-      ${mockFunction.join('\n,')}
-    }`
+        ${mockFunction.join('\n,')}
+      }
+    `
   })[0];
 };
 export type genMockDataServerConfig = { openAPI: any; mockFolder: string } & ISingleQuote;

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -879,7 +879,13 @@ class ServiceGenerator {
       nunjucks.configure({
         autoescape: false,
       });
-      return writeFile(this.finalPath, fileName, nunjucks.renderString(template, params));
+
+      return writeFile({
+        folderPath: this.finalPath,
+        fileName: fileName,
+        content: nunjucks.renderString(template, params),
+        isSingleQuote: this.config.isSingleQuote,
+      });
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('[GenSDK] file gen fail:', fileName, 'type:', type);

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -298,7 +298,6 @@ class ServiceGenerator {
     this.config = {
       projectName: 'api',
       templatesFolder: join(__dirname, '../', 'templates'),
-      isCamelCase: true,
       ...config,
     };
     this.openAPIData = openAPIData;

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -298,6 +298,7 @@ class ServiceGenerator {
     this.config = {
       projectName: 'api',
       templatesFolder: join(__dirname, '../', 'templates'),
+      isCamelCase: true,
       ...config,
     };
     this.openAPIData = openAPIData;
@@ -319,7 +320,7 @@ class ServiceGenerator {
         }
 
         tags.forEach((tagString) => {
-          const tag = camelCase(resolveTypeName(tagString));
+          const tag = this.config.isCamelCase ? camelCase(resolveTypeName(tagString)) : resolveTypeName(tagString);
 
           if (!this.apiData[tag]) {
             this.apiData[tag] = [];
@@ -531,7 +532,7 @@ class ServiceGenerator {
 
               return {
                 ...newApi,
-                functionName: camelCase(functionName),
+                functionName: this.config.isCamelCase ? camelCase(functionName) : functionName,
                 typeName: this.getTypeName(newApi),
                 path: getPrefixPath(),
                 pathInComment: formattedPath.replace(/\*/g, '&#42;'),

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,7 @@
 import path from 'path';
 import fs from 'fs';
 import { camelCase, upperFirst } from 'lodash';
+import type { GenerateServiceProps, ISingleQuote } from '.';
 
 const { prettier: defaultPrettierOptions } = require('@umijs/fabric');
 
@@ -22,31 +23,42 @@ export const mkdir = (dir: string) => {
   }
 };
 
-export const prettierFile = (content: string): [string, boolean] => {
+export const prettierFile = ({ content, isSingleQuote }: { content: string } & ISingleQuote): [string, boolean] => {
   let result = content;
   let hasError = false;
+
   try {
     const prettier = require('prettier');
     result = prettier.format(content, {
-      singleQuote: true,
       trailingComma: 'all',
       printWidth: 100,
       parser: 'typescript',
       ...defaultPrettierOptions,
+      singleQuote: isSingleQuote,
     });
   } catch (error) {
     hasError = true;
   }
+
   return [result, hasError];
 };
 
-export const writeFile = (folderPath: string, fileName: string, content: string) => {
+interface IWriteFileParams extends ISingleQuote {
+  folderPath: string;
+  fileName: string;
+  content: string;
+}
+
+export const writeFile = (params: IWriteFileParams) => {
+  const { folderPath, fileName, content, isSingleQuote } = params;
   const filePath = path.join(folderPath, fileName);
   mkdir(path.dirname(filePath));
-  const [prettierContent, hasError] = prettierFile(content);
+  const [prettierContent, hasError] = prettierFile({ content, isSingleQuote });
+
   fs.writeFileSync(filePath, prettierContent, {
     encoding: 'utf8',
   });
+
   return hasError;
 };
 


### PR DESCRIPTION
前端字符串使用趋势是推荐单引号更好，比如：各种流行库源码(react、vue)都适用单引号，避免和html片段的双引号冲突等等
但是有些人习惯了字符串双引号，prettier默认格式化js、jsx、ts、tsx为双引号，eslint默认为双引号等等
可见字符串单双引号也需根据个人意愿选择，遂增加参数isSingleQuote支持用户选择字符串为单引号或者双引号，默认还是保持单引号