### PR TITLE
fix: required在schemaObject和properties中的情况

### DIFF
--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import glob from 'glob';
-import { camelCase } from 'lodash';
+import { camelCase, isBoolean, isArray } from 'lodash';
 import * as nunjucks from 'nunjucks';
 import type {
   ContentObject,
@@ -201,10 +201,19 @@ const defaultGetType = (schemaObject: SchemaObject | undefined, namespace: strin
     }
     return `{ ${Object.keys(schemaObject.properties)
       .map((key) => {
-        const required =
-          'required' in (schemaObject.properties[key] || {})
-            ? ((schemaObject.properties[key] || {}) as any).required
-            : false;
+        let required = false;
+        if (isBoolean(schemaObject.required) && schemaObject.required) {
+          required = true;
+        }
+        if (isArray(schemaObject.required) && schemaObject.required.includes(key)) {
+          required = true;
+        }
+        if (
+          'required' in (schemaObject.properties[key] || {}) &&
+          (schemaObject.properties[key] || {}).required
+        ) {
+          required = true;
+        }
         /**
          * 将类型属性变为字符串，兼容错误格式如：
          * 3d_tile(数字开头)等错误命名，

--- a/src/serviceGenerator.ts
+++ b/src/serviceGenerator.ts
@@ -210,7 +210,7 @@ const defaultGetType = (schemaObject: SchemaObject | undefined, namespace: strin
         }
         if (
           'required' in (schemaObject.properties[key] || {}) &&
-          (schemaObject.properties[key] || {}).required
+          ((schemaObject.properties[key] || {}) as any).required
         ) {
           required = true;
         }


### PR DESCRIPTION
使用apifox生成的openapi3.1的接口时，下面这种情况required判断不正确
<img width="361" alt="image" src="https://github.com/chenshuai2144/openapi2typescript/assets/13713662/a70675db-d569-4f74-bdd4-ee8b62622ad7">
