### PR TITLE
增加 Cli 以及项目级别配置文件支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,36 @@
 
 如果你使用 [umi](https://umijs.org) ,你可以使用[@umijs/plugin-openapi](https://www.npmjs.com/package/@umijs/plugin-openapi) 插件。
 ## 使用
-```node
+```bash
 npm i --save-dev @umijs/openapi
 ```
-在项目根目录新建 ```openapi.config.ts```
+在项目根目录新建 ```openapi2ts.config.ts``` 或者 ```.openapi2tsrc.ts```
+> 配置文件还支持 ***openapi2ts.config.ts***, ***.openapi2tsrc.json*** 等格式，参考 [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig?tab=readme-ov-file#cosmiconfig)
 ```ts
-const { generateService } = require('@umijs/openapi')
-
-generateService({
+export default {
   schemaPath: 'http://petstore.swagger.io/v2/swagger.json',
   serversPath: './servers',
-})
-
+}
 ```
-在 ```package.json``` 的 ```script``` 中添加 api: ```"openapi": "ts-node openapi.config.ts",```
+如果单个项目有多个生成需求，支持传入数组配置
+```ts
+export default [
+  {
+    schemaPath: 'http://app.swagger.io/v2/swagger.json',
+    serversPath: './servers/app',
+  },
+  {
+    schemaPath: 'http://auth.swagger.io/v2/swagger.json',
+    serversPath: './servers/auth',
+  }
+]
+```
+
+在 ```package.json``` 的 ```script``` 中添加 api: ```"openapi2ts": "openapi2ts",```
 
 生成api
-```node
-npm run openapi
+```bash
+npm run openapi2ts
 ```
 ## 参数
 |  属性   | 必填  | 备注 | 类型 | 默认值 |

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "license": "MIT",
   "author": "chenshuai2144",
   "main": "dist/index.js",
+  "bin": {
+    "openapi2ts": "dist/cli.js"
+  },
   "files": [
     "dist",
     "templates"
@@ -24,6 +27,7 @@
   "dependencies": {
     "@umijs/fabric": "^2.5.6",
     "chalk": "^4.1.2",
+    "cosmiconfig": "^9.0.0",
     "dayjs": "^1.10.3",
     "glob": "^7.1.6",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   chalk:
     specifier: ^4.1.2
     version: registry.npmmirror.com/chalk@4.1.2
+  cosmiconfig:
+    specifier: ^9.0.0
+    version: 9.0.0(typescript@4.1.3)
   dayjs:
     specifier: ^1.10.3
     version: registry.npmmirror.com/dayjs@1.10.3
@@ -73,6 +76,92 @@ devDependencies:
 
 packages:
 
+  /@babel/code-frame@7.12.11:
+    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
+    dependencies:
+      '@babel/highlight': 7.22.5
+    dev: false
+
+  /@babel/code-frame@7.22.5:
+    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.22.5
+
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/highlight@7.22.5:
+    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+
+  /ansi-styles@2.2.1:
+    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: registry.npmmirror.com/sprintf-js@1.0.3
+    dev: false
+
+  /argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: false
+
+  /callsites@2.0.0:
+    resolution: {integrity: sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  /chalk@1.1.3:
+    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-styles: 2.2.1
+      escape-string-regexp: 1.0.5
+      has-ansi: registry.npmmirror.com/has-ansi@2.0.0
+      strip-ansi: registry.npmmirror.com/strip-ansi@3.0.1
+      supports-color: 2.0.0
+    dev: true
+
+  /chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
+  /chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -90,6 +179,75 @@ packages:
     dev: false
     optional: true
 
+  /color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: registry.npmmirror.com/color-name@1.1.4
+
+  /color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+
+  /cosmiconfig@5.2.1:
+    resolution: {integrity: sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==}
+    engines: {node: '>=4'}
+    dependencies:
+      import-fresh: 2.0.0
+      is-directory: registry.npmmirror.com/is-directory@0.3.1
+      js-yaml: 3.14.1
+      parse-json: 4.0.0
+    dev: false
+
+  /cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/parse-json': registry.npmmirror.com/@types/parse-json@4.0.0
+      import-fresh: 3.3.0
+      parse-json: 5.2.0
+      path-type: registry.npmmirror.com/path-type@4.0.0
+      yaml: registry.npmmirror.com/yaml@1.10.2
+
+  /cosmiconfig@9.0.0(typescript@4.1.3):
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      typescript: registry.npmmirror.com/typescript@4.1.3
+    dev: false
+
+  /env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    dependencies:
+      is-arrayish: 0.2.1
+
+  /escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  /escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -97,6 +255,109 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
+  /has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  /import-fresh@2.0.0:
+    resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==}
+    engines: {node: '>=4'}
+    dependencies:
+      caller-path: registry.npmmirror.com/caller-path@2.0.0
+      resolve-from: 3.0.0
+    dev: false
+
+  /import-fresh@3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  /is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  /js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: registry.npmmirror.com/esprima@4.0.1
+    dev: false
+
+  /js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+    dev: false
+
+  /json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  /lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  /parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+    dependencies:
+      callsites: 3.1.0
+
+  /parse-json@4.0.0:
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
+    engines: {node: '>=4'}
+    dependencies:
+      error-ex: 1.3.2
+      json-parse-better-errors: registry.npmmirror.com/json-parse-better-errors@1.0.2
+    dev: false
+
+  /parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  /resolve-from@3.0.0:
+    resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  /resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  /supports-color@2.0.0:
+    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
+  /supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
+
+  /supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
 
   registry.npmmirror.com/@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz}
@@ -115,22 +376,6 @@ packages:
       '@jridgewell/trace-mapping': registry.npmmirror.com/@jridgewell/trace-mapping@0.3.18
     dev: false
 
-  registry.npmmirror.com/@babel/code-frame@7.12.11:
-    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.12.11.tgz}
-    name: '@babel/code-frame'
-    version: 7.12.11
-    dependencies:
-      '@babel/highlight': registry.npmmirror.com/@babel/highlight@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/code-frame@7.22.5:
-    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.22.5.tgz}
-    name: '@babel/code-frame'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': registry.npmmirror.com/@babel/highlight@7.22.5
-
   registry.npmmirror.com/@babel/compat-data@7.22.6:
     resolution: {integrity: sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/compat-data/-/compat-data-7.22.6.tgz}
     name: '@babel/compat-data'
