### PR TITLE
fix: 兼容调用resolveObject函数，schemaObject为null导致报错的场景

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import glob from 'glob';
+import { camelCase } from 'lodash';
 import * as nunjucks from 'nunjucks';
 import type {
   ContentObject,
@@ -14,7 +15,6 @@ import type {
   SchemaObject,
 } from 'openapi3-ts';
 import { join } from 'path';
-import { camelCase } from 'lodash';
 import ReservedDict from 'reserved-words';
 import rimraf from 'rimraf';
 import pinyin from 'tiny-pinyin';
@@ -925,6 +925,7 @@ class ServiceGenerator {
   }
 
   resolveObject(schemaObject: SchemaObject) {
+    schemaObject = schemaObject ?? {};
     // 引用类型
     if (schemaObject.$ref) {
       return this.resolveRefObject(schemaObject);


### PR DESCRIPTION
1. 执行resolveObject函数，schemaObject为null会导致报错
2. resolveObject(schemaObject: SchemaObject = {})无法处理SchemaObject为null的情况
3. 用 ?? 去处理null, 用 || 更宽泛

![1111](https://github.com/chenshuai2144/openapi2typescript/assets/22948077/25335d8a-7005-440d-aa3c-500aac6eb033)