### PR TITLE
回退默认把int64转换为string的修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ npm run openapi
 | nullable | 否 | 使用null代替可选 | boolean | false |
 | dataFields | 否 | response中数据字段 | string[] | - |
 | isCamelCase | 否 | 小驼峰命名文件和请求函数 | boolean | true |
+| hook | 否 | 自定义 hook | [Custom Hook](#Custom-Hook) | - |
+
+## Custom Hook
+
+| 属性           | 类型 | 说明               |
+| -------------- | ---- | ------------------ |
+| afterOpenApiDataInited | (openAPIData: OpenAPIObject) => OpenAPIObject  | - |
+| customFunctionName | (data: OperationObject) => string   | 自定义请求方法路径 |
+| customTypeName | (data: OperationObject) => string | 自定义函数名称 |
+| customClassName | (tagName: string) => string  | 自定义类型名称 |
+| customType | (<br>schemaObject: SchemaObject \| undefined,<br>namespace: string,<br>originGetType:(schemaObject: SchemaObject \| undefined, namespace: string) => string,<br>) => string  | 自定义获取类型 <br> *返回非字符串将使用默认方法获取type* |
+| customFileNames |  (<br>operationObject: OperationObject,<br>apiPath: string,<br>_apiMethod: string,<br>) => string[]   | 自定义生成文件名，可返回多个，表示生成多个文件. <br> *返回为空，则使用默认的获取方法获取* |

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -139,7 +139,6 @@ const defaultGetType = (schemaObject: SchemaObject | undefined, namespace: strin
 
   if (numberEnum.includes(schemaObject.format)) {
     type = 'number';
-    if (schemaObject.format === 'int64') type = 'string';
   }
 
   if (schemaObject.enum) {


### PR DESCRIPTION
这个PR改回了int64转换为string的改动, 并在README添加了hook的相关文档.

Int64还是数字类型, 默认转换为string类型很奇怪. 即使定义的是int64, 前端在操作这个数据时也是按照number类型来处理, 只是需要注意数据溢出处理. 而不是改成字符串.

如果确实需要对int64处理为BigInt或者string类型的, 是不是也可以使用`customTypeName` 这个hook来完成? 不知道是不是有伙伴不知道这些hook的存在，所以把这部分文档抽取出来了。

相关讨论.
https://github.com/chenshuai2144/openapi2typescript/issues/131