@@ -145,7 +390,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': registry.npmmirror.com/@ampproject/remapping@2.2.1
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.22.5
+      '@babel/code-frame': 7.22.5
       '@babel/generator': registry.npmmirror.com/@babel/generator@7.22.7
       '@babel/helper-compilation-targets': registry.npmmirror.com/@babel/helper-compilation-targets@7.22.6(@babel/core@7.22.8)
       '@babel/helper-module-transforms': registry.npmmirror.com/@babel/helper-module-transforms@7.22.5
@@ -337,7 +582,7 @@ packages:
       '@babel/helper-module-imports': registry.npmmirror.com/@babel/helper-module-imports@7.22.5
       '@babel/helper-simple-access': registry.npmmirror.com/@babel/helper-simple-access@7.22.5
       '@babel/helper-split-export-declaration': registry.npmmirror.com/@babel/helper-split-export-declaration@7.22.6
-      '@babel/helper-validator-identifier': registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
       '@babel/template': registry.npmmirror.com/@babel/template@7.22.5
       '@babel/traverse': registry.npmmirror.com/@babel/traverse@7.22.8
       '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
@@ -429,12 +674,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5:
-    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz}
-    name: '@babel/helper-validator-identifier'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-
   registry.npmmirror.com/@babel/helper-validator-option@7.22.5:
     resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz}
     name: '@babel/helper-validator-option'
@@ -468,16 +707,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  registry.npmmirror.com/@babel/highlight@7.22.5:
-    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/highlight/-/highlight-7.22.5.tgz}
-    name: '@babel/highlight'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5
-      chalk: registry.npmmirror.com/chalk@2.4.2
-      js-tokens: registry.npmmirror.com/js-tokens@4.0.0
 
   registry.npmmirror.com/@babel/parser@7.22.7:
     resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/parser/-/parser-7.22.7.tgz}
@@ -1162,7 +1391,7 @@ packages:
       '@babel/helper-hoist-variables': registry.npmmirror.com/@babel/helper-hoist-variables@7.22.5
       '@babel/helper-module-transforms': registry.npmmirror.com/@babel/helper-module-transforms@7.22.5
       '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-validator-identifier': registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1751,7 +1980,7 @@ packages:
     version: 7.22.5
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.22.5
+      '@babel/code-frame': 7.22.5
       '@babel/parser': registry.npmmirror.com/@babel/parser@7.22.7
       '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
     dev: false
@@ -1762,7 +1991,7 @@ packages:
     version: 7.22.8
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.22.5
+      '@babel/code-frame': 7.22.5
       '@babel/generator': registry.npmmirror.com/@babel/generator@7.22.7
       '@babel/helper-environment-visitor': registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5
       '@babel/helper-function-name': registry.npmmirror.com/@babel/helper-function-name@7.22.5
@@ -1783,7 +2012,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': registry.npmmirror.com/@babel/helper-string-parser@7.22.5
-      '@babel/helper-validator-identifier': registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: registry.npmmirror.com/to-fast-properties@2.0.0
     dev: false
 
@@ -1798,8 +2027,8 @@ packages:
       espree: registry.npmmirror.com/espree@7.3.1
       globals: registry.npmmirror.com/globals@13.20.0
       ignore: registry.npmmirror.com/ignore@4.0.6
-      import-fresh: registry.npmmirror.com/import-fresh@3.3.0
-      js-yaml: registry.npmmirror.com/js-yaml@3.14.1
+      import-fresh: 3.3.0
+      js-yaml: 3.14.1
       minimatch: registry.npmmirror.com/minimatch@3.1.2
       strip-json-comments: registry.npmmirror.com/strip-json-comments@3.1.1
     transitivePeerDependencies:
