### PR TITLE
fix: 消除require的缓存

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,9 @@ export const getSchema = async (schemaPath: string) => {
     }
     return null;
   }
+  if (require.cache[schemaPath]) {
+    delete require.cache[schemaPath];
+  }
   const schema = require(schemaPath);
   return schema;
 };


### PR DESCRIPTION
将其应用在热更新的环境时,require的缓存会导致读取不到最新变更的json内容