### PR TITLE
feat: support requestOptionsType config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ npm run openapi
 |  属性   | 必填  | 备注 | 类型 | 默认值 |
 |  ----  | ----  |  ----  |  ----  | - |
 | requestLibPath  | 否 | 自定义请求方法路径 | string | - |
+| requestOptionsType  | 否 | 自定义请求方法 options 参数类型 | string | {[key: string]: any} |
 | requestImportStatement  | 否 | 自定义请求方法表达式 | string | - |
 | apiPrefix  | 否 | api 的前缀 | string | - |
 | serversPath  | 否 | 生成的文件夹的路径 | string | - |

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ const getImportStatement = (requestLibPath: string) => {
 
 export type GenerateServiceProps = {
   requestLibPath?: string;
+  requestOptionsType?: string;
   requestImportStatement?: string;
   /**
    * api 的前缀
@@ -186,6 +187,7 @@ export const generateService = async ({
   schemaPath,
   mockFolder,
   nullable = false,
+  requestOptionsType = '{[key: string]: any}',
   ...rest
 }: GenerateServiceProps) => {
   const openAPI = await getOpenAPIConfig(schemaPath);
@@ -193,6 +195,7 @@ export const generateService = async ({
   const serviceGenerator = new ServiceGenerator(
     {
       namespace: 'API',
+      requestOptionsType,
       requestImportStatement,
       enumStyle: 'string-literal',
       nullable,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ export type GenerateServiceProps = {
     customFunctionName?: (data: OperationObject) => string;
     /** 自定义类型名称 */
     customTypeName?: (data: OperationObject) => string;
+    /** 自定义 options 默认值 */
+    customOptionsDefaultValue?: (data: OperationObject) =>  Record<string, any> | undefined;
     /** 自定义类名 */
     customClassName?: (tagName: string) => string;
 

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -373,6 +373,7 @@ class ServiceGenerator {
         template,
         {
           namespace: this.config.namespace,
+          requestOptionsType: this.config.requestOptionsType,
           requestImportStatement: this.config.requestImportStatement,
           disableTypeCheck: false,
           ...tp,

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -555,6 +555,7 @@ class ServiceGenerator {
                 hasHeader: !!(params && params.header) || !!(body && body.mediaType),
                 params: finalParams,
                 hasParams: Boolean(Object.keys(finalParams || {}).length),
+                options: this.config.hook?.customOptionsDefaultValue?.(newApi) || {}, 
                 body,
                 file,
                 hasFormData: formData,

--- a/templates/serviceController.njk
+++ b/templates/serviceController.njk
@@ -144,7 +144,7 @@ export async function {{ api.functionName }}(
     data: body,
     {%- endif %}
     {%- endif %}
-    ...(options || {}),
+    ...(options || {{api.options | dump}}),
   });
 }
 

--- a/templates/serviceController.njk
+++ b/templates/serviceController.njk
@@ -56,7 +56,7 @@ export async function {{ api.functionName }}(
 {%- endfor -%}
 {%- endif -%}
 {{ "," if api.body or api.hasParams or api.file }}
-  options {{ "?: {[key: string]: any}" if genType === "ts" }}
+  options {{ ("?: " + requestOptionsType) if genType === "ts" }}
 ) {
   {% if api.params and api.params.path -%}
   const { {% for param in api.params.path %}'{{ param.name }}': {{ param.alias }}, {% endfor %}


### PR DESCRIPTION
resolve #83
## 1. 支持自定义 options ts 类型(`requestOptionsType`)
目前 `options` 的类型在模板里面是写死为 `{[key: string]: any}`的，希望 `options` 的ts类型变为可配置项。例如：

<img width="1059" alt="image" src="https://github.com/chenshuai2144/openapi2typescript/assets/39730999/6b2a1329-dce4-4b89-9f51-0833422e733d">

## 2. 支持自定义 options 默认值(`hook.customOptionsDefaultValue`)
<img width="1053" alt="image" src="https://github.com/chenshuai2144/openapi2typescript/assets/39730999/b3cb0361-ab70-4a5a-8184-b7b42c58ae76">