@@ -2548,28 +2777,13 @@ packages:
     version: 5.0.1
     engines: {node: '>=8'}
 
-  registry.npmmirror.com/ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-styles/-/ansi-styles-2.2.1.tgz}
-    name: ansi-styles
-    version: 2.2.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmmirror.com/ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-styles/-/ansi-styles-3.2.1.tgz}
-    name: ansi-styles
-    version: 3.2.1
-    engines: {node: '>=4'}
-    dependencies:
-      color-convert: registry.npmmirror.com/color-convert@1.9.3
-
   registry.npmmirror.com/ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz}
     name: ansi-styles
     version: 4.3.0
     engines: {node: '>=8'}
     dependencies:
-      color-convert: registry.npmmirror.com/color-convert@2.0.1
+      color-convert: 2.0.1
 
   registry.npmmirror.com/any-observable@0.3.0(rxjs@6.6.7):
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/any-observable/-/any-observable-0.3.0.tgz}
@@ -2612,19 +2826,12 @@ packages:
     name: anymatch
     version: 3.1.3
     engines: {node: '>= 8'}
+    requiresBuild: true
     dependencies:
       normalize-path: registry.npmmirror.com/normalize-path@3.0.0
       picomatch: registry.npmmirror.com/picomatch@2.3.1
     dev: false
     optional: true
-
-  registry.npmmirror.com/argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/argparse/-/argparse-1.0.10.tgz}
-    name: argparse
-    version: 1.0.10
-    dependencies:
-      sprintf-js: registry.npmmirror.com/sprintf-js@1.0.3
-    dev: false
 
   registry.npmmirror.com/aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/aria-query/-/aria-query-5.3.0.tgz}
@@ -2944,6 +3151,7 @@ packages:
     name: binary-extensions
     version: 2.2.0
     engines: {node: '>=8'}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -2955,7 +3163,7 @@ packages:
     dependencies:
       ansi-align: registry.npmmirror.com/ansi-align@3.0.1
       camelcase: registry.npmmirror.com/camelcase@6.3.0
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      chalk: 4.1.2
       cli-boxes: registry.npmmirror.com/cli-boxes@2.2.1
       string-width: registry.npmmirror.com/string-width@4.2.3
       type-fest: registry.npmmirror.com/type-fest@0.20.2
@@ -3096,7 +3304,7 @@ packages:
     version: 2.0.0
     engines: {node: '>=4'}
     dependencies:
-      callsites: registry.npmmirror.com/callsites@2.0.0
+      callsites: 2.0.0
     dev: false
 
   registry.npmmirror.com/caller-path@2.0.0:
@@ -3107,19 +3315,6 @@ packages:
     dependencies:
       caller-callsite: registry.npmmirror.com/caller-callsite@2.0.0
     dev: false
-
-  registry.npmmirror.com/callsites@2.0.0:
-    resolution: {integrity: sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/callsites/-/callsites-2.0.0.tgz}
-    name: callsites
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz}
-    name: callsites
-    version: 3.1.0
-    engines: {node: '>=6'}
 
   registry.npmmirror.com/camelcase-keys@4.2.0:
     resolution: {integrity: sha512-Ej37YKYbFUI8QiYlvj9YHb6/Z60dZyPJW0Cs8sFilMbd2lP0bw3ylAq9yJkK4lcTA2dID5fG8LjmJYbO7kWb7Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz}
@@ -3173,29 +3368,6 @@ packages:
     name: ccount
     version: 1.1.0
     dev: false
-
-  registry.npmmirror.com/chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chalk/-/chalk-1.1.3.tgz}
-    name: chalk
-    version: 1.1.3
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@2.2.1
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
-      has-ansi: registry.npmmirror.com/has-ansi@2.0.0
-      strip-ansi: registry.npmmirror.com/strip-ansi@3.0.1
-      supports-color: registry.npmmirror.com/supports-color@2.0.0
-    dev: true
-
-  registry.npmmirror.com/chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chalk/-/chalk-2.4.2.tgz}
-    name: chalk
-    version: 2.4.2
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@3.2.1
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
-      supports-color: registry.npmmirror.com/supports-color@5.5.0
 
   registry.npmmirror.com/chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz}
@@ -3259,7 +3431,7 @@ packages:
     version: 1.0.0
     engines: {node: '>=4'}
     dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
+      escape-string-regexp: 1.0.5
     dev: false
 
   registry.npmmirror.com/clean-stack@2.2.0:
@@ -3388,26 +3560,6 @@ packages:
       object-visit: registry.npmmirror.com/object-visit@1.0.1
     dev: false
 
-  registry.npmmirror.com/color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/color-convert/-/color-convert-1.9.3.tgz}
-    name: color-convert
-    version: 1.9.3
-    dependencies:
-      color-name: registry.npmmirror.com/color-name@1.1.3
-
-  registry.npmmirror.com/color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz}
-    name: color-convert
-    version: 2.0.1
-    engines: {node: '>=7.0.0'}
-    dependencies:
-      color-name: registry.npmmirror.com/color-name@1.1.4
-
-  registry.npmmirror.com/color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/color-name/-/color-name-1.1.3.tgz}
-    name: color-name
-    version: 1.1.3
-
   registry.npmmirror.com/color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz}
     name: color-name
