### PR TITLE
fix: application/x-www-form-urlencoded不适用formData传参

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -441,7 +441,7 @@ class ServiceGenerator {
               const file = this.getFileTP(newApi.requestBody);
 
               let formData = false;
-              if ((body && (body.mediaType || '').includes('form')) || file) {
+              if ((body && (body.mediaType || '').includes('form-data')) || file) {
                 formData = true;
               }
 


### PR DESCRIPTION
media为application/x-www-form-urlencoded时也含有form，但是不应该使用formData