@@ -3491,30 +3643,6 @@ packages:
     name: core-util-is
     version: 1.0.3
     dev: false
-
-  registry.npmmirror.com/cosmiconfig@5.2.1:
-    resolution: {integrity: sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz}
-    name: cosmiconfig
-    version: 5.2.1
-    engines: {node: '>=4'}
-    dependencies:
-      import-fresh: registry.npmmirror.com/import-fresh@2.0.0
-      is-directory: registry.npmmirror.com/is-directory@0.3.1
-      js-yaml: registry.npmmirror.com/js-yaml@3.14.1
-      parse-json: registry.npmmirror.com/parse-json@4.0.0
-    dev: false
-
-  registry.npmmirror.com/cosmiconfig@7.1.0:
-    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz}
-    name: cosmiconfig
-    version: 7.1.0
-    engines: {node: '>=10'}
-    dependencies:
-      '@types/parse-json': registry.npmmirror.com/@types/parse-json@4.0.0
-      import-fresh: registry.npmmirror.com/import-fresh@3.3.0
-      parse-json: registry.npmmirror.com/parse-json@5.2.0
-      path-type: registry.npmmirror.com/path-type@4.0.0
-      yaml: registry.npmmirror.com/yaml@1.10.2
 
   registry.npmmirror.com/cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.3.tgz}
@@ -3947,13 +4075,6 @@ packages:
     version: 2.2.0
     dev: false
 
-  registry.npmmirror.com/error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/error-ex/-/error-ex-1.3.2.tgz}
-    name: error-ex
-    version: 1.3.2
-    dependencies:
-      is-arrayish: registry.npmmirror.com/is-arrayish@0.2.1
-
   registry.npmmirror.com/es-abstract@1.21.2:
     resolution: {integrity: sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es-abstract/-/es-abstract-1.21.2.tgz}
     name: es-abstract
@@ -4095,17 +4216,12 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  registry.npmmirror.com/escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz}
-    name: escape-string-regexp
-    version: 1.0.5
-    engines: {node: '>=0.8.0'}
-
   registry.npmmirror.com/escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz}
     name: escape-string-regexp
     version: 4.0.0
     engines: {node: '>=10'}
+    dev: true
 
   registry.npmmirror.com/eslint-ast-utils@1.1.0:
     resolution: {integrity: sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz}
@@ -4155,7 +4271,7 @@ packages:
     dependencies:
       '@types/eslint': registry.npmmirror.com/@types/eslint@7.29.0
       ansi-escapes: registry.npmmirror.com/ansi-escapes@4.3.2
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      chalk: 4.1.2
       eslint-rule-docs: registry.npmmirror.com/eslint-rule-docs@1.1.235
       log-symbols: registry.npmmirror.com/log-symbols@4.1.0
       plur: registry.npmmirror.com/plur@4.0.0
@@ -4249,7 +4365,7 @@ packages:
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
+      escape-string-regexp: 1.0.5
       eslint: registry.npmmirror.com/eslint@7.32.0
       ignore: registry.npmmirror.com/ignore@5.2.4
     dev: false
@@ -4507,16 +4623,16 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     hasBin: true
     dependencies:
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.12.11
+      '@babel/code-frame': 7.12.11
       '@eslint/eslintrc': registry.npmmirror.com/@eslint/eslintrc@0.4.3
       '@humanwhocodes/config-array': registry.npmmirror.com/@humanwhocodes/config-array@0.5.0
       ajv: registry.npmmirror.com/ajv@6.12.6
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      chalk: 4.1.2
       cross-spawn: registry.npmmirror.com/cross-spawn@7.0.3
       debug: registry.npmmirror.com/debug@4.3.4
       doctrine: registry.npmmirror.com/doctrine@3.0.0
       enquirer: registry.npmmirror.com/enquirer@2.3.6
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@4.0.0
+      escape-string-regexp: 4.0.0
       eslint-scope: registry.npmmirror.com/eslint-scope@5.1.1
       eslint-utils: registry.npmmirror.com/eslint-utils@2.1.0
       eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys@2.1.0
@@ -4529,10 +4645,10 @@ packages:
       glob-parent: registry.npmmirror.com/glob-parent@5.1.2
       globals: registry.npmmirror.com/globals@13.20.0
       ignore: registry.npmmirror.com/ignore@4.0.6
-      import-fresh: registry.npmmirror.com/import-fresh@3.3.0
+      import-fresh: 3.3.0
       imurmurhash: registry.npmmirror.com/imurmurhash@0.1.4
       is-glob: registry.npmmirror.com/is-glob@4.0.3
-      js-yaml: registry.npmmirror.com/js-yaml@3.14.1
+      js-yaml: 3.14.1
       json-stable-stringify-without-jsonify: registry.npmmirror.com/json-stable-stringify-without-jsonify@1.0.1
       levn: registry.npmmirror.com/levn@0.4.1
       lodash.merge: registry.npmmirror.com/lodash.merge@4.6.2
@@ -4804,7 +4920,7 @@ packages:
     version: 1.7.0
     engines: {node: '>=0.10.0'}
     dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
+      escape-string-regexp: 1.0.5
       object-assign: registry.npmmirror.com/object-assign@4.1.1
     dev: true
 
@@ -4814,7 +4930,7 @@ packages:
     version: 2.0.0
     engines: {node: '>=4'}
     dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
+      escape-string-regexp: 1.0.5
     dev: true
 
   registry.npmmirror.com/figures@3.2.0:
@@ -4823,7 +4939,7 @@ packages:
     version: 3.2.0
     engines: {node: '>=8'}
     dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
+      escape-string-regexp: 1.0.5
     dev: true
 
   registry.npmmirror.com/file-entry-cache@4.0.0:
@@ -4861,6 +4977,7 @@ packages:
     name: fill-range
     version: 7.0.1
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       to-regex-range: registry.npmmirror.com/to-regex-range@5.0.1
 
@@ -5294,18 +5411,6 @@ packages:
     version: 1.0.2
     dev: false
 
-  registry.npmmirror.com/has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-flag/-/has-flag-3.0.0.tgz}
-    name: has-flag
-    version: 3.0.0
-    engines: {node: '>=4'}
-
-  registry.npmmirror.com/has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz}
-    name: has-flag
-    version: 4.0.0
-    engines: {node: '>=8'}
-
   registry.npmmirror.com/has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz}
     name: has-property-descriptors
@@ -5489,25 +5594,6 @@ packages:
     version: 5.2.4
     engines: {node: '>= 4'}
 
-  registry.npmmirror.com/import-fresh@2.0.0:
-    resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-fresh/-/import-fresh-2.0.0.tgz}
-    name: import-fresh
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      caller-path: registry.npmmirror.com/caller-path@2.0.0
-      resolve-from: registry.npmmirror.com/resolve-from@3.0.0
-    dev: false
-
-  registry.npmmirror.com/import-fresh@3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz}
-    name: import-fresh
-    version: 3.3.0
-    engines: {node: '>=6'}
-    dependencies:
-      parent-module: registry.npmmirror.com/parent-module@1.0.1
-      resolve-from: registry.npmmirror.com/resolve-from@4.0.0
-
   registry.npmmirror.com/import-lazy@2.1.0:
     resolution: {integrity: sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-lazy/-/import-lazy-2.1.0.tgz}
     name: import-lazy
@@ -5607,7 +5693,7 @@ packages:
     name: inquirer-autosubmit-prompt
     version: 0.2.0
     dependencies:
-      chalk: registry.npmmirror.com/chalk@2.4.2
+      chalk: 2.4.2
       inquirer: registry.npmmirror.com/inquirer@6.5.2
       rxjs: registry.npmmirror.com/rxjs@6.6.7
     dev: true
@@ -5619,7 +5705,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       ansi-escapes: registry.npmmirror.com/ansi-escapes@3.2.0
-      chalk: registry.npmmirror.com/chalk@2.4.2
+      chalk: 2.4.2
       cli-cursor: registry.npmmirror.com/cli-cursor@2.1.0
       cli-width: registry.npmmirror.com/cli-width@2.2.1
       external-editor: registry.npmmirror.com/external-editor@3.1.0
@@ -5640,7 +5726,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       ansi-escapes: registry.npmmirror.com/ansi-escapes@4.3.2
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      chalk: 4.1.2
       cli-cursor: registry.npmmirror.com/cli-cursor@3.1.0
       cli-width: registry.npmmirror.com/cli-width@3.0.0
       external-editor: registry.npmmirror.com/external-editor@3.1.0
@@ -5722,11 +5808,6 @@ packages:
       is-typed-array: registry.npmmirror.com/is-typed-array@1.1.10
     dev: false
 
-  registry.npmmirror.com/is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-arrayish/-/is-arrayish-0.2.1.tgz}
-    name: is-arrayish
-    version: 0.2.1
-
   registry.npmmirror.com/is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-bigint/-/is-bigint-1.0.4.tgz}
     name: is-bigint
@@ -5740,6 +5821,7 @@ packages:
     name: is-binary-path
     version: 2.1.0
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       binary-extensions: registry.npmmirror.com/binary-extensions@2.2.0
     dev: false
@@ -5991,6 +6073,7 @@ packages:
     name: is-number
     version: 7.0.0
     engines: {node: '>=0.12.0'}
+    requiresBuild: true
 
   registry.npmmirror.com/is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz}
@@ -6241,21 +6324,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  registry.npmmirror.com/js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz}
-    name: js-tokens
-    version: 4.0.0
-
-  registry.npmmirror.com/js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/js-yaml/-/js-yaml-3.14.1.tgz}
-    name: js-yaml
-    version: 3.14.1
-    hasBin: true
-    dependencies:
-      argparse: registry.npmmirror.com/argparse@1.0.10
-      esprima: registry.npmmirror.com/esprima@4.0.1
-    dev: false
-
   registry.npmmirror.com/jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/jsesc/-/jsesc-0.5.0.tgz}
     name: jsesc
@@ -6288,11 +6356,6 @@ packages:
     name: json-parse-better-errors
     version: 1.0.2
     dev: false
-
-  registry.npmmirror.com/json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz}
-    name: json-parse-even-better-errors
-    version: 2.3.1
 
   registry.npmmirror.com/json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz}
@@ -6449,11 +6512,6 @@ packages:
       type-check: registry.npmmirror.com/type-check@0.4.0
     dev: false
 
-  registry.npmmirror.com/lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz}
-    name: lines-and-columns
-    version: 1.2.4
-
   registry.npmmirror.com/listr-input@0.2.1:
     resolution: {integrity: sha512-oa8iVG870qJq+OuuMK3DjGqFcwsK1SDu+kULp9kEq09TY231aideIZenr3lFOQdASpAr6asuyJBbX62/a3IIhg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-input/-/listr-input-0.2.1.tgz}
     name: listr-input
@@ -6482,7 +6540,7 @@ packages:
     peerDependencies:
       listr: ^0.14.2
     dependencies:
-      chalk: registry.npmmirror.com/chalk@1.1.3
+      chalk: 1.1.3
       cli-truncate: registry.npmmirror.com/cli-truncate@0.2.1
       elegant-spinner: registry.npmmirror.com/elegant-spinner@1.0.1
       figures: registry.npmmirror.com/figures@1.7.0
@@ -6499,7 +6557,7 @@ packages:
     version: 0.5.0
     engines: {node: '>=4'}
     dependencies:
-      chalk: registry.npmmirror.com/chalk@2.4.2
+      chalk: 2.4.2
       cli-cursor: registry.npmmirror.com/cli-cursor@2.1.0
       date-fns: registry.npmmirror.com/date-fns@1.30.1
       figures: registry.npmmirror.com/figures@2.0.0
@@ -6532,7 +6590,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       graceful-fs: registry.npmmirror.com/graceful-fs@4.2.11
-      parse-json: registry.npmmirror.com/parse-json@4.0.0
+      parse-json: 4.0.0
       pify: registry.npmmirror.com/pify@3.0.0
       strip-bom: registry.npmmirror.com/strip-bom@3.0.0
     dev: false
@@ -6615,7 +6673,7 @@ packages:
     version: 1.0.2
     engines: {node: '>=0.10.0'}
     dependencies:
-      chalk: registry.npmmirror.com/chalk@1.1.3
+      chalk: 1.1.3
     dev: true
 
   registry.npmmirror.com/log-symbols@2.2.0:
@@ -6624,7 +6682,7 @@ packages:
     version: 2.2.0
     engines: {node: '>=4'}
     dependencies:
-      chalk: registry.npmmirror.com/chalk@2.4.2
+      chalk: 2.4.2
     dev: false
 
   registry.npmmirror.com/log-symbols@4.1.0:
@@ -6633,7 +6691,7 @@ packages:
     version: 4.1.0
     engines: {node: '>=10'}
     dependencies:
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      chalk: 4.1.2
       is-unicode-supported: registry.npmmirror.com/is-unicode-supported@0.1.0
 
   registry.npmmirror.com/log-update@2.3.0:
@@ -6659,7 +6717,7 @@ packages:
     version: 1.4.0
     hasBin: true
     dependencies:
-      js-tokens: registry.npmmirror.com/js-tokens@4.0.0
+      js-tokens: 4.0.0
     dev: false
 
   registry.npmmirror.com/loud-rejection@1.6.0:
@@ -7210,6 +7268,7 @@ packages:
     name: normalize-path
     version: 3.0.0
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -7251,7 +7310,7 @@ packages:
       any-observable: registry.npmmirror.com/any-observable@0.5.1(rxjs@6.6.7)
       async-exit-hook: registry.npmmirror.com/async-exit-hook@2.0.1
       chalk: registry.npmmirror.com/chalk@4.1.2
-      cosmiconfig: registry.npmmirror.com/cosmiconfig@7.1.0
+      cosmiconfig: 7.1.0
       del: registry.npmmirror.com/del@6.1.1
       escape-goat: registry.npmmirror.com/escape-goat@3.0.0
       escape-string-regexp: registry.npmmirror.com/escape-string-regexp@4.0.0
@@ -7576,7 +7635,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@sindresorhus/is': registry.npmmirror.com/@sindresorhus/is@4.6.0
-      callsites: registry.npmmirror.com/callsites@3.1.0
+      callsites: 3.1.0
       dot-prop: registry.npmmirror.com/dot-prop@6.0.1
       lodash.isequal: registry.npmmirror.com/lodash.isequal@4.5.0
       type-fest: registry.npmmirror.com/type-fest@0.20.2
@@ -7764,14 +7823,6 @@ packages:
       semver: registry.npmmirror.com/semver@6.3.0
     dev: true
 
-  registry.npmmirror.com/parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz}
-    name: parent-module
-    version: 1.0.1
-    engines: {node: '>=6'}
-    dependencies:
-      callsites: registry.npmmirror.com/callsites@3.1.0
-
   registry.npmmirror.com/parse-entities@1.2.2:
     resolution: {integrity: sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parse-entities/-/parse-entities-1.2.2.tgz}
     name: parse-entities
@@ -7797,27 +7848,6 @@ packages:
       is-decimal: registry.npmmirror.com/is-decimal@1.0.4
       is-hexadecimal: registry.npmmirror.com/is-hexadecimal@1.0.4
     dev: false
-
-  registry.npmmirror.com/parse-json@4.0.0:
-    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parse-json/-/parse-json-4.0.0.tgz}
-    name: parse-json
-    version: 4.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      error-ex: registry.npmmirror.com/error-ex@1.3.2
-      json-parse-better-errors: registry.npmmirror.com/json-parse-better-errors@1.0.2
-    dev: false
-
-  registry.npmmirror.com/parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parse-json/-/parse-json-5.2.0.tgz}
-    name: parse-json
-    version: 5.2.0
-    engines: {node: '>=8'}
-    dependencies:
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.22.5
-      error-ex: registry.npmmirror.com/error-ex@1.3.2
-      json-parse-even-better-errors: registry.npmmirror.com/json-parse-even-better-errors@2.3.1
-      lines-and-columns: registry.npmmirror.com/lines-and-columns@1.2.4
 
   registry.npmmirror.com/pascalcase@0.1.1:
     resolution: {integrity: sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pascalcase/-/pascalcase-0.1.1.tgz}
@@ -8016,7 +8046,7 @@ packages:
     version: 6.0.1
     engines: {node: '>=6'}
     dependencies:
-      chalk: registry.npmmirror.com/chalk@2.4.2
+      chalk: 2.4.2
       lodash: registry.npmmirror.com/lodash@4.17.21
       log-symbols: registry.npmmirror.com/log-symbols@2.2.0
       postcss: registry.npmmirror.com/postcss@7.0.39
@@ -8322,7 +8352,7 @@ packages:
     dependencies:
       '@types/normalize-package-data': registry.npmmirror.com/@types/normalize-package-data@2.4.1
       normalize-package-data: registry.npmmirror.com/normalize-package-data@2.5.0
-      parse-json: registry.npmmirror.com/parse-json@5.2.0
+      parse-json: 5.2.0
       type-fest: registry.npmmirror.com/type-fest@0.6.0
 
   registry.npmmirror.com/readable-stream@1.0.34:
@@ -8363,6 +8393,7 @@ packages:
     name: readdirp
     version: 3.6.0
     engines: {node: '>=8.10.0'}
+    requiresBuild: true
     dependencies:
       picomatch: registry.npmmirror.com/picomatch@2.3.1
     dev: false
@@ -8650,26 +8681,7 @@ packages:
     version: 3.0.0
     engines: {node: '>=8'}
     dependencies:
-      resolve-from: registry.npmmirror.com/resolve-from@5.0.0
-
-  registry.npmmirror.com/resolve-from@3.0.0:
-    resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-from/-/resolve-from-3.0.0.tgz}
-    name: resolve-from
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz}
-    name: resolve-from
-    version: 4.0.0
-    engines: {node: '>=4'}
-
-  registry.npmmirror.com/resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-from/-/resolve-from-5.0.0.tgz}
-    name: resolve-from
-    version: 5.0.0
-    engines: {node: '>=8'}
+      resolve-from: 5.0.0
 
   registry.npmmirror.com/resolve-url@0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-url/-/resolve-url-0.2.1.tgz}
@@ -8990,7 +9002,7 @@ packages:
     version: 2.1.0
     engines: {node: '>=6'}
     dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@3.2.1
+      ansi-styles: 3.2.1
       astral-regex: registry.npmmirror.com/astral-regex@1.0.0
       is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@2.0.0
     dev: false
@@ -9001,7 +9013,7 @@ packages:
     version: 4.0.0
     engines: {node: '>=10'}
     dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@4.3.0
+      ansi-styles: 4.3.0
       astral-regex: registry.npmmirror.com/astral-regex@2.0.0
       is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@3.0.0
     dev: false
@@ -9493,8 +9505,8 @@ packages:
       '@stylelint/postcss-markdown': registry.npmmirror.com/@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)
       autoprefixer: registry.npmmirror.com/autoprefixer@9.8.8
       balanced-match: registry.npmmirror.com/balanced-match@2.0.0
-      chalk: registry.npmmirror.com/chalk@4.1.2
-      cosmiconfig: registry.npmmirror.com/cosmiconfig@7.1.0
+      chalk: 4.1.2
+      cosmiconfig: 7.1.0
       debug: registry.npmmirror.com/debug@4.3.4
       execall: registry.npmmirror.com/execall@2.0.0
       fast-glob: registry.npmmirror.com/fast-glob@3.3.0
@@ -9526,7 +9538,7 @@ packages:
       postcss-selector-parser: registry.npmmirror.com/postcss-selector-parser@6.0.13
       postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
       postcss-value-parser: registry.npmmirror.com/postcss-value-parser@4.2.0
-      resolve-from: registry.npmmirror.com/resolve-from@5.0.0
+      resolve-from: 5.0.0
       slash: registry.npmmirror.com/slash@3.0.0
       specificity: registry.npmmirror.com/specificity@0.4.1
       string-width: registry.npmmirror.com/string-width@4.2.3
@@ -9552,8 +9564,8 @@ packages:
     dependencies:
       autoprefixer: registry.npmmirror.com/autoprefixer@9.8.8
       balanced-match: registry.npmmirror.com/balanced-match@1.0.2
-      chalk: registry.npmmirror.com/chalk@2.4.2
-      cosmiconfig: registry.npmmirror.com/cosmiconfig@5.2.1
+      chalk: 2.4.2
+      cosmiconfig: 5.2.1
       debug: registry.npmmirror.com/debug@4.3.4
       execall: registry.npmmirror.com/execall@1.0.0
       file-entry-cache: registry.npmmirror.com/file-entry-cache@4.0.0
@@ -9588,7 +9600,7 @@ packages:
       postcss-selector-parser: registry.npmmirror.com/postcss-selector-parser@3.1.2
       postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
       postcss-value-parser: registry.npmmirror.com/postcss-value-parser@3.3.1
-      resolve-from: registry.npmmirror.com/resolve-from@4.0.0
+      resolve-from: 4.0.0
       signal-exit: registry.npmmirror.com/signal-exit@3.0.7
       slash: registry.npmmirror.com/slash@2.0.0
       specificity: registry.npmmirror.com/specificity@0.4.1
@@ -9609,28 +9621,13 @@ packages:
       postcss: registry.npmmirror.com/postcss@7.0.39
     dev: false
 
-  registry.npmmirror.com/supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-color/-/supports-color-2.0.0.tgz}
-    name: supports-color
-    version: 2.0.0
-    engines: {node: '>=0.8.0'}
-    dev: true
-
-  registry.npmmirror.com/supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-color/-/supports-color-5.5.0.tgz}
-    name: supports-color
-    version: 5.5.0
-    engines: {node: '>=4'}
-    dependencies:
-      has-flag: registry.npmmirror.com/has-flag@3.0.0
-
   registry.npmmirror.com/supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz}
     name: supports-color
     version: 7.2.0
     engines: {node: '>=8'}
     dependencies:
-      has-flag: registry.npmmirror.com/has-flag@4.0.0
+      has-flag: 4.0.0
 
   registry.npmmirror.com/supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz}
@@ -9638,8 +9635,8 @@ packages:
     version: 2.3.0
     engines: {node: '>=8'}
     dependencies:
-      has-flag: registry.npmmirror.com/has-flag@4.0.0
-      supports-color: registry.npmmirror.com/supports-color@7.2.0
+      has-flag: 4.0.0
+      supports-color: 7.2.0
 
   registry.npmmirror.com/supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz}
@@ -9819,6 +9816,7 @@ packages:
     name: to-regex-range
     version: 5.0.1
     engines: {node: '>=8.0'}
+    requiresBuild: true
     dependencies:
       is-number: registry.npmmirror.com/is-number@7.0.0
 
@@ -10216,7 +10214,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       boxen: registry.npmmirror.com/boxen@5.1.2
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      chalk: 4.1.2
       configstore: registry.npmmirror.com/configstore@5.0.1
       has-yarn: registry.npmmirror.com/has-yarn@2.1.0
       import-lazy: registry.npmmirror.com/import-lazy@2.1.0
@@ -10431,7 +10429,7 @@ packages:
     version: 7.0.0
     engines: {node: '>=10'}
     dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@4.3.0
+      ansi-styles: 4.3.0
       string-width: registry.npmmirror.com/string-width@4.2.3
       strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import chalk from 'chalk';
+import { cosmiconfigSync } from 'cosmiconfig';
+import { generateService, GenerateServiceProps } from './index';
+
+const explorerSync = cosmiconfigSync('openapi2ts');
+const searchedFor = explorerSync.search();
+
+async function run() {
+  try {
+    if (searchedFor?.config) {
+      const configs: GenerateServiceProps[] = Array.isArray(searchedFor.config)
+        ? searchedFor.config
+        : [searchedFor.config];
+
+      for (const config of configs) {
+        await generateService(config);
+      }
+    } else {
+      throw new Error('config is not found');
+    }
+  } catch (error) {
+    console.log(chalk.red(error));
+  }
+}
+
+run();


### PR DESCRIPTION
这个pr主要包含两个点：
1. 当前的使用方式需要由本地的`ts-node` 执行代码，但实际项目中，经常没有`ts-node`或者 `tsx` 这类依赖， 直接支持 cli 配合读取项目的配置文件应该是一个更好的使用方式。
2. 配置文件中以数组的方式支持同时配置多个 openapi endpoint，满足项目可能同时对接多个服务的场景。

不确定 **openapi2ts** 这个cli 的命令是否合适，欢迎讨论。