### PR TITLE
解析工作项目的prettier配置进行格式化

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,15 @@
-const fabric = require('@umijs/fabric');
-
 module.exports = {
-  ...fabric.prettier,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+  proseWrap: 'never',
+  endOfLine: 'lf',
+  overrides: [
+    {
+      files: '.prettierrc',
+      options: {
+        parser: 'json',
+      },
+    },
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test:windows": "rimraf ./test/servers/ ./test/servers-allof/ ./test/file-servers/ && npm run build && cd ./test && ts-node ./test.js --project tsconfig.json && cd .."
   },
   "dependencies": {
-    "@umijs/fabric": "^2.5.6",
     "chalk": "^4.1.2",
     "dayjs": "^1.10.3",
     "glob": "^7.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,1274 +1,111 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  chalk:
-    specifier: ^4.1.2
-    version: registry.npmmirror.com/chalk@4.1.2
-  cosmiconfig:
-    specifier: ^9.0.0
-    version: 9.0.0(typescript@4.1.3)
-  dayjs:
-    specifier: ^1.10.3
-    version: registry.npmmirror.com/dayjs@1.10.3
-  glob:
-    specifier: ^7.1.6
-    version: registry.npmmirror.com/glob@7.1.6
-  lodash:
-    specifier: ^4.17.21
-    version: registry.npmmirror.com/lodash@4.17.21
-  memoizee:
-    specifier: ^0.4.15
-    version: registry.npmmirror.com/memoizee@0.4.15
-  mock.js:
-    specifier: ^0.2.0
-    version: registry.npmmirror.com/mock.js@0.2.0
-  mockjs:
-    specifier: ^1.1.0
-    version: registry.npmmirror.com/mockjs@1.1.0
-  node-fetch:
-    specifier: ^2.6.1
-    version: registry.npmmirror.com/node-fetch@2.6.1
-  nunjucks:
-    specifier: ^3.2.2
-    version: registry.npmmirror.com/nunjucks@3.2.2
-  openapi3-ts:
-    specifier: ^2.0.1
-    version: registry.npmmirror.com/openapi3-ts@2.0.1
-  prettier:
-    specifier: ^2.2.1
-    version: registry.npmmirror.com/prettier@2.2.1
-  reserved-words:
-    specifier: ^0.1.2
-    version: registry.npmmirror.com/reserved-words@0.1.2
-  rimraf:
-    specifier: ^3.0.2
-    version: registry.npmmirror.com/rimraf@3.0.2
-  swagger2openapi:
-    specifier: ^7.0.4
-    version: registry.npmmirror.com/swagger2openapi@7.0.4
-  tiny-pinyin:
-    specifier: ^1.3.2
-    version: registry.npmmirror.com/tiny-pinyin@1.3.2
+importers:
 
-devDependencies:
-  '@types/express':
-    specifier: ^4.17.11
-    version: registry.npmmirror.com/@types/express@4.17.11
-  '@types/node':
-    specifier: ^14.14.22
-    version: registry.npmmirror.com/@types/node@14.14.22
-  np:
-    specifier: ^7.2.0
-    version: registry.npmmirror.com/np@7.2.0
-  tslib:
-    specifier: ^2.6.0
-    version: registry.npmmirror.com/tslib@2.6.0
-  typescript:
-    specifier: ^4.1.3
-    version: registry.npmmirror.com/typescript@4.1.3
+  .:
+    dependencies:
+      chalk:
+        specifier: ^4.1.2
+        version: https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz
+      cosmiconfig:
+        specifier: ^9.0.0
+        version: 9.0.0(typescript@4.1.3)
+      dayjs:
+        specifier: ^1.10.3
+        version: https://registry.npmmirror.com/dayjs/-/dayjs-1.10.3.tgz
+      glob:
+        specifier: ^7.1.6
+        version: https://registry.npmmirror.com/glob/-/glob-7.1.6.tgz
+      lodash:
+        specifier: ^4.17.21
+        version: https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz
+      memoizee:
+        specifier: ^0.4.15
+        version: https://registry.npmmirror.com/memoizee/-/memoizee-0.4.15.tgz
+      mock.js:
+        specifier: ^0.2.0
+        version: https://registry.npmmirror.com/mock.js/-/mock.js-0.2.0.tgz
+      mockjs:
+        specifier: ^1.1.0
+        version: https://registry.npmmirror.com/mockjs/-/mockjs-1.1.0.tgz
+      node-fetch:
+        specifier: ^2.6.1
+        version: https://registry.npmmirror.com/node-fetch/-/node-fetch-2.6.1.tgz
+      nunjucks:
+        specifier: ^3.2.2
+        version: https://registry.npmmirror.com/nunjucks/-/nunjucks-3.2.2.tgz
+      openapi3-ts:
+        specifier: ^2.0.1
+        version: https://registry.npmmirror.com/openapi3-ts/-/openapi3-ts-2.0.1.tgz
+      prettier:
+        specifier: ^2.2.1
+        version: https://registry.npmmirror.com/prettier/-/prettier-2.2.1.tgz
+      reserved-words:
+        specifier: ^0.1.2
+        version: https://registry.npmmirror.com/reserved-words/-/reserved-words-0.1.2.tgz
+      rimraf:
+        specifier: ^3.0.2
+        version: https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz
+      swagger2openapi:
+        specifier: ^7.0.4
+        version: https://registry.npmmirror.com/swagger2openapi/-/swagger2openapi-7.0.4.tgz
+      tiny-pinyin:
+        specifier: ^1.3.2
+        version: https://registry.npmmirror.com/tiny-pinyin/-/tiny-pinyin-1.3.2.tgz
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.11
+        version: https://registry.npmmirror.com/@types/express/-/express-4.17.11.tgz
+      '@types/node':
+        specifier: ^14.14.22
+        version: https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+      np:
+        specifier: ^7.2.0
+        version: https://registry.npmmirror.com/np/-/np-7.2.0.tgz
+      tslib:
+        specifier: ^2.6.0
+        version: https://registry.npmmirror.com/tslib/-/tslib-2.6.0.tgz
+      typescript:
+        specifier: ^4.1.3
+        version: https://registry.npmmirror.com/typescript/-/typescript-4.1.3.tgz
 
 packages:
 
-  /@babel/code-frame@7.22.5:
+  '@babel/code-frame@7.22.5':
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.22.5
 
-  /@babel/helper-validator-identifier@7.22.5:
+  '@babel/helper-validator-identifier@7.22.5':
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/highlight@7.22.5:
+  '@babel/highlight@7.22.5':
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.5
-      chalk: 2.4.2
-      js-tokens: 4.0.0
 
-  /@nodelib/fs.scandir@2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-    dev: true
-
-  /@nodelib/fs.stat@2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-    dev: true
-
-  /@nodelib/fs.walk@1.2.8:
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.15.0
-    dev: true
-
-  /@types/minimist@1.2.2:
-    resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
-    dev: true
-
-  /@types/normalize-package-data@2.4.1:
-    resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
-    dev: true
-
-  /@types/parse-json@4.0.0:
-    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
-    dev: true
-
-  /ansi-escapes@3.2.0:
-    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: 0.21.3
-    dev: true
-
-  /ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /ansi-regex@3.0.1:
-    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
-    dependencies:
-      color-convert: 1.9.3
-
-  /ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-    dependencies:
-      color-convert: 2.0.1
-
-  /argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: false
-
-  /array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /arrify@1.0.1:
-    resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  /brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  /braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
-    engines: {node: '>=8'}
-    dependencies:
-      fill-range: 7.0.1
-    dev: true
-
-  /callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-
-  /camelcase-keys@6.2.2:
-    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
-    engines: {node: '>=8'}
-    dependencies:
-      camelcase: 5.3.1
-      map-obj: 4.3.0
-      quick-lru: 4.0.1
-    dev: true
-
-  /camelcase@5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-styles: 2.2.1
-      escape-string-regexp: 1.0.5
-      has-ansi: registry.npmmirror.com/has-ansi@2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
-    dev: true
-
-  /chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-
-  /chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-    dev: true
-
-  /chokidar@3.5.3:
-    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
-    engines: {node: '>= 8.10.0'}
-    requiresBuild: true
-    dependencies:
-      anymatch: registry.npmmirror.com/anymatch@3.1.3
-      braces: registry.npmmirror.com/braces@3.0.2
-      glob-parent: registry.npmmirror.com/glob-parent@5.1.2
-      is-binary-path: registry.npmmirror.com/is-binary-path@2.1.0
-      is-glob: registry.npmmirror.com/is-glob@4.0.3
-      normalize-path: registry.npmmirror.com/normalize-path@3.0.0
-      readdirp: registry.npmmirror.com/readdirp@3.6.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
-    optional: true
-
-  /ci-info@2.0.0:
-    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
-    dev: true
-
-  /color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-    dependencies:
-      color-name: 1.1.3
-
-  /color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-    dependencies:
-      color-name: 1.1.4
-
-  /color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-
-  /color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  /concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  /cosmiconfig@7.1.0:
-    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@types/parse-json': 4.0.0
-      import-fresh: 3.3.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 1.10.2
-    dev: true
-
-  /cosmiconfig@9.0.0(typescript@4.1.3):
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-      typescript: registry.npmmirror.com/typescript@4.1.3
-    dev: false
-
-  /cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-    dev: true
-
-  /decamelize-keys@1.1.1:
-    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      decamelize: 1.2.0
-      map-obj: 1.0.1
-    dev: true
-
-  /decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
-    dependencies:
-      path-type: 4.0.0
-    dev: true
-
-  /emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
-
-  /end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
-    dependencies:
-      once: 1.4.0
-    dev: true
-
-  /env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
-    dependencies:
-      is-arrayish: 0.2.1
-
-  /escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-
-  /fast-glob@3.3.0:
-    resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
-    dev: true
-
-  /fastq@1.15.0:
-    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
-    dependencies:
-      reusify: 1.0.4
-    dev: true
-
-  /fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      to-regex-range: 5.0.1
-    dev: true
-
-  /find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
-    dependencies:
-      locate-path: 5.0.0
-      path-exists: 4.0.0
-    dev: true
-
-  /find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
-    dependencies:
-      locate-path: registry.npmmirror.com/locate-path@6.0.0
-      path-exists: registry.npmmirror.com/path-exists@4.0.0
-    dev: true
-
-  /fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-    dev: true
-
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: true
-
-  /get-stream@4.1.0:
-    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
-    engines: {node: '>=6'}
-    dependencies:
-      pump: 3.0.0
-    dev: true
-
-  /get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-    dependencies:
-      pump: 3.0.0
-    dev: true
-
-  /get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-    dependencies:
-      is-glob: 4.0.3
-    dev: true
-
-  /glob@7.1.6:
-    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: true
-
-  /globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.0
-      ignore: 5.2.4
-      merge2: 1.4.1
-      slash: 3.0.0
-    dev: true
-
-  /hard-rejection@2.1.0:
-    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
-
-  /has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
-
-  /has@1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
-    engines: {node: '>= 0.4.0'}
-    dependencies:
-      function-bind: 1.1.1
-    dev: true
-
-  /hosted-git-info@2.8.9:
-    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
-    dev: true
-
-  /hosted-git-info@4.1.0:
-    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
-    engines: {node: '>=10'}
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
-
-  /human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
-    dev: true
-
-  /ignore@5.2.4:
-    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
-    engines: {node: '>= 4'}
-    dev: true
-
-  /import-fresh@3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
-    engines: {node: '>=6'}
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
-  /import-lazy@2.1.0:
-    resolution: {integrity: sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-    dev: true
-
-  /indent-string@3.2.0:
-    resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-    dev: true
-
-  /inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
-
-  /ini@1.3.7:
-    resolution: {integrity: sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==}
-    dev: true
-
-  /ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-    dev: true
-
-  /ini@2.0.0:
-    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  /is-core-module@2.12.1:
-    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
-    dependencies:
-      has: 1.0.3
-    dev: true
-
-  /is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /is-fullwidth-code-point@1.0.0:
-    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      number-is-nan: registry.npmmirror.com/number-is-nan@1.0.1
-    dev: true
-
-  /is-fullwidth-code-point@2.0.0:
-    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: 2.1.1
-    dev: true
-
-  /is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-    dev: true
-
-  /is-plain-obj@1.1.0:
-    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /is-stream@1.1.0:
-    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-    dev: true
-
-  /is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
-
-  /js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  /js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-    dependencies:
-      argparse: 2.0.1
-    dev: false
-
-  /json-buffer@3.0.0:
-    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
-    dev: true
-
-  /json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-    dev: true
-
-  /json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-
-  /keyv@3.1.0:
-    resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
-    dependencies:
-      json-buffer: 3.0.0
-    dev: true
-
-  /keyv@4.5.2:
-    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
-    dependencies:
-      json-buffer: 3.0.1
-    dev: true
-
-  /kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-
-  /locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
-    dependencies:
-      p-locate: 4.1.0
-    dev: true
-
-  /lodash.zip@4.2.0:
-    resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
-    dev: true
-
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
-
-  /log-symbols@1.0.2:
-    resolution: {integrity: sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      chalk: 1.1.3
-    dev: true
-
-  /lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-    dependencies:
-      yallist: 4.0.0
-    dev: true
-
-  /map-age-cleaner@0.1.3:
-    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
-    engines: {node: '>=6'}
-    dependencies:
-      p-defer: 1.0.0
-    dev: true
-
-  /map-obj@1.0.1:
-    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /map-obj@4.3.0:
-    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: true
-
-  /merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-    dev: true
-
-  /micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
-    engines: {node: '>=8.6'}
-    dependencies:
-      braces: 3.0.2
-      picomatch: 2.3.1
-    dev: true
-
-  /mimic-fn@1.2.0:
-    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /mimic-fn@3.1.0:
-    resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /min-indent@1.0.1:
-    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: true
-
-  /minimist-options@4.1.0:
-    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
-    engines: {node: '>= 6'}
-    dependencies:
-      arrify: 1.0.1
-      is-plain-obj: 1.1.0
-      kind-of: 6.0.3
-    dev: true
-
-  /minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
-
-  /normalize-package-data@2.5.0:
-    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
-    dependencies:
-      hosted-git-info: 2.8.9
-      resolve: 1.22.2
-      semver: 5.7.1
-      validate-npm-package-license: 3.0.4
-    dev: true
-
-  /normalize-package-data@3.0.3:
-    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
-    engines: {node: '>=10'}
-    dependencies:
-      hosted-git-info: 4.1.0
-      is-core-module: 2.12.1
-      semver: 7.5.4
-      validate-npm-package-license: 3.0.4
-    dev: true
-
-  /npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-    dependencies:
-      path-key: 3.1.1
-    dev: true
-
-  /object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-    dependencies:
-      wrappy: 1.0.2
-    dev: true
-
-  /onetime@2.0.1:
-    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      mimic-fn: 1.2.0
-    dev: true
-
-  /onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
-    dependencies:
-      mimic-fn: 2.1.0
-    dev: true
-
-  /p-defer@1.0.0:
-    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
-    dependencies:
-      p-try: 2.2.0
-    dev: true
-
-  /p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      yocto-queue: registry.npmmirror.com/yocto-queue@0.1.0
-    dev: true
-
-  /p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
-    dependencies:
-      p-limit: 2.3.0
-    dev: true
-
-  /p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
-    dependencies:
-      p-limit: 3.1.0
-    dev: true
-
-  /p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-    dependencies:
-      callsites: 3.1.0
-
-  /parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@babel/code-frame': 7.22.5
-      error-ex: 1.3.2
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
-
-  /path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
-
-  /path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-    dev: true
-
-  /pump@3.0.0:
-    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
-    dependencies:
-      end-of-stream: 1.4.4
-      once: 1.4.0
-    dev: true
-
-  /queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
-
-  /quick-lru@4.0.1:
-    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /read-pkg-up@7.0.1:
-    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
-    engines: {node: '>=8'}
-    dependencies:
-      find-up: 4.1.0
-      read-pkg: 5.2.0
-      type-fest: 0.8.1
-    dev: true
-
-  /read-pkg@5.2.0:
-    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@types/normalize-package-data': 2.4.1
-      normalize-package-data: 2.5.0
-      parse-json: 5.2.0
-      type-fest: 0.6.0
-    dev: true
-
-  /redent@3.0.0:
-    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
-    engines: {node: '>=8'}
-    dependencies:
-      indent-string: 4.0.0
-      strip-indent: 3.0.0
-    dev: true
-
-  /resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-
-  /resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /resolve@1.22.2:
-    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
-    hasBin: true
-    dependencies:
-      is-core-module: 2.12.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-    dev: true
-
-  /reusify@1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
-
-  /rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    hasBin: true
-    dependencies:
-      glob: 7.1.6
-    dev: true
-
-  /run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-    dependencies:
-      queue-microtask: 1.2.3
-    dev: true
-
-  /semver@5.7.1:
-    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
-    hasBin: true
-    dev: true
-
-  /semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
-    hasBin: true
-    dev: true
-
-  /semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
-
-  /shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-    dependencies:
-      shebang-regex: 3.0.0
-    dev: true
-
-  /shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-    dev: true
-
-  /slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /slice-ansi@0.0.4:
-    resolution: {integrity: sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /spdx-correct@3.2.0:
-    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
-    dependencies:
-      spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.13
-    dev: true
-
-  /spdx-exceptions@2.3.0:
-    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
-    dev: true
-
-  /spdx-expression-parse@3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
-    dependencies:
-      spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.13
-    dev: true
-
-  /spdx-license-ids@3.0.13:
-    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
-    dev: true
-
-  /string-width@1.0.2:
-    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      code-point-at: registry.npmmirror.com/code-point-at@1.1.0
-      is-fullwidth-code-point: 1.0.0
-      strip-ansi: 3.0.1
-    dev: true
-
-  /string-width@2.1.1:
-    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
-    engines: {node: '>=4'}
-    dependencies:
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 4.0.0
-    dev: true
-
-  /string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-    dev: true
-
-  /strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: true
-
-  /strip-ansi@4.0.0:
-    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-regex: 3.0.1
-    dev: true
-
-  /strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
-    engines: {node: '>=6'}
-    dependencies:
-      ansi-regex: 4.1.1
-    dev: true
-
-  /strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-    dependencies:
-      ansi-regex: 5.0.1
-    dev: true
-
-  /strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /strip-indent@3.0.0:
-    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      min-indent: 1.0.1
-    dev: true
-
-  /strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
-    engines: {node: '>=0.8.0'}
-    dev: true
-
-  /supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
-    dependencies:
-      has-flag: 3.0.0
-
-  /supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-    dependencies:
-      has-flag: 4.0.0
-    dev: true
-
-  /supports-hyperlinks@2.3.0:
-    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
-    engines: {node: '>=8'}
-    dependencies:
-      has-flag: 4.0.0
-      supports-color: 7.2.0
-    dev: true
-
-  /supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-    dependencies:
-      is-number: 7.0.0
-    dev: true
-
-  /trim-newlines@3.0.1:
-    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /type-fest@0.10.0:
-    resolution: {integrity: sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /type-fest@0.18.1:
-    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /type-fest@0.20.2:
-    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /type-fest@0.4.1:
-    resolution: {integrity: sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /type-fest@0.6.0:
-    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /type-fest@0.8.1:
-    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /typedarray-to-buffer@3.1.5:
-    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
-    dependencies:
-      is-typedarray: 1.0.0
-    dev: true
-
-  /validate-npm-package-license@3.0.4:
-    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
-    dependencies:
-      spdx-correct: 3.2.0
-      spdx-expression-parse: 3.0.1
-    dev: true
-
-  /which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-    dependencies:
-      isexe: 2.0.0
-    dev: true
-
-  /wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
-
-  /write-file-atomic@3.0.3:
-    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
-    dependencies:
-      imurmurhash: 0.1.4
-      is-typedarray: 1.0.0
-      signal-exit: 3.0.7
-      typedarray-to-buffer: 3.1.5
-    dev: true
-
-  /yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
-
-  /yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
-    dev: true
-
-  /yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-    dev: true
-
-  registry.npmmirror.com/@exodus/schemasafe@1.0.1:
+  '@exodus/schemasafe@https://registry.npmmirror.com/@exodus/schemasafe/-/schemasafe-1.0.1.tgz':
     resolution: {integrity: sha512-PQdbF8dGd4LnbwBlcc4ML8RKYdplm+e9sUeWBTr4zgF13/Shiuov9XznvM4T8cb1CfyKK21yTUkuAIIh/DAH/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@exodus/schemasafe/-/schemasafe-1.0.1.tgz}
     name: '@exodus/schemasafe'
     version: 1.0.1
-    dev: false
 
-  registry.npmmirror.com/@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7):
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@samverschueren/stream-to-observable@https://registry.npmmirror.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz':
     resolution: {integrity: sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz}
-    id: registry.npmmirror.com/@samverschueren/stream-to-observable/0.3.1
     name: '@samverschueren/stream-to-observable'
     version: 0.3.1
     engines: {node: '>=6'}
@@ -1280,220 +117,192 @@ packages:
         optional: true
       zen-observable:
         optional: true
-    dependencies:
-      any-observable: registry.npmmirror.com/any-observable@0.3.0(rxjs@6.6.7)
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
-    transitivePeerDependencies:
-      - zenObservable
-    dev: true
 
-  registry.npmmirror.com/@sindresorhus/is@0.14.0:
+  '@sindresorhus/is@https://registry.npmmirror.com/@sindresorhus/is/-/is-0.14.0.tgz':
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@sindresorhus/is/-/is-0.14.0.tgz}
     name: '@sindresorhus/is'
     version: 0.14.0
     engines: {node: '>=6'}
-    dev: true
 
-  registry.npmmirror.com/@sindresorhus/is@2.1.1:
+  '@sindresorhus/is@https://registry.npmmirror.com/@sindresorhus/is/-/is-2.1.1.tgz':
     resolution: {integrity: sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@sindresorhus/is/-/is-2.1.1.tgz}
     name: '@sindresorhus/is'
     version: 2.1.1
     engines: {node: '>=10'}
-    dev: true
 
-  registry.npmmirror.com/@sindresorhus/is@4.6.0:
+  '@sindresorhus/is@https://registry.npmmirror.com/@sindresorhus/is/-/is-4.6.0.tgz':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@sindresorhus/is/-/is-4.6.0.tgz}
     name: '@sindresorhus/is'
     version: 4.6.0
     engines: {node: '>=10'}
-    dev: true
 
-  registry.npmmirror.com/@szmarczak/http-timer@1.1.2:
+  '@szmarczak/http-timer@https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz':
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz}
     name: '@szmarczak/http-timer'
     version: 1.1.2
     engines: {node: '>=6'}
-    dependencies:
-      defer-to-connect: registry.npmmirror.com/defer-to-connect@1.1.3
-    dev: true
 
-  registry.npmmirror.com/@szmarczak/http-timer@4.0.6:
+  '@szmarczak/http-timer@https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz}
     name: '@szmarczak/http-timer'
     version: 4.0.6
     engines: {node: '>=10'}
-    dependencies:
-      defer-to-connect: registry.npmmirror.com/defer-to-connect@2.0.1
-    dev: true
 
-  registry.npmmirror.com/@types/body-parser@1.19.2:
+  '@types/body-parser@https://registry.npmmirror.com/@types/body-parser/-/body-parser-1.19.2.tgz':
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/body-parser/-/body-parser-1.19.2.tgz}
     name: '@types/body-parser'
     version: 1.19.2
-    dependencies:
-      '@types/connect': registry.npmmirror.com/@types/connect@3.4.35
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-    dev: true
 
-  registry.npmmirror.com/@types/cacheable-request@6.0.3:
+  '@types/cacheable-request@https://registry.npmmirror.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz}
     name: '@types/cacheable-request'
     version: 6.0.3
-    dependencies:
-      '@types/http-cache-semantics': registry.npmmirror.com/@types/http-cache-semantics@4.0.1
-      '@types/keyv': registry.npmmirror.com/@types/keyv@3.1.4
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-      '@types/responselike': registry.npmmirror.com/@types/responselike@1.0.0
-    dev: true
 
-  registry.npmmirror.com/@types/connect@3.4.35:
+  '@types/connect@https://registry.npmmirror.com/@types/connect/-/connect-3.4.35.tgz':
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/connect/-/connect-3.4.35.tgz}
     name: '@types/connect'
     version: 3.4.35
-    dependencies:
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-    dev: true
 
-  registry.npmmirror.com/@types/express-serve-static-core@4.17.35:
+  '@types/express-serve-static-core@https://registry.npmmirror.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz':
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz}
     name: '@types/express-serve-static-core'
     version: 4.17.35
-    dependencies:
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-      '@types/qs': registry.npmmirror.com/@types/qs@6.9.7
-      '@types/range-parser': registry.npmmirror.com/@types/range-parser@1.2.4
-      '@types/send': registry.npmmirror.com/@types/send@0.17.1
-    dev: true
 
-  registry.npmmirror.com/@types/express@4.17.11:
+  '@types/express@https://registry.npmmirror.com/@types/express/-/express-4.17.11.tgz':
     resolution: {integrity: sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/express/-/express-4.17.11.tgz}
     name: '@types/express'
     version: 4.17.11
-    dependencies:
-      '@types/body-parser': registry.npmmirror.com/@types/body-parser@1.19.2
-      '@types/express-serve-static-core': registry.npmmirror.com/@types/express-serve-static-core@4.17.35
-      '@types/qs': registry.npmmirror.com/@types/qs@6.9.7
-      '@types/serve-static': registry.npmmirror.com/@types/serve-static@1.15.2
-    dev: true
 
-  registry.npmmirror.com/@types/http-cache-semantics@4.0.1:
+  '@types/http-cache-semantics@https://registry.npmmirror.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz':
     resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz}
     name: '@types/http-cache-semantics'
     version: 4.0.1
-    dev: true
 
-  registry.npmmirror.com/@types/http-errors@2.0.1:
+  '@types/http-errors@https://registry.npmmirror.com/@types/http-errors/-/http-errors-2.0.1.tgz':
     resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/http-errors/-/http-errors-2.0.1.tgz}
     name: '@types/http-errors'
     version: 2.0.1
-    dev: true
 
-  registry.npmmirror.com/@types/keyv@3.1.4:
+  '@types/keyv@https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz}
     name: '@types/keyv'
     version: 3.1.4
-    dependencies:
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-    dev: true
 
-  registry.npmmirror.com/@types/mime@1.3.2:
+  '@types/mime@https://registry.npmmirror.com/@types/mime/-/mime-1.3.2.tgz':
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/mime/-/mime-1.3.2.tgz}
     name: '@types/mime'
     version: 1.3.2
-    dev: true
 
-  registry.npmmirror.com/@types/mime@3.0.1:
+  '@types/mime@https://registry.npmmirror.com/@types/mime/-/mime-3.0.1.tgz':
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/mime/-/mime-3.0.1.tgz}
     name: '@types/mime'
     version: 3.0.1
-    dev: true
 
-  registry.npmmirror.com/@types/node@14.14.22:
+  '@types/minimist@1.2.2':
+    resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
+
+  '@types/node@https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz':
     resolution: {integrity: sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz}
     name: '@types/node'
     version: 14.14.22
-    dev: true
 
-  registry.npmmirror.com/@types/qs@6.9.7:
+  '@types/normalize-package-data@2.4.1':
+    resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
+
+  '@types/parse-json@4.0.0':
+    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+
+  '@types/qs@https://registry.npmmirror.com/@types/qs/-/qs-6.9.7.tgz':
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/qs/-/qs-6.9.7.tgz}
     name: '@types/qs'
     version: 6.9.7
-    dev: true
 
-  registry.npmmirror.com/@types/range-parser@1.2.4:
+  '@types/range-parser@https://registry.npmmirror.com/@types/range-parser/-/range-parser-1.2.4.tgz':
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/range-parser/-/range-parser-1.2.4.tgz}
     name: '@types/range-parser'
     version: 1.2.4
-    dev: true
 
-  registry.npmmirror.com/@types/responselike@1.0.0:
+  '@types/responselike@https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.0.tgz':
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.0.tgz}
     name: '@types/responselike'
     version: 1.0.0
-    dependencies:
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-    dev: true
 
-  registry.npmmirror.com/@types/send@0.17.1:
+  '@types/send@https://registry.npmmirror.com/@types/send/-/send-0.17.1.tgz':
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/send/-/send-0.17.1.tgz}
     name: '@types/send'
     version: 0.17.1
-    dependencies:
-      '@types/mime': registry.npmmirror.com/@types/mime@1.3.2
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-    dev: true
 
-  registry.npmmirror.com/@types/serve-static@1.15.2:
+  '@types/serve-static@https://registry.npmmirror.com/@types/serve-static/-/serve-static-1.15.2.tgz':
     resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/serve-static/-/serve-static-1.15.2.tgz}
     name: '@types/serve-static'
     version: 1.15.2
-    dependencies:
-      '@types/http-errors': registry.npmmirror.com/@types/http-errors@2.0.1
-      '@types/mime': registry.npmmirror.com/@types/mime@3.0.1
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-    dev: true
 
-  registry.npmmirror.com/a-sync-waterfall@1.0.1:
+  a-sync-waterfall@https://registry.npmmirror.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz:
     resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz}
     name: a-sync-waterfall
     version: 1.0.1
-    dev: false
 
-  registry.npmmirror.com/aggregate-error@3.1.0:
+  aggregate-error@https://registry.npmmirror.com/aggregate-error/-/aggregate-error-3.1.0.tgz:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/aggregate-error/-/aggregate-error-3.1.0.tgz}
     name: aggregate-error
     version: 3.1.0
     engines: {node: '>=8'}
-    dependencies:
-      clean-stack: registry.npmmirror.com/clean-stack@2.2.0
-      indent-string: 4.0.0
-    dev: true
 
-  registry.npmmirror.com/ansi-align@3.0.1:
+  ansi-align@https://registry.npmmirror.com/ansi-align/-/ansi-align-3.0.1.tgz:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-align/-/ansi-align-3.0.1.tgz}
     name: ansi-align
     version: 3.0.1
-    dependencies:
-      string-width: 4.2.3
-    dev: true
 
-  registry.npmmirror.com/ansi-regex@5.0.1:
+  ansi-escapes@3.2.0:
+    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
+    engines: {node: '>=4'}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@2.1.1:
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
+    engines: {node: '>=0.10.0'}
+
+  ansi-regex@3.0.1:
+    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
+    engines: {node: '>=4'}
+
+  ansi-regex@4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+    engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz}
     name: ansi-regex
     version: 5.0.1
     engines: {node: '>=8'}
 
-  registry.npmmirror.com/ansi-styles@4.3.0:
+  ansi-styles@2.2.1:
+    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
+    engines: {node: '>=0.10.0'}
+
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz}
     name: ansi-styles
     version: 4.3.0
     engines: {node: '>=8'}
-    dependencies:
-      color-convert: 2.0.1
 
-  registry.npmmirror.com/any-observable@0.3.0(rxjs@6.6.7):
+  any-observable@https://registry.npmmirror.com/any-observable/-/any-observable-0.3.0.tgz:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/any-observable/-/any-observable-0.3.0.tgz}
-    id: registry.npmmirror.com/any-observable/0.3.0
     name: any-observable
     version: 0.3.0
     engines: {node: '>=6'}
@@ -1505,13 +314,9 @@ packages:
         optional: true
       zenObservable:
         optional: true
-    dependencies:
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
-    dev: true
 
-  registry.npmmirror.com/any-observable@0.5.1(rxjs@6.6.7):
+  any-observable@https://registry.npmmirror.com/any-observable/-/any-observable-0.5.1.tgz:
     resolution: {integrity: sha512-8zv01bgDOp9PTmRTNCAHTw64TFP2rvlX4LvtNJLachaXY+AjmIvLT47fABNPCiIe89hKiSCo2n5zmPqI9CElPA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/any-observable/-/any-observable-0.5.1.tgz}
-    id: registry.npmmirror.com/any-observable/0.5.1
     name: any-observable
     version: 0.5.1
     engines: {node: '>=8'}
@@ -1523,465 +328,2547 @@ packages:
         optional: true
       zen-observable:
         optional: true
-    dependencies:
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
-    dev: true
 
-  registry.npmmirror.com/anymatch@3.1.3:
+  anymatch@https://registry.npmmirror.com/anymatch/-/anymatch-3.1.3.tgz:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/anymatch/-/anymatch-3.1.3.tgz}
     name: anymatch
     version: 3.1.3
     engines: {node: '>= 8'}
-    requiresBuild: true
-    dependencies:
-      normalize-path: registry.npmmirror.com/normalize-path@3.0.0
-      picomatch: registry.npmmirror.com/picomatch@2.3.1
-    dev: false
-    optional: true
 
-  registry.npmmirror.com/asap@2.0.6:
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  arrify@1.0.1:
+    resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
+    engines: {node: '>=0.10.0'}
+
+  asap@https://registry.npmmirror.com/asap/-/asap-2.0.6.tgz:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/asap/-/asap-2.0.6.tgz}
     name: asap
     version: 2.0.6
-    dev: false
 
-  registry.npmmirror.com/async-exit-hook@2.0.1:
+  async-exit-hook@https://registry.npmmirror.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz}
     name: async-exit-hook
     version: 2.0.1
     engines: {node: '>=0.12.0'}
-    dev: true
 
-  registry.npmmirror.com/binary-extensions@2.2.0:
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  binary-extensions@https://registry.npmmirror.com/binary-extensions/-/binary-extensions-2.2.0.tgz:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/binary-extensions/-/binary-extensions-2.2.0.tgz}
     name: binary-extensions
     version: 2.2.0
     engines: {node: '>=8'}
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  registry.npmmirror.com/boxen@5.1.2:
+  boxen@https://registry.npmmirror.com/boxen/-/boxen-5.1.2.tgz:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/boxen/-/boxen-5.1.2.tgz}
     name: boxen
     version: 5.1.2
     engines: {node: '>=10'}
-    dependencies:
-      ansi-align: registry.npmmirror.com/ansi-align@3.0.1
-      camelcase: 6.3.0
-      chalk: 4.1.2
-      cli-boxes: registry.npmmirror.com/cli-boxes@2.2.1
-      string-width: 4.2.3
-      type-fest: 0.20.2
-      widest-line: registry.npmmirror.com/widest-line@3.1.0
-      wrap-ansi: registry.npmmirror.com/wrap-ansi@7.0.0
-    dev: true
 
-  registry.npmmirror.com/braces@3.0.2:
+  brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+
+  braces@3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+
+  braces@https://registry.npmmirror.com/braces/-/braces-3.0.2.tgz:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/braces/-/braces-3.0.2.tgz}
     name: braces
     version: 3.0.2
     engines: {node: '>=8'}
-    requiresBuild: true
-    dependencies:
-      fill-range: registry.npmmirror.com/fill-range@7.0.1
-    dev: false
-    optional: true
 
-  registry.npmmirror.com/builtins@1.0.3:
+  builtins@https://registry.npmmirror.com/builtins/-/builtins-1.0.3.tgz:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/builtins/-/builtins-1.0.3.tgz}
     name: builtins
     version: 1.0.3
-    dev: true
 
-  registry.npmmirror.com/cacheable-lookup@2.0.1:
+  cacheable-lookup@https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz:
     resolution: {integrity: sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz}
     name: cacheable-lookup
     version: 2.0.1
     engines: {node: '>=10'}
-    dependencies:
-      '@types/keyv': registry.npmmirror.com/@types/keyv@3.1.4
-      keyv: 4.5.2
-    dev: true
 
-  registry.npmmirror.com/cacheable-request@6.1.0:
+  cacheable-request@https://registry.npmmirror.com/cacheable-request/-/cacheable-request-6.1.0.tgz:
     resolution: {integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cacheable-request/-/cacheable-request-6.1.0.tgz}
     name: cacheable-request
     version: 6.1.0
     engines: {node: '>=8'}
-    dependencies:
-      clone-response: registry.npmmirror.com/clone-response@1.0.3
-      get-stream: 5.2.0
-      http-cache-semantics: registry.npmmirror.com/http-cache-semantics@4.1.1
-      keyv: 3.1.0
-      lowercase-keys: registry.npmmirror.com/lowercase-keys@2.0.0
-      normalize-url: registry.npmmirror.com/normalize-url@4.5.1
-      responselike: registry.npmmirror.com/responselike@1.0.2
-    dev: true
 
-  registry.npmmirror.com/cacheable-request@7.0.4:
+  cacheable-request@https://registry.npmmirror.com/cacheable-request/-/cacheable-request-7.0.4.tgz:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cacheable-request/-/cacheable-request-7.0.4.tgz}
     name: cacheable-request
     version: 7.0.4
     engines: {node: '>=8'}
-    dependencies:
-      clone-response: registry.npmmirror.com/clone-response@1.0.3
-      get-stream: 5.2.0
-      http-cache-semantics: registry.npmmirror.com/http-cache-semantics@4.1.1
-      keyv: 4.5.2
-      lowercase-keys: registry.npmmirror.com/lowercase-keys@2.0.0
-      normalize-url: registry.npmmirror.com/normalize-url@6.1.0
-      responselike: registry.npmmirror.com/responselike@2.0.1
-    dev: true
 
-  registry.npmmirror.com/call-me-maybe@1.0.2:
+  call-me-maybe@https://registry.npmmirror.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz}
     name: call-me-maybe
     version: 1.0.2
-    dev: false
 
-  registry.npmmirror.com/chalk@4.1.2:
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase-keys@6.2.2:
+    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
+    engines: {node: '>=8'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  chalk@1.1.3:
+    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
+    engines: {node: '>=0.10.0'}
+
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz}
     name: chalk
     version: 4.1.2
     engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@4.3.0
-      supports-color: registry.npmmirror.com/supports-color@7.2.0
 
-  registry.npmmirror.com/chardet@0.7.0:
+  chardet@https://registry.npmmirror.com/chardet/-/chardet-0.7.0.tgz:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chardet/-/chardet-0.7.0.tgz}
     name: chardet
     version: 0.7.0
-    dev: true
 
-  registry.npmmirror.com/clean-stack@2.2.0:
+  chokidar@3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+
+  ci-info@2.0.0:
+    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
+
+  clean-stack@https://registry.npmmirror.com/clean-stack/-/clean-stack-2.2.0.tgz:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/clean-stack/-/clean-stack-2.2.0.tgz}
     name: clean-stack
     version: 2.2.0
     engines: {node: '>=6'}
-    dev: true
 
-  registry.npmmirror.com/cli-boxes@2.2.1:
+  cli-boxes@https://registry.npmmirror.com/cli-boxes/-/cli-boxes-2.2.1.tgz:
     resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cli-boxes/-/cli-boxes-2.2.1.tgz}
     name: cli-boxes
     version: 2.2.1
     engines: {node: '>=6'}
-    dev: true
 
-  registry.npmmirror.com/cli-cursor@2.1.0:
+  cli-cursor@https://registry.npmmirror.com/cli-cursor/-/cli-cursor-2.1.0.tgz:
     resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cli-cursor/-/cli-cursor-2.1.0.tgz}
     name: cli-cursor
     version: 2.1.0
     engines: {node: '>=4'}
-    dependencies:
-      restore-cursor: registry.npmmirror.com/restore-cursor@2.0.0
-    dev: true
 
-  registry.npmmirror.com/cli-cursor@3.1.0:
+  cli-cursor@https://registry.npmmirror.com/cli-cursor/-/cli-cursor-3.1.0.tgz:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cli-cursor/-/cli-cursor-3.1.0.tgz}
     name: cli-cursor
     version: 3.1.0
     engines: {node: '>=8'}
-    dependencies:
-      restore-cursor: registry.npmmirror.com/restore-cursor@3.1.0
-    dev: true
 
-  registry.npmmirror.com/cli-truncate@0.2.1:
+  cli-truncate@https://registry.npmmirror.com/cli-truncate/-/cli-truncate-0.2.1.tgz:
     resolution: {integrity: sha512-f4r4yJnbT++qUPI9NR4XLDLq41gQ+uqnPItWG0F5ZkehuNiTTa3EY0S4AqTSUOeJ7/zU41oWPQSNkW5BqPL9bg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cli-truncate/-/cli-truncate-0.2.1.tgz}
     name: cli-truncate
     version: 0.2.1
     engines: {node: '>=0.10.0'}
-    dependencies:
-      slice-ansi: 0.0.4
-      string-width: 1.0.2
-    dev: true
 
-  registry.npmmirror.com/cli-width@2.2.1:
+  cli-width@https://registry.npmmirror.com/cli-width/-/cli-width-2.2.1.tgz:
     resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cli-width/-/cli-width-2.2.1.tgz}
     name: cli-width
     version: 2.2.1
-    dev: true
 
-  registry.npmmirror.com/cli-width@3.0.0:
+  cli-width@https://registry.npmmirror.com/cli-width/-/cli-width-3.0.0.tgz:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cli-width/-/cli-width-3.0.0.tgz}
     name: cli-width
     version: 3.0.0
     engines: {node: '>= 10'}
-    dev: true
 
-  registry.npmmirror.com/cliui@7.0.4:
+  cliui@https://registry.npmmirror.com/cliui/-/cliui-7.0.4.tgz:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cliui/-/cliui-7.0.4.tgz}
     name: cliui
     version: 7.0.4
-    dependencies:
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
-      wrap-ansi: registry.npmmirror.com/wrap-ansi@7.0.0
-    dev: false
 
-  registry.npmmirror.com/cliui@8.0.1:
+  cliui@https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz}
     name: cliui
     version: 8.0.1
     engines: {node: '>=12'}
-    dependencies:
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
-      wrap-ansi: registry.npmmirror.com/wrap-ansi@7.0.0
-    dev: false
 
-  registry.npmmirror.com/clone-response@1.0.3:
+  clone-response@https://registry.npmmirror.com/clone-response/-/clone-response-1.0.3.tgz:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/clone-response/-/clone-response-1.0.3.tgz}
     name: clone-response
     version: 1.0.3
-    dependencies:
-      mimic-response: registry.npmmirror.com/mimic-response@1.0.1
-    dev: true
 
-  registry.npmmirror.com/code-point-at@1.1.0:
+  code-point-at@https://registry.npmmirror.com/code-point-at/-/code-point-at-1.1.0.tgz:
     resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/code-point-at/-/code-point-at-1.1.0.tgz}
     name: code-point-at
     version: 1.1.0
     engines: {node: '>=0.10.0'}
-    dev: true
 
-  registry.npmmirror.com/commander@11.0.0:
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@https://registry.npmmirror.com/commander/-/commander-11.0.0.tgz:
     resolution: {integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/commander/-/commander-11.0.0.tgz}
     name: commander
     version: 11.0.0
     engines: {node: '>=16'}
-    dev: false
 
-  registry.npmmirror.com/commander@5.1.0:
+  commander@https://registry.npmmirror.com/commander/-/commander-5.1.0.tgz:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/commander/-/commander-5.1.0.tgz}
     name: commander
     version: 5.1.0
     engines: {node: '>= 6'}
-    dev: false
 
-  registry.npmmirror.com/configstore@5.0.1:
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  configstore@https://registry.npmmirror.com/configstore/-/configstore-5.0.1.tgz:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/configstore/-/configstore-5.0.1.tgz}
     name: configstore
     version: 5.0.1
     engines: {node: '>=8'}
-    dependencies:
-      dot-prop: registry.npmmirror.com/dot-prop@5.3.0
-      graceful-fs: registry.npmmirror.com/graceful-fs@4.2.11
-      make-dir: registry.npmmirror.com/make-dir@3.1.0
-      unique-string: registry.npmmirror.com/unique-string@2.0.0
-      write-file-atomic: 3.0.3
-      xdg-basedir: registry.npmmirror.com/xdg-basedir@4.0.0
-    dev: true
 
-  registry.npmmirror.com/crypto-random-string@2.0.0:
+  cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+
+  cosmiconfig@9.0.0:
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  cross-spawn@7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+
+  crypto-random-string@https://registry.npmmirror.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz}
     name: crypto-random-string
     version: 2.0.0
     engines: {node: '>=8'}
-    dev: true
 
-  registry.npmmirror.com/d@1.0.1:
+  d@https://registry.npmmirror.com/d/-/d-1.0.1.tgz:
     resolution: {integrity: sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/d/-/d-1.0.1.tgz}
     name: d
     version: 1.0.1
-    dependencies:
-      es5-ext: registry.npmmirror.com/es5-ext@0.10.62
-      type: registry.npmmirror.com/type@1.2.0
-    dev: false
 
-  registry.npmmirror.com/date-fns@1.30.1:
+  date-fns@https://registry.npmmirror.com/date-fns/-/date-fns-1.30.1.tgz:
     resolution: {integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/date-fns/-/date-fns-1.30.1.tgz}
     name: date-fns
     version: 1.30.1
-    dev: true
 
-  registry.npmmirror.com/dayjs@1.10.3:
+  dayjs@https://registry.npmmirror.com/dayjs/-/dayjs-1.10.3.tgz:
     resolution: {integrity: sha512-/2fdLN987N8Ki7Id8BUN2nhuiRyxTLumQnSQf9CNncFCyqFsSKb9TNhzRYcC8K8eJSJOKvbvkImo/MKKhNi4iw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dayjs/-/dayjs-1.10.3.tgz}
     name: dayjs
     version: 1.10.3
-    dev: false
 
-  registry.npmmirror.com/decompress-response@3.3.0:
+  decamelize-keys@1.1.1:
+    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
+    engines: {node: '>=0.10.0'}
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
+  decompress-response@https://registry.npmmirror.com/decompress-response/-/decompress-response-3.3.0.tgz:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/decompress-response/-/decompress-response-3.3.0.tgz}
     name: decompress-response
     version: 3.3.0
     engines: {node: '>=4'}
-    dependencies:
-      mimic-response: registry.npmmirror.com/mimic-response@1.0.1
-    dev: true
 
-  registry.npmmirror.com/decompress-response@5.0.0:
+  decompress-response@https://registry.npmmirror.com/decompress-response/-/decompress-response-5.0.0.tgz:
     resolution: {integrity: sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/decompress-response/-/decompress-response-5.0.0.tgz}
     name: decompress-response
     version: 5.0.0
     engines: {node: '>=10'}
-    dependencies:
-      mimic-response: registry.npmmirror.com/mimic-response@2.1.0
-    dev: true
 
-  registry.npmmirror.com/deep-extend@0.6.0:
+  deep-extend@https://registry.npmmirror.com/deep-extend/-/deep-extend-0.6.0.tgz:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/deep-extend/-/deep-extend-0.6.0.tgz}
     name: deep-extend
     version: 0.6.0
     engines: {node: '>=4.0.0'}
-    dev: true
 
-  registry.npmmirror.com/defer-to-connect@1.1.3:
+  defer-to-connect@https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz}
     name: defer-to-connect
     version: 1.1.3
-    dev: true
 
-  registry.npmmirror.com/defer-to-connect@2.0.1:
+  defer-to-connect@https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz}
     name: defer-to-connect
     version: 2.0.1
     engines: {node: '>=10'}
-    dev: true
 
-  registry.npmmirror.com/del@6.1.1:
+  del@https://registry.npmmirror.com/del/-/del-6.1.1.tgz:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/del/-/del-6.1.1.tgz}
     name: del
     version: 6.1.1
     engines: {node: '>=10'}
-    dependencies:
-      globby: 11.1.0
-      graceful-fs: registry.npmmirror.com/graceful-fs@4.2.11
-      is-glob: 4.0.3
-      is-path-cwd: registry.npmmirror.com/is-path-cwd@2.2.0
-      is-path-inside: registry.npmmirror.com/is-path-inside@3.0.3
-      p-map: registry.npmmirror.com/p-map@4.0.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-    dev: true
 
-  registry.npmmirror.com/dot-prop@5.3.0:
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  dot-prop@https://registry.npmmirror.com/dot-prop/-/dot-prop-5.3.0.tgz:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dot-prop/-/dot-prop-5.3.0.tgz}
     name: dot-prop
     version: 5.3.0
     engines: {node: '>=8'}
-    dependencies:
-      is-obj: registry.npmmirror.com/is-obj@2.0.0
-    dev: true
 
-  registry.npmmirror.com/dot-prop@6.0.1:
+  dot-prop@https://registry.npmmirror.com/dot-prop/-/dot-prop-6.0.1.tgz:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dot-prop/-/dot-prop-6.0.1.tgz}
     name: dot-prop
     version: 6.0.1
     engines: {node: '>=10'}
-    dependencies:
-      is-obj: registry.npmmirror.com/is-obj@2.0.0
-    dev: true
 
-  registry.npmmirror.com/duplexer3@0.1.5:
+  duplexer3@https://registry.npmmirror.com/duplexer3/-/duplexer3-0.1.5.tgz:
     resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/duplexer3/-/duplexer3-0.1.5.tgz}
     name: duplexer3
     version: 0.1.5
-    dev: true
 
-  registry.npmmirror.com/elegant-spinner@1.0.1:
+  elegant-spinner@https://registry.npmmirror.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz:
     resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz}
     name: elegant-spinner
     version: 1.0.1
     engines: {node: '>=0.10.0'}
-    dev: true
 
-  registry.npmmirror.com/emoji-regex@8.0.0:
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz}
     name: emoji-regex
     version: 8.0.0
 
-  registry.npmmirror.com/es5-ext@0.10.62:
+  end-of-stream@1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  es5-ext@https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz:
     resolution: {integrity: sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz}
     name: es5-ext
     version: 0.10.62
     engines: {node: '>=0.10'}
-    requiresBuild: true
-    dependencies:
-      es6-iterator: registry.npmmirror.com/es6-iterator@2.0.3
-      es6-symbol: registry.npmmirror.com/es6-symbol@3.1.3
-      next-tick: registry.npmmirror.com/next-tick@1.1.0
-    dev: false
 
-  registry.npmmirror.com/es6-iterator@2.0.3:
+  es6-iterator@https://registry.npmmirror.com/es6-iterator/-/es6-iterator-2.0.3.tgz:
     resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es6-iterator/-/es6-iterator-2.0.3.tgz}
     name: es6-iterator
     version: 2.0.3
-    dependencies:
-      d: registry.npmmirror.com/d@1.0.1
-      es5-ext: registry.npmmirror.com/es5-ext@0.10.62
-      es6-symbol: registry.npmmirror.com/es6-symbol@3.1.3
-    dev: false
 
-  registry.npmmirror.com/es6-promise@3.3.1:
+  es6-promise@https://registry.npmmirror.com/es6-promise/-/es6-promise-3.3.1.tgz:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es6-promise/-/es6-promise-3.3.1.tgz}
     name: es6-promise
     version: 3.3.1
-    dev: false
 
-  registry.npmmirror.com/es6-symbol@3.1.3:
+  es6-symbol@https://registry.npmmirror.com/es6-symbol/-/es6-symbol-3.1.3.tgz:
     resolution: {integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es6-symbol/-/es6-symbol-3.1.3.tgz}
     name: es6-symbol
     version: 3.1.3
-    dependencies:
-      d: registry.npmmirror.com/d@1.0.1
-      ext: registry.npmmirror.com/ext@1.7.0
-    dev: false
 
-  registry.npmmirror.com/es6-weak-map@2.0.3:
+  es6-weak-map@https://registry.npmmirror.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz:
     resolution: {integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz}
     name: es6-weak-map
     version: 2.0.3
-    dependencies:
-      d: registry.npmmirror.com/d@1.0.1
-      es5-ext: registry.npmmirror.com/es5-ext@0.10.62
-      es6-iterator: registry.npmmirror.com/es6-iterator@2.0.3
-      es6-symbol: registry.npmmirror.com/es6-symbol@3.1.3
-    dev: false
 
-  registry.npmmirror.com/escalade@3.1.1:
+  escalade@https://registry.npmmirror.com/escalade/-/escalade-3.1.1.tgz:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/escalade/-/escalade-3.1.1.tgz}
     name: escalade
     version: 3.1.1
     engines: {node: '>=6'}
-    dev: false
 
-  registry.npmmirror.com/escape-goat@2.1.1:
+  escape-goat@https://registry.npmmirror.com/escape-goat/-/escape-goat-2.1.1.tgz:
     resolution: {integrity: sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/escape-goat/-/escape-goat-2.1.1.tgz}
     name: escape-goat
     version: 2.1.1
     engines: {node: '>=8'}
-    dev: true
 
-  registry.npmmirror.com/escape-goat@3.0.0:
+  escape-goat@https://registry.npmmirror.com/escape-goat/-/escape-goat-3.0.0.tgz:
     resolution: {integrity: sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/escape-goat/-/escape-goat-3.0.0.tgz}
     name: escape-goat
     version: 3.0.0
     engines: {node: '>=10'}
-    dev: true
 
-  registry.npmmirror.com/escape-string-regexp@4.0.0:
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz}
     name: escape-string-regexp
     version: 4.0.0
     engines: {node: '>=10'}
-    dev: true
 
-  registry.npmmirror.com/event-emitter@0.3.5:
+  event-emitter@https://registry.npmmirror.com/event-emitter/-/event-emitter-0.3.5.tgz:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/event-emitter/-/event-emitter-0.3.5.tgz}
     name: event-emitter
     version: 0.3.5
-    dependencies:
-      d: registry.npmmirror.com/d@1.0.1
-      es5-ext: registry.npmmirror.com/es5-ext@0.10.62
-    dev: false
 
-  registry.npmmirror.com/execa@5.1.1:
+  execa@https://registry.npmmirror.com/execa/-/execa-5.1.1.tgz:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/execa/-/execa-5.1.1.tgz}
     name: execa
     version: 5.1.1
     engines: {node: '>=10'}
+
+  ext@https://registry.npmmirror.com/ext/-/ext-1.7.0.tgz:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ext/-/ext-1.7.0.tgz}
+    name: ext
+    version: 1.7.0
+
+  external-editor@https://registry.npmmirror.com/external-editor/-/external-editor-3.1.0.tgz:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/external-editor/-/external-editor-3.1.0.tgz}
+    name: external-editor
+    version: 3.1.0
+    engines: {node: '>=4'}
+
+  fast-glob@3.3.0:
+    resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
+    engines: {node: '>=8.6.0'}
+
+  fast-safe-stringify@https://registry.npmmirror.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz}
+    name: fast-safe-stringify
+    version: 2.1.1
+
+  fastq@1.15.0:
+    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
+
+  figures@https://registry.npmmirror.com/figures/-/figures-1.7.0.tgz:
+    resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/figures/-/figures-1.7.0.tgz}
+    name: figures
+    version: 1.7.0
+    engines: {node: '>=0.10.0'}
+
+  figures@https://registry.npmmirror.com/figures/-/figures-2.0.0.tgz:
+    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/figures/-/figures-2.0.0.tgz}
+    name: figures
+    version: 2.0.0
+    engines: {node: '>=4'}
+
+  figures@https://registry.npmmirror.com/figures/-/figures-3.2.0.tgz:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/figures/-/figures-3.2.0.tgz}
+    name: figures
+    version: 3.2.0
+    engines: {node: '>=8'}
+
+  fill-range@7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+
+  fill-range@https://registry.npmmirror.com/fill-range/-/fill-range-7.0.1.tgz:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fill-range/-/fill-range-7.0.1.tgz}
+    name: fill-range
+    version: 7.0.1
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fs.realpath@https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz}
+    name: fs.realpath
+    version: 1.0.0
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+
+  get-caller-file@https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz}
+    name: get-caller-file
+    version: 2.0.5
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-stream@4.1.0:
+    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
+    engines: {node: '>=6'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  github-url-from-git@https://registry.npmmirror.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz:
+    resolution: {integrity: sha512-WWOec4aRI7YAykQ9+BHmzjyNlkfJFG8QLXnDTsLz/kZefq7qkzdfo4p6fkYYMIq1aj+gZcQs/1HQhQh3DPPxlQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz}
+    name: github-url-from-git
+    version: 1.5.0
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz}
+    name: glob-parent
+    version: 5.1.2
+    engines: {node: '>= 6'}
+
+  glob@7.1.6:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+
+  glob@https://registry.npmmirror.com/glob/-/glob-7.1.6.tgz:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/glob/-/glob-7.1.6.tgz}
+    name: glob
+    version: 7.1.6
+
+  global-dirs@https://registry.npmmirror.com/global-dirs/-/global-dirs-2.1.0.tgz:
+    resolution: {integrity: sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/global-dirs/-/global-dirs-2.1.0.tgz}
+    name: global-dirs
+    version: 2.1.0
+    engines: {node: '>=8'}
+
+  global-dirs@https://registry.npmmirror.com/global-dirs/-/global-dirs-3.0.1.tgz:
+    resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/global-dirs/-/global-dirs-3.0.1.tgz}
+    name: global-dirs
+    version: 3.0.1
+    engines: {node: '>=10'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  got@https://registry.npmmirror.com/got/-/got-10.7.0.tgz:
+    resolution: {integrity: sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/got/-/got-10.7.0.tgz}
+    name: got
+    version: 10.7.0
+    engines: {node: '>=10'}
+
+  got@https://registry.npmmirror.com/got/-/got-9.6.0.tgz:
+    resolution: {integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/got/-/got-9.6.0.tgz}
+    name: got
+    version: 9.6.0
+    engines: {node: '>=8.6'}
+
+  graceful-fs@https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz}
+    name: graceful-fs
+    version: 4.2.11
+
+  hard-rejection@2.1.0:
+    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
+    engines: {node: '>=6'}
+
+  has-ansi@https://registry.npmmirror.com/has-ansi/-/has-ansi-2.0.0.tgz:
+    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-ansi/-/has-ansi-2.0.0.tgz}
+    name: has-ansi
+    version: 2.0.0
+    engines: {node: '>=0.10.0'}
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-yarn@https://registry.npmmirror.com/has-yarn/-/has-yarn-2.1.0.tgz:
+    resolution: {integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-yarn/-/has-yarn-2.1.0.tgz}
+    name: has-yarn
+    version: 2.1.0
+    engines: {node: '>=8'}
+
+  has@1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  hosted-git-info@4.1.0:
+    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+    engines: {node: '>=10'}
+
+  hosted-git-info@https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz:
+    resolution: {integrity: sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz}
+    name: hosted-git-info
+    version: 3.0.8
+    engines: {node: '>=10'}
+
+  http-cache-semantics@https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz:
+    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz}
+    name: http-cache-semantics
+    version: 4.1.1
+
+  http2-client@https://registry.npmmirror.com/http2-client/-/http2-client-1.3.5.tgz:
+    resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/http2-client/-/http2-client-1.3.5.tgz}
+    name: http2-client
+    version: 1.3.5
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  iconv-lite@https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.4.24.tgz:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.4.24.tgz}
+    name: iconv-lite
+    version: 0.4.24
+    engines: {node: '>=0.10.0'}
+
+  ignore-walk@https://registry.npmmirror.com/ignore-walk/-/ignore-walk-3.0.4.tgz:
+    resolution: {integrity: sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ignore-walk/-/ignore-walk-3.0.4.tgz}
+    name: ignore-walk
+    version: 3.0.4
+
+  ignore@5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+
+  import-lazy@2.1.0:
+    resolution: {integrity: sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==}
+    engines: {node: '>=4'}
+
+  import-local@https://registry.npmmirror.com/import-local/-/import-local-3.1.0.tgz:
+    resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-local/-/import-local-3.1.0.tgz}
+    name: import-local
+    version: 3.1.0
+    engines: {node: '>=8'}
+    hasBin: true
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  indent-string@3.2.0:
+    resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==}
+    engines: {node: '>=4'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+
+  inflight@https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz}
+    name: inflight
+    version: 1.0.6
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inherits@https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz}
+    name: inherits
+    version: 2.0.4
+
+  ini@1.3.7:
+    resolution: {integrity: sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@2.0.0:
+    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
+    engines: {node: '>=10'}
+
+  inquirer-autosubmit-prompt@https://registry.npmmirror.com/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz:
+    resolution: {integrity: sha512-mzNrusCk5L6kSzlN0Ioddn8yzrhYNLli+Sn2ZxMuLechMYAzakiFCIULxsxlQb5YKzthLGfrFACcWoAvM7p04Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz}
+    name: inquirer-autosubmit-prompt
+    version: 0.2.0
+
+  inquirer@https://registry.npmmirror.com/inquirer/-/inquirer-6.5.2.tgz:
+    resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inquirer/-/inquirer-6.5.2.tgz}
+    name: inquirer
+    version: 6.5.2
+    engines: {node: '>=6.0.0'}
+
+  inquirer@https://registry.npmmirror.com/inquirer/-/inquirer-7.3.3.tgz:
+    resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inquirer/-/inquirer-7.3.3.tgz}
+    name: inquirer
+    version: 7.3.3
+    engines: {node: '>=8.0.0'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-binary-path@https://registry.npmmirror.com/is-binary-path/-/is-binary-path-2.1.0.tgz:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-binary-path/-/is-binary-path-2.1.0.tgz}
+    name: is-binary-path
+    version: 2.1.0
+    engines: {node: '>=8'}
+
+  is-ci@https://registry.npmmirror.com/is-ci/-/is-ci-2.0.0.tgz:
+    resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-ci/-/is-ci-2.0.0.tgz}
+    name: is-ci
+    version: 2.0.0
+    hasBin: true
+
+  is-core-module@2.12.1:
+    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
+
+  is-docker@https://registry.npmmirror.com/is-docker/-/is-docker-2.2.1.tgz:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-docker/-/is-docker-2.2.1.tgz}
+    name: is-docker
+    version: 2.2.1
+    engines: {node: '>=8'}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-extglob@https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz}
+    name: is-extglob
+    version: 2.1.1
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@1.0.0:
+    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@2.0.0:
+    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
+    engines: {node: '>=4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-fullwidth-code-point@https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz}
+    name: is-fullwidth-code-point
+    version: 3.0.0
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz}
+    name: is-glob
+    version: 4.0.3
+    engines: {node: '>=0.10.0'}
+
+  is-installed-globally@https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz:
+    resolution: {integrity: sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz}
+    name: is-installed-globally
+    version: 0.3.2
+    engines: {node: '>=8'}
+
+  is-installed-globally@https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz:
+    resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz}
+    name: is-installed-globally
+    version: 0.4.0
+    engines: {node: '>=10'}
+
+  is-interactive@https://registry.npmmirror.com/is-interactive/-/is-interactive-1.0.0.tgz:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-interactive/-/is-interactive-1.0.0.tgz}
+    name: is-interactive
+    version: 1.0.0
+    engines: {node: '>=8'}
+
+  is-npm@https://registry.npmmirror.com/is-npm/-/is-npm-5.0.0.tgz:
+    resolution: {integrity: sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-npm/-/is-npm-5.0.0.tgz}
+    name: is-npm
+    version: 5.0.0
+    engines: {node: '>=10'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-number@https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz}
+    name: is-number
+    version: 7.0.0
+    engines: {node: '>=0.12.0'}
+
+  is-obj@https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz}
+    name: is-obj
+    version: 2.0.0
+    engines: {node: '>=8'}
+
+  is-observable@https://registry.npmmirror.com/is-observable/-/is-observable-1.1.0.tgz:
+    resolution: {integrity: sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-observable/-/is-observable-1.1.0.tgz}
+    name: is-observable
+    version: 1.1.0
+    engines: {node: '>=4'}
+
+  is-path-cwd@https://registry.npmmirror.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz:
+    resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz}
+    name: is-path-cwd
+    version: 2.2.0
+    engines: {node: '>=6'}
+
+  is-path-inside@https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz}
+    name: is-path-inside
+    version: 3.0.3
+    engines: {node: '>=8'}
+
+  is-plain-obj@1.1.0:
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
+
+  is-promise@https://registry.npmmirror.com/is-promise/-/is-promise-2.2.2.tgz:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-promise/-/is-promise-2.2.2.tgz}
+    name: is-promise
+    version: 2.2.2
+
+  is-scoped@https://registry.npmmirror.com/is-scoped/-/is-scoped-2.1.0.tgz:
+    resolution: {integrity: sha512-Cv4OpPTHAK9kHYzkzCrof3VJh7H/PrG2MBUMvvJebaaUMbqhm0YAtXnvh0I3Hnj2tMZWwrRROWLSgfJrKqWmlQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-scoped/-/is-scoped-2.1.0.tgz}
+    name: is-scoped
+    version: 2.1.0
+    engines: {node: '>=8'}
+
+  is-stream@1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  is-url-superb@https://registry.npmmirror.com/is-url-superb/-/is-url-superb-4.0.0.tgz:
+    resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-url-superb/-/is-url-superb-4.0.0.tgz}
+    name: is-url-superb
+    version: 4.0.0
+    engines: {node: '>=10'}
+
+  is-wsl@https://registry.npmmirror.com/is-wsl/-/is-wsl-2.2.0.tgz:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-wsl/-/is-wsl-2.2.0.tgz}
+    name: is-wsl
+    version: 2.2.0
+    engines: {node: '>=8'}
+
+  is-yarn-global@https://registry.npmmirror.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz:
+    resolution: {integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz}
+    name: is-yarn-global
+    version: 0.3.0
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  issue-regex@https://registry.npmmirror.com/issue-regex/-/issue-regex-3.1.0.tgz:
+    resolution: {integrity: sha512-0RHjbtw9QXeSYnIEY5Yrp2QZrdtz21xBDV9C/GIlY2POmgoS6a7qjkYS5siRKXScnuAj5/SPv1C3YForNCHTJA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/issue-regex/-/issue-regex-3.1.0.tgz}
+    name: issue-regex
+    version: 3.1.0
+    engines: {node: '>=10'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.0:
+    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  keyv@3.1.0:
+    resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
+
+  keyv@4.5.2:
+    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  latest-version@https://registry.npmmirror.com/latest-version/-/latest-version-5.1.0.tgz:
+    resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/latest-version/-/latest-version-5.1.0.tgz}
+    name: latest-version
+    version: 5.1.0
+    engines: {node: '>=8'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  listr-input@https://registry.npmmirror.com/listr-input/-/listr-input-0.2.1.tgz:
+    resolution: {integrity: sha512-oa8iVG870qJq+OuuMK3DjGqFcwsK1SDu+kULp9kEq09TY231aideIZenr3lFOQdASpAr6asuyJBbX62/a3IIhg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-input/-/listr-input-0.2.1.tgz}
+    name: listr-input
+    version: 0.2.1
+    engines: {node: '>=6'}
+
+  listr-silent-renderer@https://registry.npmmirror.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz:
+    resolution: {integrity: sha512-L26cIFm7/oZeSNVhWB6faeorXhMg4HNlb/dS/7jHhr708jxlXrtrBWo4YUxZQkc6dGoxEAe6J/D3juTRBUzjtA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz}
+    name: listr-silent-renderer
+    version: 1.1.1
+    engines: {node: '>=4'}
+
+  listr-update-renderer@https://registry.npmmirror.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz:
+    resolution: {integrity: sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz}
+    name: listr-update-renderer
+    version: 0.5.0
+    engines: {node: '>=6'}
+    peerDependencies:
+      listr: ^0.14.2
+
+  listr-verbose-renderer@https://registry.npmmirror.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz:
+    resolution: {integrity: sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz}
+    name: listr-verbose-renderer
+    version: 0.5.0
+    engines: {node: '>=4'}
+
+  listr@https://registry.npmmirror.com/listr/-/listr-0.14.3.tgz:
+    resolution: {integrity: sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr/-/listr-0.14.3.tgz}
+    name: listr
+    version: 0.14.3
+    engines: {node: '>=6'}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  locate-path@https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz}
+    name: locate-path
+    version: 6.0.0
+    engines: {node: '>=10'}
+
+  lodash.isequal@https://registry.npmmirror.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz}
+    name: lodash.isequal
+    version: 4.5.0
+
+  lodash.zip@4.2.0:
+    resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  lodash@https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz}
+    name: lodash
+    version: 4.17.21
+
+  log-symbols@1.0.2:
+    resolution: {integrity: sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==}
+    engines: {node: '>=0.10.0'}
+
+  log-symbols@https://registry.npmmirror.com/log-symbols/-/log-symbols-4.1.0.tgz:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/log-symbols/-/log-symbols-4.1.0.tgz}
+    name: log-symbols
+    version: 4.1.0
+    engines: {node: '>=10'}
+
+  log-update@https://registry.npmmirror.com/log-update/-/log-update-2.3.0.tgz:
+    resolution: {integrity: sha512-vlP11XfFGyeNQlmEn9tJ66rEW1coA/79m5z6BCkudjbAGE83uhAcGYrBFwfs3AdLiLzGRusRPAbSPK9xZteCmg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/log-update/-/log-update-2.3.0.tgz}
+    name: log-update
+    version: 2.3.0
+    engines: {node: '>=4'}
+
+  lowercase-keys@https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz:
+    resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz}
+    name: lowercase-keys
+    version: 1.0.1
+    engines: {node: '>=0.10.0'}
+
+  lowercase-keys@https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz}
+    name: lowercase-keys
+    version: 2.0.0
+    engines: {node: '>=8'}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  lru-queue@https://registry.npmmirror.com/lru-queue/-/lru-queue-0.1.0.tgz:
+    resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lru-queue/-/lru-queue-0.1.0.tgz}
+    name: lru-queue
+    version: 0.1.0
+
+  make-dir@https://registry.npmmirror.com/make-dir/-/make-dir-3.1.0.tgz:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/make-dir/-/make-dir-3.1.0.tgz}
+    name: make-dir
+    version: 3.1.0
+    engines: {node: '>=8'}
+
+  map-age-cleaner@0.1.3:
+    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
+    engines: {node: '>=6'}
+
+  map-obj@1.0.1:
+    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
+    engines: {node: '>=0.10.0'}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
+
+  memoizee@https://registry.npmmirror.com/memoizee/-/memoizee-0.4.15.tgz:
+    resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/memoizee/-/memoizee-0.4.15.tgz}
+    name: memoizee
+    version: 0.4.15
+
+  meow@https://registry.npmmirror.com/meow/-/meow-8.1.2.tgz:
+    resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/meow/-/meow-8.1.2.tgz}
+    name: meow
+    version: 8.1.2
+    engines: {node: '>=10'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+
+  mimic-fn@1.2.0:
+    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
+    engines: {node: '>=4'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  mimic-fn@3.1.0:
+    resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
+    engines: {node: '>=8'}
+
+  mimic-response@https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz}
+    name: mimic-response
+    version: 1.0.1
+    engines: {node: '>=4'}
+
+  mimic-response@https://registry.npmmirror.com/mimic-response/-/mimic-response-2.1.0.tgz:
+    resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mimic-response/-/mimic-response-2.1.0.tgz}
+    name: mimic-response
+    version: 2.1.0
+    engines: {node: '>=8'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz}
+    name: minimatch
+    version: 3.1.2
+
+  minimist-options@4.1.0:
+    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
+    engines: {node: '>= 6'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mock.js@https://registry.npmmirror.com/mock.js/-/mock.js-0.2.0.tgz:
+    resolution: {integrity: sha512-DKI8Rh/h7Mma+fg+6aD0uUvwn0QXAjKG6q3s+lTaCboCQ/kvQMBN9IXRBzgEaz4aPiYoRnKU9jVsfZp0mHpWrQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mock.js/-/mock.js-0.2.0.tgz}
+    name: mock.js
+    version: 0.2.0
+
+  mockjs@https://registry.npmmirror.com/mockjs/-/mockjs-1.1.0.tgz:
+    resolution: {integrity: sha512-eQsKcWzIaZzEZ07NuEyO4Nw65g0hdWAyurVol1IPl1gahRwY+svqzfgfey8U8dahLwG44d6/RwEzuK52rSa/JQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mockjs/-/mockjs-1.1.0.tgz}
+    name: mockjs
+    version: 1.1.0
+    hasBin: true
+
+  mute-stream@https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.7.tgz:
+    resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.7.tgz}
+    name: mute-stream
+    version: 0.0.7
+
+  mute-stream@https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.8.tgz:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.8.tgz}
+    name: mute-stream
+    version: 0.0.8
+
+  new-github-release-url@https://registry.npmmirror.com/new-github-release-url/-/new-github-release-url-1.0.0.tgz:
+    resolution: {integrity: sha512-dle7yf655IMjyFUqn6Nxkb18r4AOAkzRcgcZv6WZ0IqrOH4QCEZ8Sm6I7XX21zvHdBeeMeTkhR9qT2Z0EJDx6A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/new-github-release-url/-/new-github-release-url-1.0.0.tgz}
+    name: new-github-release-url
+    version: 1.0.0
+    engines: {node: '>=10'}
+
+  next-tick@https://registry.npmmirror.com/next-tick/-/next-tick-1.1.0.tgz:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/next-tick/-/next-tick-1.1.0.tgz}
+    name: next-tick
+    version: 1.1.0
+
+  node-fetch-h2@https://registry.npmmirror.com/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz:
+    resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz}
+    name: node-fetch-h2
+    version: 2.3.0
+    engines: {node: 4.x || >=6.0.0}
+
+  node-fetch@https://registry.npmmirror.com/node-fetch/-/node-fetch-2.6.1.tgz:
+    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/node-fetch/-/node-fetch-2.6.1.tgz}
+    name: node-fetch
+    version: 2.6.1
+    engines: {node: 4.x || >=6.0.0}
+
+  node-readfiles@https://registry.npmmirror.com/node-readfiles/-/node-readfiles-0.2.0.tgz:
+    resolution: {integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/node-readfiles/-/node-readfiles-0.2.0.tgz}
+    name: node-readfiles
+    version: 0.2.0
+
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  normalize-package-data@3.0.3:
+    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
+    engines: {node: '>=10'}
+
+  normalize-path@https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz}
+    name: normalize-path
+    version: 3.0.0
+    engines: {node: '>=0.10.0'}
+
+  normalize-url@https://registry.npmmirror.com/normalize-url/-/normalize-url-4.5.1.tgz:
+    resolution: {integrity: sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-url/-/normalize-url-4.5.1.tgz}
+    name: normalize-url
+    version: 4.5.1
+    engines: {node: '>=8'}
+
+  normalize-url@https://registry.npmmirror.com/normalize-url/-/normalize-url-6.1.0.tgz:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-url/-/normalize-url-6.1.0.tgz}
+    name: normalize-url
+    version: 6.1.0
+    engines: {node: '>=10'}
+
+  np@https://registry.npmmirror.com/np/-/np-7.2.0.tgz:
+    resolution: {integrity: sha512-jfMFJXAJlGkCowMPGzA8Ywbmywk7I9hT96DsOcWjDsjq/zP5h6m3VZDcZ1AWYoCBPg4E/lFrJxROmiQH3OWnzA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/np/-/np-7.2.0.tgz}
+    name: np
+    version: 7.2.0
+    engines: {git: '>=2.11.0', node: '>=10', npm: '>=6.8.0', yarn: '>=1.7.0'}
+    hasBin: true
+
+  npm-name@https://registry.npmmirror.com/npm-name/-/npm-name-6.0.1.tgz:
+    resolution: {integrity: sha512-fhKRvUAxaYzMEUZim4mXWyfFbVS+M1CbrCLdAo3txWzrctxKka/h+KaBW0O9Cz5uOM00Nldn2JLWhuwnyW3SUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/npm-name/-/npm-name-6.0.1.tgz}
+    name: npm-name
+    version: 6.0.1
+    engines: {node: '>=10'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  number-is-nan@https://registry.npmmirror.com/number-is-nan/-/number-is-nan-1.0.1.tgz:
+    resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/number-is-nan/-/number-is-nan-1.0.1.tgz}
+    name: number-is-nan
+    version: 1.0.1
+    engines: {node: '>=0.10.0'}
+
+  nunjucks@https://registry.npmmirror.com/nunjucks/-/nunjucks-3.2.2.tgz:
+    resolution: {integrity: sha512-KUi85OoF2NMygwODAy28Lh9qHmq5hO3rBlbkYoC8v377h4l8Pt5qFjILl0LWpMbOrZ18CzfVVUvIHUIrtED3sA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/nunjucks/-/nunjucks-3.2.2.tgz}
+    name: nunjucks
+    version: 3.2.2
+    engines: {node: '>= 6.9.0'}
+    hasBin: true
+
+  oas-kit-common@https://registry.npmmirror.com/oas-kit-common/-/oas-kit-common-1.0.8.tgz:
+    resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-kit-common/-/oas-kit-common-1.0.8.tgz}
+    name: oas-kit-common
+    version: 1.0.8
+
+  oas-linter@https://registry.npmmirror.com/oas-linter/-/oas-linter-3.2.2.tgz:
+    resolution: {integrity: sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-linter/-/oas-linter-3.2.2.tgz}
+    name: oas-linter
+    version: 3.2.2
+
+  oas-resolver@https://registry.npmmirror.com/oas-resolver/-/oas-resolver-2.5.6.tgz:
+    resolution: {integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-resolver/-/oas-resolver-2.5.6.tgz}
+    name: oas-resolver
+    version: 2.5.6
+    hasBin: true
+
+  oas-schema-walker@https://registry.npmmirror.com/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz:
+    resolution: {integrity: sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz}
+    name: oas-schema-walker
+    version: 1.1.5
+
+  oas-validator@https://registry.npmmirror.com/oas-validator/-/oas-validator-5.0.8.tgz:
+    resolution: {integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-validator/-/oas-validator-5.0.8.tgz}
+    name: oas-validator
+    version: 5.0.8
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  once@https://registry.npmmirror.com/once/-/once-1.4.0.tgz:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/once/-/once-1.4.0.tgz}
+    name: once
+    version: 1.4.0
+
+  onetime@2.0.1:
+    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
+    engines: {node: '>=4'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  onetime@https://registry.npmmirror.com/onetime/-/onetime-5.1.2.tgz:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/onetime/-/onetime-5.1.2.tgz}
+    name: onetime
+    version: 5.1.2
+    engines: {node: '>=6'}
+
+  open@https://registry.npmmirror.com/open/-/open-7.4.2.tgz:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/open/-/open-7.4.2.tgz}
+    name: open
+    version: 7.4.2
+    engines: {node: '>=8'}
+
+  openapi3-ts@https://registry.npmmirror.com/openapi3-ts/-/openapi3-ts-2.0.1.tgz:
+    resolution: {integrity: sha512-v6X3iwddhi276siej96jHGIqTx3wzVfMTmpGJEQDt7GPI7pI6sywItURLzpEci21SBRpPN/aOWSF5mVfFVNmcg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/openapi3-ts/-/openapi3-ts-2.0.1.tgz}
+    name: openapi3-ts
+    version: 2.0.1
+
+  org-regex@https://registry.npmmirror.com/org-regex/-/org-regex-1.0.0.tgz:
+    resolution: {integrity: sha512-7bqkxkEJwzJQUAlyYniqEZ3Ilzjh0yoa62c7gL6Ijxj5bEpPL+8IE1Z0PFj0ywjjXQcdrwR51g9MIcLezR0hKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/org-regex/-/org-regex-1.0.0.tgz}
+    name: org-regex
+    version: 1.0.0
+    engines: {node: '>=8'}
+
+  os-tmpdir@https://registry.npmmirror.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz}
+    name: os-tmpdir
+    version: 1.0.2
+    engines: {node: '>=0.10.0'}
+
+  ow@https://registry.npmmirror.com/ow/-/ow-0.21.0.tgz:
+    resolution: {integrity: sha512-dlsoDe39g7mhdsdrC1R/YwjT7yjVqE3svWwOlMGvN690waBkgEZBmKBdkmKvSt5/wZ6E0Jn/nIesPqMZOpPKqw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ow/-/ow-0.21.0.tgz}
+    name: ow
+    version: 0.21.0
+    engines: {node: '>=10'}
+
+  p-cancelable@https://registry.npmmirror.com/p-cancelable/-/p-cancelable-1.1.0.tgz:
+    resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-cancelable/-/p-cancelable-1.1.0.tgz}
+    name: p-cancelable
+    version: 1.1.0
+    engines: {node: '>=6'}
+
+  p-cancelable@https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz}
+    name: p-cancelable
+    version: 2.1.1
+    engines: {node: '>=8'}
+
+  p-defer@1.0.0:
+    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
+    engines: {node: '>=4'}
+
+  p-event@https://registry.npmmirror.com/p-event/-/p-event-4.2.0.tgz:
+    resolution: {integrity: sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-event/-/p-event-4.2.0.tgz}
+    name: p-event
+    version: 4.2.0
+    engines: {node: '>=8'}
+
+  p-finally@https://registry.npmmirror.com/p-finally/-/p-finally-1.0.0.tgz:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-finally/-/p-finally-1.0.0.tgz}
+    name: p-finally
+    version: 1.0.0
+    engines: {node: '>=4'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-limit@https://registry.npmmirror.com/p-limit/-/p-limit-2.3.0.tgz:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-limit/-/p-limit-2.3.0.tgz}
+    name: p-limit
+    version: 2.3.0
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  p-map@https://registry.npmmirror.com/p-map/-/p-map-2.1.0.tgz:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-map/-/p-map-2.1.0.tgz}
+    name: p-map
+    version: 2.1.0
+    engines: {node: '>=6'}
+
+  p-map@https://registry.npmmirror.com/p-map/-/p-map-3.0.0.tgz:
+    resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-map/-/p-map-3.0.0.tgz}
+    name: p-map
+    version: 3.0.0
+    engines: {node: '>=8'}
+
+  p-map@https://registry.npmmirror.com/p-map/-/p-map-4.0.0.tgz:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-map/-/p-map-4.0.0.tgz}
+    name: p-map
+    version: 4.0.0
+    engines: {node: '>=10'}
+
+  p-memoize@https://registry.npmmirror.com/p-memoize/-/p-memoize-4.0.4.tgz:
+    resolution: {integrity: sha512-ijdh0DP4Mk6J4FXlOM6vPPoCjPytcEseW8p/k5SDTSSfGV3E9bpt9Yzfifvzp6iohIieoLTkXRb32OWV0fB2Lw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-memoize/-/p-memoize-4.0.4.tgz}
+    name: p-memoize
+    version: 4.0.4
+    engines: {node: '>=10'}
+
+  p-reflect@https://registry.npmmirror.com/p-reflect/-/p-reflect-2.1.0.tgz:
+    resolution: {integrity: sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-reflect/-/p-reflect-2.1.0.tgz}
+    name: p-reflect
+    version: 2.1.0
+    engines: {node: '>=8'}
+
+  p-settle@https://registry.npmmirror.com/p-settle/-/p-settle-4.1.1.tgz:
+    resolution: {integrity: sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-settle/-/p-settle-4.1.1.tgz}
+    name: p-settle
+    version: 4.1.1
+    engines: {node: '>=10'}
+
+  p-timeout@https://registry.npmmirror.com/p-timeout/-/p-timeout-3.2.0.tgz:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-timeout/-/p-timeout-3.2.0.tgz}
+    name: p-timeout
+    version: 3.2.0
+    engines: {node: '>=8'}
+
+  p-timeout@https://registry.npmmirror.com/p-timeout/-/p-timeout-4.1.0.tgz:
+    resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-timeout/-/p-timeout-4.1.0.tgz}
+    name: p-timeout
+    version: 4.1.0
+    engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  package-json@https://registry.npmmirror.com/package-json/-/package-json-6.5.0.tgz:
+    resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/package-json/-/package-json-6.5.0.tgz}
+    name: package-json
+    version: 6.5.0
+    engines: {node: '>=8'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-exists@https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz}
+    name: path-exists
+    version: 4.0.0
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-is-absolute@https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz}
+    name: path-is-absolute
+    version: 1.0.1
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz}
+    name: picomatch
+    version: 2.3.1
+    engines: {node: '>=8.6'}
+
+  pkg-dir@https://registry.npmmirror.com/pkg-dir/-/pkg-dir-4.2.0.tgz:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pkg-dir/-/pkg-dir-4.2.0.tgz}
+    name: pkg-dir
+    version: 4.2.0
+    engines: {node: '>=8'}
+
+  pkg-dir@https://registry.npmmirror.com/pkg-dir/-/pkg-dir-5.0.0.tgz:
+    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pkg-dir/-/pkg-dir-5.0.0.tgz}
+    name: pkg-dir
+    version: 5.0.0
+    engines: {node: '>=10'}
+
+  prepend-http@https://registry.npmmirror.com/prepend-http/-/prepend-http-2.0.0.tgz:
+    resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prepend-http/-/prepend-http-2.0.0.tgz}
+    name: prepend-http
+    version: 2.0.0
+    engines: {node: '>=4'}
+
+  prettier@https://registry.npmmirror.com/prettier/-/prettier-2.2.1.tgz:
+    resolution: {integrity: sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prettier/-/prettier-2.2.1.tgz}
+    name: prettier
+    version: 2.2.1
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  pump@3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+
+  pupa@https://registry.npmmirror.com/pupa/-/pupa-2.1.1.tgz:
+    resolution: {integrity: sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pupa/-/pupa-2.1.1.tgz}
+    name: pupa
+    version: 2.1.1
+    engines: {node: '>=8'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@4.0.1:
+    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
+    engines: {node: '>=8'}
+
+  rc@https://registry.npmmirror.com/rc/-/rc-1.2.8.tgz:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rc/-/rc-1.2.8.tgz}
+    name: rc
+    version: 1.2.8
+    hasBin: true
+
+  read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
+
+  read-pkg-up@https://registry.npmmirror.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz}
+    name: read-pkg-up
+    version: 7.0.1
+    engines: {node: '>=8'}
+
+  read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
+
+  readdirp@https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz}
+    name: readdirp
+    version: 3.6.0
+    engines: {node: '>=8.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  reftools@https://registry.npmmirror.com/reftools/-/reftools-1.1.9.tgz:
+    resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/reftools/-/reftools-1.1.9.tgz}
+    name: reftools
+    version: 1.1.9
+
+  registry-auth-token@https://registry.npmmirror.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz:
+    resolution: {integrity: sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz}
+    name: registry-auth-token
+    version: 4.2.2
+    engines: {node: '>=6.0.0'}
+
+  registry-url@https://registry.npmmirror.com/registry-url/-/registry-url-5.1.0.tgz:
+    resolution: {integrity: sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/registry-url/-/registry-url-5.1.0.tgz}
+    name: registry-url
+    version: 5.1.0
+    engines: {node: '>=8'}
+
+  require-directory@https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz}
+    name: require-directory
+    version: 2.1.1
+    engines: {node: '>=0.10.0'}
+
+  reserved-words@https://registry.npmmirror.com/reserved-words/-/reserved-words-0.1.2.tgz:
+    resolution: {integrity: sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/reserved-words/-/reserved-words-0.1.2.tgz}
+    name: reserved-words
+    version: 0.1.2
+
+  resolve-cwd@https://registry.npmmirror.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz}
+    name: resolve-cwd
+    version: 3.0.0
+    engines: {node: '>=8'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve@1.22.2:
+    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
+    hasBin: true
+
+  responselike@https://registry.npmmirror.com/responselike/-/responselike-1.0.2.tgz:
+    resolution: {integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/responselike/-/responselike-1.0.2.tgz}
+    name: responselike
+    version: 1.0.2
+
+  responselike@https://registry.npmmirror.com/responselike/-/responselike-2.0.1.tgz:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/responselike/-/responselike-2.0.1.tgz}
+    name: responselike
+    version: 2.0.1
+
+  restore-cursor@https://registry.npmmirror.com/restore-cursor/-/restore-cursor-2.0.0.tgz:
+    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/restore-cursor/-/restore-cursor-2.0.0.tgz}
+    name: restore-cursor
+    version: 2.0.0
+    engines: {node: '>=4'}
+
+  restore-cursor@https://registry.npmmirror.com/restore-cursor/-/restore-cursor-3.1.0.tgz:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/restore-cursor/-/restore-cursor-3.1.0.tgz}
+    name: restore-cursor
+    version: 3.1.0
+    engines: {node: '>=8'}
+
+  reusify@1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
+
+  rimraf@https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz}
+    name: rimraf
+    version: 3.0.2
+    hasBin: true
+
+  run-async@https://registry.npmmirror.com/run-async/-/run-async-2.4.1.tgz:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/run-async/-/run-async-2.4.1.tgz}
+    name: run-async
+    version: 2.4.1
+    engines: {node: '>=0.12.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz:
+    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz}
+    name: rxjs
+    version: 6.6.7
+    engines: {npm: '>=2.0.0'}
+
+  safer-buffer@https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz}
+    name: safer-buffer
+    version: 2.1.2
+
+  scoped-regex@https://registry.npmmirror.com/scoped-regex/-/scoped-regex-2.1.0.tgz:
+    resolution: {integrity: sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/scoped-regex/-/scoped-regex-2.1.0.tgz}
+    name: scoped-regex
+    version: 2.1.0
+    engines: {node: '>=8'}
+
+  semver-diff@https://registry.npmmirror.com/semver-diff/-/semver-diff-3.1.1.tgz:
+    resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/semver-diff/-/semver-diff-3.1.1.tgz}
+    name: semver-diff
+    version: 3.1.1
+    engines: {node: '>=8'}
+
+  semver@5.7.1:
+    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+    hasBin: true
+
+  semver@6.3.0:
+    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    hasBin: true
+
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@https://registry.npmmirror.com/semver/-/semver-7.5.4.tgz:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/semver/-/semver-7.5.4.tgz}
+    name: semver
+    version: 7.5.4
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  should-equal@https://registry.npmmirror.com/should-equal/-/should-equal-2.0.0.tgz:
+    resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-equal/-/should-equal-2.0.0.tgz}
+    name: should-equal
+    version: 2.0.0
+
+  should-format@https://registry.npmmirror.com/should-format/-/should-format-3.0.3.tgz:
+    resolution: {integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-format/-/should-format-3.0.3.tgz}
+    name: should-format
+    version: 3.0.3
+
+  should-type-adaptors@https://registry.npmmirror.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz:
+    resolution: {integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz}
+    name: should-type-adaptors
+    version: 1.1.0
+
+  should-type@https://registry.npmmirror.com/should-type/-/should-type-1.4.0.tgz:
+    resolution: {integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-type/-/should-type-1.4.0.tgz}
+    name: should-type
+    version: 1.4.0
+
+  should-util@https://registry.npmmirror.com/should-util/-/should-util-1.0.1.tgz:
+    resolution: {integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-util/-/should-util-1.0.1.tgz}
+    name: should-util
+    version: 1.0.1
+
+  should@https://registry.npmmirror.com/should/-/should-13.2.3.tgz:
+    resolution: {integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should/-/should-13.2.3.tgz}
+    name: should
+    version: 13.2.3
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  slice-ansi@0.0.4:
+    resolution: {integrity: sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==}
+    engines: {node: '>=0.10.0'}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.3.0:
+    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.13:
+    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
+
+  split@https://registry.npmmirror.com/split/-/split-1.0.1.tgz:
+    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/split/-/split-1.0.1.tgz}
+    name: split
+    version: 1.0.1
+
+  string-width@1.0.2:
+    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
+    engines: {node: '>=0.10.0'}
+
+  string-width@2.1.1:
+    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
+    engines: {node: '>=4'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz}
+    name: string-width
+    version: 4.2.3
+    engines: {node: '>=8'}
+
+  strip-ansi@3.0.1:
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
+    engines: {node: '>=0.10.0'}
+
+  strip-ansi@4.0.0:
+    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
+    engines: {node: '>=4'}
+
+  strip-ansi@5.2.0:
+    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
+    engines: {node: '>=6'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz}
+    name: strip-ansi
+    version: 6.0.1
+    engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  supports-color@2.0.0:
+    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
+    engines: {node: '>=0.8.0'}
+
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz}
+    name: supports-color
+    version: 7.2.0
+    engines: {node: '>=8'}
+
+  supports-hyperlinks@2.3.0:
+    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
+    engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  swagger2openapi@https://registry.npmmirror.com/swagger2openapi/-/swagger2openapi-7.0.4.tgz:
+    resolution: {integrity: sha512-MGzJU44XSXHKxvtx/NbBnP3z5s1KzN5xhqIBERoZEKfRiZ56lNUo5TGOv0dJ8n7JGeheCeU0CydfvbSOh+DaXg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/swagger2openapi/-/swagger2openapi-7.0.4.tgz}
+    name: swagger2openapi
+    version: 7.0.4
+    hasBin: true
+
+  symbol-observable@https://registry.npmmirror.com/symbol-observable/-/symbol-observable-1.2.0.tgz:
+    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/symbol-observable/-/symbol-observable-1.2.0.tgz}
+    name: symbol-observable
+    version: 1.2.0
+    engines: {node: '>=0.10.0'}
+
+  symbol-observable@https://registry.npmmirror.com/symbol-observable/-/symbol-observable-3.0.0.tgz:
+    resolution: {integrity: sha512-6tDOXSHiVjuCaasQSWTmHUWn4PuG7qa3+1WT031yTc/swT7+rLiw3GOrFxaH1E3lLP09dH3bVuVDf2gK5rxG3Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/symbol-observable/-/symbol-observable-3.0.0.tgz}
+    name: symbol-observable
+    version: 3.0.0
+    engines: {node: '>=0.10'}
+
+  terminal-link@https://registry.npmmirror.com/terminal-link/-/terminal-link-2.1.1.tgz:
+    resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/terminal-link/-/terminal-link-2.1.1.tgz}
+    name: terminal-link
+    version: 2.1.1
+    engines: {node: '>=8'}
+
+  through@https://registry.npmmirror.com/through/-/through-2.3.8.tgz:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/through/-/through-2.3.8.tgz}
+    name: through
+    version: 2.3.8
+
+  timers-ext@https://registry.npmmirror.com/timers-ext/-/timers-ext-0.1.7.tgz:
+    resolution: {integrity: sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/timers-ext/-/timers-ext-0.1.7.tgz}
+    name: timers-ext
+    version: 0.1.7
+
+  tiny-pinyin@https://registry.npmmirror.com/tiny-pinyin/-/tiny-pinyin-1.3.2.tgz:
+    resolution: {integrity: sha512-uHNGu4evFt/8eNLldazeAM1M8JrMc1jshhJJfVRARTN3yT8HEEibofeQ7QETWQ5ISBjd6fKtTVBCC/+mGS6FpA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tiny-pinyin/-/tiny-pinyin-1.3.2.tgz}
+    name: tiny-pinyin
+    version: 1.3.2
+
+  tmp@https://registry.npmmirror.com/tmp/-/tmp-0.0.33.tgz:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tmp/-/tmp-0.0.33.tgz}
+    name: tmp
+    version: 0.0.33
+    engines: {node: '>=0.6.0'}
+
+  to-readable-stream@https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz:
+    resolution: {integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz}
+    name: to-readable-stream
+    version: 1.0.0
+    engines: {node: '>=6'}
+
+  to-readable-stream@https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-2.1.0.tgz:
+    resolution: {integrity: sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-2.1.0.tgz}
+    name: to-readable-stream
+    version: 2.1.0
+    engines: {node: '>=8'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  to-regex-range@https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz}
+    name: to-regex-range
+    version: 5.0.1
+    engines: {node: '>=8.0'}
+
+  trim-newlines@3.0.1:
+    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
+    engines: {node: '>=8'}
+
+  tslib@https://registry.npmmirror.com/tslib/-/tslib-1.14.1.tgz:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tslib/-/tslib-1.14.1.tgz}
+    name: tslib
+    version: 1.14.1
+
+  tslib@https://registry.npmmirror.com/tslib/-/tslib-2.6.0.tgz:
+    resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tslib/-/tslib-2.6.0.tgz}
+    name: tslib
+    version: 2.6.0
+
+  type-fest@0.10.0:
+    resolution: {integrity: sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==}
+    engines: {node: '>=8'}
+
+  type-fest@0.18.1:
+    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
+    engines: {node: '>=10'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  type-fest@0.4.1:
+    resolution: {integrity: sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==}
+    engines: {node: '>=6'}
+
+  type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+
+  type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+
+  type@https://registry.npmmirror.com/type/-/type-1.2.0.tgz:
+    resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type/-/type-1.2.0.tgz}
+    name: type
+    version: 1.2.0
+
+  type@https://registry.npmmirror.com/type/-/type-2.7.2.tgz:
+    resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type/-/type-2.7.2.tgz}
+    name: type
+    version: 2.7.2
+
+  typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
+  typescript@https://registry.npmmirror.com/typescript/-/typescript-4.1.3.tgz:
+    resolution: {integrity: sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/typescript/-/typescript-4.1.3.tgz}
+    name: typescript
+    version: 4.1.3
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
+  unique-string@https://registry.npmmirror.com/unique-string/-/unique-string-2.0.0.tgz:
+    resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unique-string/-/unique-string-2.0.0.tgz}
+    name: unique-string
+    version: 2.0.0
+    engines: {node: '>=8'}
+
+  update-notifier@https://registry.npmmirror.com/update-notifier/-/update-notifier-5.1.0.tgz:
+    resolution: {integrity: sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/update-notifier/-/update-notifier-5.1.0.tgz}
+    name: update-notifier
+    version: 5.1.0
+    engines: {node: '>=10'}
+
+  url-parse-lax@https://registry.npmmirror.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz:
+    resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz}
+    name: url-parse-lax
+    version: 3.0.0
+    engines: {node: '>=4'}
+
+  vali-date@https://registry.npmmirror.com/vali-date/-/vali-date-1.0.0.tgz:
+    resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vali-date/-/vali-date-1.0.0.tgz}
+    name: vali-date
+    version: 1.0.0
+    engines: {node: '>=0.10.0'}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validate-npm-package-name@https://registry.npmmirror.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz:
+    resolution: {integrity: sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz}
+    name: validate-npm-package-name
+    version: 3.0.0
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  widest-line@https://registry.npmmirror.com/widest-line/-/widest-line-3.1.0.tgz:
+    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/widest-line/-/widest-line-3.1.0.tgz}
+    name: widest-line
+    version: 3.1.0
+    engines: {node: '>=8'}
+
+  wrap-ansi@https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz:
+    resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz}
+    name: wrap-ansi
+    version: 3.0.1
+    engines: {node: '>=4'}
+
+  wrap-ansi@https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz}
+    name: wrap-ansi
+    version: 7.0.0
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  wrappy@https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz}
+    name: wrappy
+    version: 1.0.2
+
+  write-file-atomic@3.0.3:
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+
+  xdg-basedir@https://registry.npmmirror.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz:
+    resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz}
+    name: xdg-basedir
+    version: 4.0.0
+    engines: {node: '>=8'}
+
+  y18n@https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz}
+    name: y18n
+    version: 5.0.8
+    engines: {node: '>=10'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+
+  yaml@https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz}
+    name: yaml
+    version: 1.10.2
+    engines: {node: '>= 6'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs-parser@https://registry.npmmirror.com/yargs-parser/-/yargs-parser-20.2.9.tgz:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs-parser/-/yargs-parser-20.2.9.tgz}
+    name: yargs-parser
+    version: 20.2.9
+    engines: {node: '>=10'}
+
+  yargs-parser@https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz}
+    name: yargs-parser
+    version: 21.1.1
+    engines: {node: '>=12'}
+
+  yargs@https://registry.npmmirror.com/yargs/-/yargs-16.2.0.tgz:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs/-/yargs-16.2.0.tgz}
+    name: yargs
+    version: 16.2.0
+    engines: {node: '>=10'}
+
+  yargs@https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz}
+    name: yargs
+    version: 17.7.2
+    engines: {node: '>=12'}
+
+  yocto-queue@https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz}
+    name: yocto-queue
+    version: 0.1.0
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@babel/code-frame@7.22.5':
+    dependencies:
+      '@babel/highlight': 7.22.5
+
+  '@babel/helper-validator-identifier@7.22.5': {}
+
+  '@babel/highlight@7.22.5':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+
+  '@exodus/schemasafe@https://registry.npmmirror.com/@exodus/schemasafe/-/schemasafe-1.0.1.tgz': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.15.0
+
+  '@samverschueren/stream-to-observable@https://registry.npmmirror.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz(rxjs@6.6.7)':
+    dependencies:
+      any-observable: https://registry.npmmirror.com/any-observable/-/any-observable-0.3.0.tgz(rxjs@6.6.7)
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
+    transitivePeerDependencies:
+      - zenObservable
+
+  '@sindresorhus/is@https://registry.npmmirror.com/@sindresorhus/is/-/is-0.14.0.tgz': {}
+
+  '@sindresorhus/is@https://registry.npmmirror.com/@sindresorhus/is/-/is-2.1.1.tgz': {}
+
+  '@sindresorhus/is@https://registry.npmmirror.com/@sindresorhus/is/-/is-4.6.0.tgz': {}
+
+  '@szmarczak/http-timer@https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz':
+    dependencies:
+      defer-to-connect: https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz
+
+  '@szmarczak/http-timer@https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz':
+    dependencies:
+      defer-to-connect: https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz
+
+  '@types/body-parser@https://registry.npmmirror.com/@types/body-parser/-/body-parser-1.19.2.tgz':
+    dependencies:
+      '@types/connect': https://registry.npmmirror.com/@types/connect/-/connect-3.4.35.tgz
+      '@types/node': https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+
+  '@types/cacheable-request@https://registry.npmmirror.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz':
+    dependencies:
+      '@types/http-cache-semantics': https://registry.npmmirror.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz
+      '@types/keyv': https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz
+      '@types/node': https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+      '@types/responselike': https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.0.tgz
+
+  '@types/connect@https://registry.npmmirror.com/@types/connect/-/connect-3.4.35.tgz':
+    dependencies:
+      '@types/node': https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+
+  '@types/express-serve-static-core@https://registry.npmmirror.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz':
+    dependencies:
+      '@types/node': https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+      '@types/qs': https://registry.npmmirror.com/@types/qs/-/qs-6.9.7.tgz
+      '@types/range-parser': https://registry.npmmirror.com/@types/range-parser/-/range-parser-1.2.4.tgz
+      '@types/send': https://registry.npmmirror.com/@types/send/-/send-0.17.1.tgz
+
+  '@types/express@https://registry.npmmirror.com/@types/express/-/express-4.17.11.tgz':
+    dependencies:
+      '@types/body-parser': https://registry.npmmirror.com/@types/body-parser/-/body-parser-1.19.2.tgz
+      '@types/express-serve-static-core': https://registry.npmmirror.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz
+      '@types/qs': https://registry.npmmirror.com/@types/qs/-/qs-6.9.7.tgz
+      '@types/serve-static': https://registry.npmmirror.com/@types/serve-static/-/serve-static-1.15.2.tgz
+
+  '@types/http-cache-semantics@https://registry.npmmirror.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz': {}
+
+  '@types/http-errors@https://registry.npmmirror.com/@types/http-errors/-/http-errors-2.0.1.tgz': {}
+
+  '@types/keyv@https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz':
+    dependencies:
+      '@types/node': https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+
+  '@types/mime@https://registry.npmmirror.com/@types/mime/-/mime-1.3.2.tgz': {}
+
+  '@types/mime@https://registry.npmmirror.com/@types/mime/-/mime-3.0.1.tgz': {}
+
+  '@types/minimist@1.2.2': {}
+
+  '@types/node@https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz': {}
+
+  '@types/normalize-package-data@2.4.1': {}
+
+  '@types/parse-json@4.0.0': {}
+
+  '@types/qs@https://registry.npmmirror.com/@types/qs/-/qs-6.9.7.tgz': {}
+
+  '@types/range-parser@https://registry.npmmirror.com/@types/range-parser/-/range-parser-1.2.4.tgz': {}
+
+  '@types/responselike@https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.0.tgz':
+    dependencies:
+      '@types/node': https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+
+  '@types/send@https://registry.npmmirror.com/@types/send/-/send-0.17.1.tgz':
+    dependencies:
+      '@types/mime': https://registry.npmmirror.com/@types/mime/-/mime-1.3.2.tgz
+      '@types/node': https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+
+  '@types/serve-static@https://registry.npmmirror.com/@types/serve-static/-/serve-static-1.15.2.tgz':
+    dependencies:
+      '@types/http-errors': https://registry.npmmirror.com/@types/http-errors/-/http-errors-2.0.1.tgz
+      '@types/mime': https://registry.npmmirror.com/@types/mime/-/mime-3.0.1.tgz
+      '@types/node': https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz
+
+  a-sync-waterfall@https://registry.npmmirror.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz: {}
+
+  aggregate-error@https://registry.npmmirror.com/aggregate-error/-/aggregate-error-3.1.0.tgz:
+    dependencies:
+      clean-stack: https://registry.npmmirror.com/clean-stack/-/clean-stack-2.2.0.tgz
+      indent-string: 4.0.0
+
+  ansi-align@https://registry.npmmirror.com/ansi-align/-/ansi-align-3.0.1.tgz:
+    dependencies:
+      string-width: 4.2.3
+
+  ansi-escapes@3.2.0: {}
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
+  ansi-regex@2.1.1: {}
+
+  ansi-regex@3.0.1: {}
+
+  ansi-regex@4.1.1: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz: {}
+
+  ansi-styles@2.2.1: {}
+
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz:
+    dependencies:
+      color-convert: 2.0.1
+
+  any-observable@https://registry.npmmirror.com/any-observable/-/any-observable-0.3.0.tgz(rxjs@6.6.7):
+    dependencies:
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
+
+  any-observable@https://registry.npmmirror.com/any-observable/-/any-observable-0.5.1.tgz(rxjs@6.6.7):
+    dependencies:
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
+
+  anymatch@https://registry.npmmirror.com/anymatch/-/anymatch-3.1.3.tgz:
+    dependencies:
+      normalize-path: https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz
+      picomatch: https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz
+    optional: true
+
+  argparse@2.0.1: {}
+
+  array-union@2.1.0: {}
+
+  arrify@1.0.1: {}
+
+  asap@https://registry.npmmirror.com/asap/-/asap-2.0.6.tgz: {}
+
+  async-exit-hook@https://registry.npmmirror.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz: {}
+
+  balanced-match@1.0.2: {}
+
+  binary-extensions@https://registry.npmmirror.com/binary-extensions/-/binary-extensions-2.2.0.tgz:
+    optional: true
+
+  boxen@https://registry.npmmirror.com/boxen/-/boxen-5.1.2.tgz:
+    dependencies:
+      ansi-align: https://registry.npmmirror.com/ansi-align/-/ansi-align-3.0.1.tgz
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      cli-boxes: https://registry.npmmirror.com/cli-boxes/-/cli-boxes-2.2.1.tgz
+      string-width: 4.2.3
+      type-fest: 0.20.2
+      widest-line: https://registry.npmmirror.com/widest-line/-/widest-line-3.1.0.tgz
+      wrap-ansi: https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+
+  brace-expansion@1.1.11:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  braces@3.0.2:
+    dependencies:
+      fill-range: 7.0.1
+
+  braces@https://registry.npmmirror.com/braces/-/braces-3.0.2.tgz:
+    dependencies:
+      fill-range: https://registry.npmmirror.com/fill-range/-/fill-range-7.0.1.tgz
+    optional: true
+
+  builtins@https://registry.npmmirror.com/builtins/-/builtins-1.0.3.tgz: {}
+
+  cacheable-lookup@https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz:
+    dependencies:
+      '@types/keyv': https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz
+      keyv: 4.5.2
+
+  cacheable-request@https://registry.npmmirror.com/cacheable-request/-/cacheable-request-6.1.0.tgz:
+    dependencies:
+      clone-response: https://registry.npmmirror.com/clone-response/-/clone-response-1.0.3.tgz
+      get-stream: 5.2.0
+      http-cache-semantics: https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz
+      keyv: 3.1.0
+      lowercase-keys: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz
+      normalize-url: https://registry.npmmirror.com/normalize-url/-/normalize-url-4.5.1.tgz
+      responselike: https://registry.npmmirror.com/responselike/-/responselike-1.0.2.tgz
+
+  cacheable-request@https://registry.npmmirror.com/cacheable-request/-/cacheable-request-7.0.4.tgz:
+    dependencies:
+      clone-response: https://registry.npmmirror.com/clone-response/-/clone-response-1.0.3.tgz
+      get-stream: 5.2.0
+      http-cache-semantics: https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz
+      keyv: 4.5.2
+      lowercase-keys: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz
+      normalize-url: https://registry.npmmirror.com/normalize-url/-/normalize-url-6.1.0.tgz
+      responselike: https://registry.npmmirror.com/responselike/-/responselike-2.0.1.tgz
+
+  call-me-maybe@https://registry.npmmirror.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz: {}
+
+  callsites@3.1.0: {}
+
+  camelcase-keys@6.2.2:
+    dependencies:
+      camelcase: 5.3.1
+      map-obj: 4.3.0
+      quick-lru: 4.0.1
+
+  camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
+
+  chalk@1.1.3:
+    dependencies:
+      ansi-styles: 2.2.1
+      escape-string-regexp: 1.0.5
+      has-ansi: https://registry.npmmirror.com/has-ansi/-/has-ansi-2.0.0.tgz
+      strip-ansi: 3.0.1
+      supports-color: 2.0.0
+
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz:
+    dependencies:
+      ansi-styles: https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz
+      supports-color: https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz
+
+  chardet@https://registry.npmmirror.com/chardet/-/chardet-0.7.0.tgz: {}
+
+  chokidar@3.5.3:
+    dependencies:
+      anymatch: https://registry.npmmirror.com/anymatch/-/anymatch-3.1.3.tgz
+      braces: https://registry.npmmirror.com/braces/-/braces-3.0.2.tgz
+      glob-parent: https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz
+      is-binary-path: https://registry.npmmirror.com/is-binary-path/-/is-binary-path-2.1.0.tgz
+      is-glob: https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz
+      normalize-path: https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz
+      readdirp: https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz
+    optionalDependencies:
+      fsevents: 2.3.2
+    optional: true
+
+  ci-info@2.0.0: {}
+
+  clean-stack@https://registry.npmmirror.com/clean-stack/-/clean-stack-2.2.0.tgz: {}
+
+  cli-boxes@https://registry.npmmirror.com/cli-boxes/-/cli-boxes-2.2.1.tgz: {}
+
+  cli-cursor@https://registry.npmmirror.com/cli-cursor/-/cli-cursor-2.1.0.tgz:
+    dependencies:
+      restore-cursor: https://registry.npmmirror.com/restore-cursor/-/restore-cursor-2.0.0.tgz
+
+  cli-cursor@https://registry.npmmirror.com/cli-cursor/-/cli-cursor-3.1.0.tgz:
+    dependencies:
+      restore-cursor: https://registry.npmmirror.com/restore-cursor/-/restore-cursor-3.1.0.tgz
+
+  cli-truncate@https://registry.npmmirror.com/cli-truncate/-/cli-truncate-0.2.1.tgz:
+    dependencies:
+      slice-ansi: 0.0.4
+      string-width: 1.0.2
+
+  cli-width@https://registry.npmmirror.com/cli-width/-/cli-width-2.2.1.tgz: {}
+
+  cli-width@https://registry.npmmirror.com/cli-width/-/cli-width-3.0.0.tgz: {}
+
+  cliui@https://registry.npmmirror.com/cliui/-/cliui-7.0.4.tgz:
+    dependencies:
+      string-width: https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz
+      strip-ansi: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz
+      wrap-ansi: https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+
+  cliui@https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz:
+    dependencies:
+      string-width: https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz
+      strip-ansi: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz
+      wrap-ansi: https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz
+
+  clone-response@https://registry.npmmirror.com/clone-response/-/clone-response-1.0.3.tgz:
+    dependencies:
+      mimic-response: https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz
+
+  code-point-at@https://registry.npmmirror.com/code-point-at/-/code-point-at-1.1.0.tgz: {}
+
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.3: {}
+
+  color-name@1.1.4: {}
+
+  commander@https://registry.npmmirror.com/commander/-/commander-11.0.0.tgz: {}
+
+  commander@https://registry.npmmirror.com/commander/-/commander-5.1.0.tgz: {}
+
+  concat-map@0.0.1: {}
+
+  configstore@https://registry.npmmirror.com/configstore/-/configstore-5.0.1.tgz:
+    dependencies:
+      dot-prop: https://registry.npmmirror.com/dot-prop/-/dot-prop-5.3.0.tgz
+      graceful-fs: https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz
+      make-dir: https://registry.npmmirror.com/make-dir/-/make-dir-3.1.0.tgz
+      unique-string: https://registry.npmmirror.com/unique-string/-/unique-string-2.0.0.tgz
+      write-file-atomic: 3.0.3
+      xdg-basedir: https://registry.npmmirror.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz
+
+  cosmiconfig@7.1.0:
+    dependencies:
+      '@types/parse-json': 4.0.0
+      import-fresh: 3.3.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+
+  cosmiconfig@9.0.0(typescript@4.1.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      typescript: https://registry.npmmirror.com/typescript/-/typescript-4.1.3.tgz
+
+  cross-spawn@7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  crypto-random-string@https://registry.npmmirror.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz: {}
+
+  d@https://registry.npmmirror.com/d/-/d-1.0.1.tgz:
+    dependencies:
+      es5-ext: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz
+      type: https://registry.npmmirror.com/type/-/type-1.2.0.tgz
+
+  date-fns@https://registry.npmmirror.com/date-fns/-/date-fns-1.30.1.tgz: {}
+
+  dayjs@https://registry.npmmirror.com/dayjs/-/dayjs-1.10.3.tgz: {}
+
+  decamelize-keys@1.1.1:
+    dependencies:
+      decamelize: 1.2.0
+      map-obj: 1.0.1
+
+  decamelize@1.2.0: {}
+
+  decompress-response@https://registry.npmmirror.com/decompress-response/-/decompress-response-3.3.0.tgz:
+    dependencies:
+      mimic-response: https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz
+
+  decompress-response@https://registry.npmmirror.com/decompress-response/-/decompress-response-5.0.0.tgz:
+    dependencies:
+      mimic-response: https://registry.npmmirror.com/mimic-response/-/mimic-response-2.1.0.tgz
+
+  deep-extend@https://registry.npmmirror.com/deep-extend/-/deep-extend-0.6.0.tgz: {}
+
+  defer-to-connect@https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz: {}
+
+  defer-to-connect@https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz: {}
+
+  del@https://registry.npmmirror.com/del/-/del-6.1.1.tgz:
+    dependencies:
+      globby: 11.1.0
+      graceful-fs: https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz
+      is-glob: 4.0.3
+      is-path-cwd: https://registry.npmmirror.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz
+      is-path-inside: https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz
+      p-map: https://registry.npmmirror.com/p-map/-/p-map-4.0.0.tgz
+      rimraf: 3.0.2
+      slash: 3.0.0
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
+  dot-prop@https://registry.npmmirror.com/dot-prop/-/dot-prop-5.3.0.tgz:
+    dependencies:
+      is-obj: https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz
+
+  dot-prop@https://registry.npmmirror.com/dot-prop/-/dot-prop-6.0.1.tgz:
+    dependencies:
+      is-obj: https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz
+
+  duplexer3@https://registry.npmmirror.com/duplexer3/-/duplexer3-0.1.5.tgz: {}
+
+  elegant-spinner@https://registry.npmmirror.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz: {}
+
+  end-of-stream@1.4.4:
+    dependencies:
+      once: 1.4.0
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.2:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es5-ext@https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz:
+    dependencies:
+      es6-iterator: https://registry.npmmirror.com/es6-iterator/-/es6-iterator-2.0.3.tgz
+      es6-symbol: https://registry.npmmirror.com/es6-symbol/-/es6-symbol-3.1.3.tgz
+      next-tick: https://registry.npmmirror.com/next-tick/-/next-tick-1.1.0.tgz
+
+  es6-iterator@https://registry.npmmirror.com/es6-iterator/-/es6-iterator-2.0.3.tgz:
+    dependencies:
+      d: https://registry.npmmirror.com/d/-/d-1.0.1.tgz
+      es5-ext: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz
+      es6-symbol: https://registry.npmmirror.com/es6-symbol/-/es6-symbol-3.1.3.tgz
+
+  es6-promise@https://registry.npmmirror.com/es6-promise/-/es6-promise-3.3.1.tgz: {}
+
+  es6-symbol@https://registry.npmmirror.com/es6-symbol/-/es6-symbol-3.1.3.tgz:
+    dependencies:
+      d: https://registry.npmmirror.com/d/-/d-1.0.1.tgz
+      ext: https://registry.npmmirror.com/ext/-/ext-1.7.0.tgz
+
+  es6-weak-map@https://registry.npmmirror.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz:
+    dependencies:
+      d: https://registry.npmmirror.com/d/-/d-1.0.1.tgz
+      es5-ext: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz
+      es6-iterator: https://registry.npmmirror.com/es6-iterator/-/es6-iterator-2.0.3.tgz
+      es6-symbol: https://registry.npmmirror.com/es6-symbol/-/es6-symbol-3.1.3.tgz
+
+  escalade@https://registry.npmmirror.com/escalade/-/escalade-3.1.1.tgz: {}
+
+  escape-goat@https://registry.npmmirror.com/escape-goat/-/escape-goat-2.1.1.tgz: {}
+
+  escape-goat@https://registry.npmmirror.com/escape-goat/-/escape-goat-3.0.0.tgz: {}
+
+  escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz: {}
+
+  event-emitter@https://registry.npmmirror.com/event-emitter/-/event-emitter-0.3.5.tgz:
+    dependencies:
+      d: https://registry.npmmirror.com/d/-/d-1.0.1.tgz
+      es5-ext: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz
+
+  execa@https://registry.npmmirror.com/execa/-/execa-5.1.1.tgz:
     dependencies:
       cross-spawn: 7.0.3
       get-stream: 6.0.1
@@ -1992,660 +2879,522 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-    dev: true
 
-  registry.npmmirror.com/ext@1.7.0:
-    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ext/-/ext-1.7.0.tgz}
-    name: ext
-    version: 1.7.0
+  ext@https://registry.npmmirror.com/ext/-/ext-1.7.0.tgz:
     dependencies:
-      type: registry.npmmirror.com/type@2.7.2
-    dev: false
+      type: https://registry.npmmirror.com/type/-/type-2.7.2.tgz
 
-  registry.npmmirror.com/external-editor@3.1.0:
-    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/external-editor/-/external-editor-3.1.0.tgz}
-    name: external-editor
-    version: 3.1.0
-    engines: {node: '>=4'}
+  external-editor@https://registry.npmmirror.com/external-editor/-/external-editor-3.1.0.tgz:
     dependencies:
-      chardet: registry.npmmirror.com/chardet@0.7.0
-      iconv-lite: registry.npmmirror.com/iconv-lite@0.4.24
-      tmp: registry.npmmirror.com/tmp@0.0.33
-    dev: true
+      chardet: https://registry.npmmirror.com/chardet/-/chardet-0.7.0.tgz
+      iconv-lite: https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.4.24.tgz
+      tmp: https://registry.npmmirror.com/tmp/-/tmp-0.0.33.tgz
 
-  registry.npmmirror.com/fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz}
-    name: fast-safe-stringify
-    version: 2.1.1
-    dev: false
+  fast-glob@3.3.0:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
 
-  registry.npmmirror.com/figures@1.7.0:
-    resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/figures/-/figures-1.7.0.tgz}
-    name: figures
-    version: 1.7.0
-    engines: {node: '>=0.10.0'}
+  fast-safe-stringify@https://registry.npmmirror.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz: {}
+
+  fastq@1.15.0:
+    dependencies:
+      reusify: 1.0.4
+
+  figures@https://registry.npmmirror.com/figures/-/figures-1.7.0.tgz:
     dependencies:
       escape-string-regexp: 1.0.5
       object-assign: 4.1.1
-    dev: true
 
-  registry.npmmirror.com/figures@2.0.0:
-    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/figures/-/figures-2.0.0.tgz}
-    name: figures
-    version: 2.0.0
-    engines: {node: '>=4'}
+  figures@https://registry.npmmirror.com/figures/-/figures-2.0.0.tgz:
     dependencies:
       escape-string-regexp: 1.0.5
-    dev: true
 
-  registry.npmmirror.com/figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/figures/-/figures-3.2.0.tgz}
-    name: figures
-    version: 3.2.0
-    engines: {node: '>=8'}
+  figures@https://registry.npmmirror.com/figures/-/figures-3.2.0.tgz:
     dependencies:
       escape-string-regexp: 1.0.5
-    dev: true
 
-  registry.npmmirror.com/fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fill-range/-/fill-range-7.0.1.tgz}
-    name: fill-range
-    version: 7.0.1
-    engines: {node: '>=8'}
-    requiresBuild: true
+  fill-range@7.0.1:
     dependencies:
-      to-regex-range: registry.npmmirror.com/to-regex-range@5.0.1
-    dev: false
+      to-regex-range: 5.0.1
+
+  fill-range@https://registry.npmmirror.com/fill-range/-/fill-range-7.0.1.tgz:
+    dependencies:
+      to-regex-range: https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz
     optional: true
 
-  registry.npmmirror.com/fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz}
-    name: fs.realpath
-    version: 1.0.0
-    dev: false
-
-  registry.npmmirror.com/get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz}
-    name: get-caller-file
-    version: 2.0.5
-    engines: {node: 6.* || 8.* || >= 10.*}
-    dev: false
-
-  registry.npmmirror.com/github-url-from-git@1.5.0:
-    resolution: {integrity: sha512-WWOec4aRI7YAykQ9+BHmzjyNlkfJFG8QLXnDTsLz/kZefq7qkzdfo4p6fkYYMIq1aj+gZcQs/1HQhQh3DPPxlQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz}
-    name: github-url-from-git
-    version: 1.5.0
-    dev: true
-
-  registry.npmmirror.com/glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz}
-    name: glob-parent
-    version: 5.1.2
-    engines: {node: '>= 6'}
-    requiresBuild: true
+  find-up@4.1.0:
     dependencies:
-      is-glob: registry.npmmirror.com/is-glob@4.0.3
-    dev: false
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz
+      path-exists: https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz
+
+  fs.realpath@1.0.0: {}
+
+  fs.realpath@https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz: {}
+
+  fsevents@2.3.2:
     optional: true
 
-  registry.npmmirror.com/glob@7.1.6:
-    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/glob/-/glob-7.1.6.tgz}
-    name: glob
-    version: 7.1.6
-    dependencies:
-      fs.realpath: registry.npmmirror.com/fs.realpath@1.0.0
-      inflight: registry.npmmirror.com/inflight@1.0.6
-      inherits: registry.npmmirror.com/inherits@2.0.4
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-      once: registry.npmmirror.com/once@1.4.0
-      path-is-absolute: registry.npmmirror.com/path-is-absolute@1.0.1
-    dev: false
+  function-bind@1.1.1: {}
 
-  registry.npmmirror.com/global-dirs@2.1.0:
-    resolution: {integrity: sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/global-dirs/-/global-dirs-2.1.0.tgz}
-    name: global-dirs
-    version: 2.1.0
-    engines: {node: '>=8'}
+  get-caller-file@https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz: {}
+
+  get-stream@4.1.0:
+    dependencies:
+      pump: 3.0.0
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.0
+
+  get-stream@6.0.1: {}
+
+  github-url-from-git@https://registry.npmmirror.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz:
+    dependencies:
+      is-glob: https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz
+    optional: true
+
+  glob@7.1.6:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  glob@https://registry.npmmirror.com/glob/-/glob-7.1.6.tgz:
+    dependencies:
+      fs.realpath: https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz
+      inflight: https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz
+      inherits: https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz
+      minimatch: https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz
+      once: https://registry.npmmirror.com/once/-/once-1.4.0.tgz
+      path-is-absolute: https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz
+
+  global-dirs@https://registry.npmmirror.com/global-dirs/-/global-dirs-2.1.0.tgz:
     dependencies:
       ini: 1.3.7
-    dev: true
 
-  registry.npmmirror.com/global-dirs@3.0.1:
-    resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/global-dirs/-/global-dirs-3.0.1.tgz}
-    name: global-dirs
-    version: 3.0.1
-    engines: {node: '>=10'}
+  global-dirs@https://registry.npmmirror.com/global-dirs/-/global-dirs-3.0.1.tgz:
     dependencies:
       ini: 2.0.0
-    dev: true
 
-  registry.npmmirror.com/got@10.7.0:
-    resolution: {integrity: sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/got/-/got-10.7.0.tgz}
-    name: got
-    version: 10.7.0
-    engines: {node: '>=10'}
+  globby@11.1.0:
     dependencies:
-      '@sindresorhus/is': registry.npmmirror.com/@sindresorhus/is@2.1.1
-      '@szmarczak/http-timer': registry.npmmirror.com/@szmarczak/http-timer@4.0.6
-      '@types/cacheable-request': registry.npmmirror.com/@types/cacheable-request@6.0.3
-      '@types/keyv': registry.npmmirror.com/@types/keyv@3.1.4
-      '@types/responselike': registry.npmmirror.com/@types/responselike@1.0.0
-      cacheable-lookup: registry.npmmirror.com/cacheable-lookup@2.0.1
-      cacheable-request: registry.npmmirror.com/cacheable-request@7.0.4
-      decompress-response: registry.npmmirror.com/decompress-response@5.0.0
-      duplexer3: registry.npmmirror.com/duplexer3@0.1.5
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.0
+      ignore: 5.2.4
+      merge2: 1.4.1
+      slash: 3.0.0
+
+  got@https://registry.npmmirror.com/got/-/got-10.7.0.tgz:
+    dependencies:
+      '@sindresorhus/is': https://registry.npmmirror.com/@sindresorhus/is/-/is-2.1.1.tgz
+      '@szmarczak/http-timer': https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz
+      '@types/cacheable-request': https://registry.npmmirror.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz
+      '@types/keyv': https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz
+      '@types/responselike': https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.0.tgz
+      cacheable-lookup: https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz
+      cacheable-request: https://registry.npmmirror.com/cacheable-request/-/cacheable-request-7.0.4.tgz
+      decompress-response: https://registry.npmmirror.com/decompress-response/-/decompress-response-5.0.0.tgz
+      duplexer3: https://registry.npmmirror.com/duplexer3/-/duplexer3-0.1.5.tgz
       get-stream: 5.2.0
-      lowercase-keys: registry.npmmirror.com/lowercase-keys@2.0.0
-      mimic-response: registry.npmmirror.com/mimic-response@2.1.0
-      p-cancelable: registry.npmmirror.com/p-cancelable@2.1.1
-      p-event: registry.npmmirror.com/p-event@4.2.0
-      responselike: registry.npmmirror.com/responselike@2.0.1
-      to-readable-stream: registry.npmmirror.com/to-readable-stream@2.1.0
+      lowercase-keys: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz
+      mimic-response: https://registry.npmmirror.com/mimic-response/-/mimic-response-2.1.0.tgz
+      p-cancelable: https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz
+      p-event: https://registry.npmmirror.com/p-event/-/p-event-4.2.0.tgz
+      responselike: https://registry.npmmirror.com/responselike/-/responselike-2.0.1.tgz
+      to-readable-stream: https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-2.1.0.tgz
       type-fest: 0.10.0
-    dev: true
 
-  registry.npmmirror.com/got@9.6.0:
-    resolution: {integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/got/-/got-9.6.0.tgz}
-    name: got
-    version: 9.6.0
-    engines: {node: '>=8.6'}
+  got@https://registry.npmmirror.com/got/-/got-9.6.0.tgz:
     dependencies:
-      '@sindresorhus/is': registry.npmmirror.com/@sindresorhus/is@0.14.0
-      '@szmarczak/http-timer': registry.npmmirror.com/@szmarczak/http-timer@1.1.2
-      '@types/keyv': registry.npmmirror.com/@types/keyv@3.1.4
-      '@types/responselike': registry.npmmirror.com/@types/responselike@1.0.0
-      cacheable-request: registry.npmmirror.com/cacheable-request@6.1.0
-      decompress-response: registry.npmmirror.com/decompress-response@3.3.0
-      duplexer3: registry.npmmirror.com/duplexer3@0.1.5
+      '@sindresorhus/is': https://registry.npmmirror.com/@sindresorhus/is/-/is-0.14.0.tgz
+      '@szmarczak/http-timer': https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz
+      '@types/keyv': https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz
+      '@types/responselike': https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.0.tgz
+      cacheable-request: https://registry.npmmirror.com/cacheable-request/-/cacheable-request-6.1.0.tgz
+      decompress-response: https://registry.npmmirror.com/decompress-response/-/decompress-response-3.3.0.tgz
+      duplexer3: https://registry.npmmirror.com/duplexer3/-/duplexer3-0.1.5.tgz
       get-stream: 4.1.0
-      lowercase-keys: registry.npmmirror.com/lowercase-keys@1.0.1
-      mimic-response: registry.npmmirror.com/mimic-response@1.0.1
-      p-cancelable: registry.npmmirror.com/p-cancelable@1.1.0
-      to-readable-stream: registry.npmmirror.com/to-readable-stream@1.0.0
-      url-parse-lax: registry.npmmirror.com/url-parse-lax@3.0.0
-    dev: true
+      lowercase-keys: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz
+      mimic-response: https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz
+      p-cancelable: https://registry.npmmirror.com/p-cancelable/-/p-cancelable-1.1.0.tgz
+      to-readable-stream: https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz
+      url-parse-lax: https://registry.npmmirror.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz
 
-  registry.npmmirror.com/graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz}
-    name: graceful-fs
-    version: 4.2.11
-    dev: true
+  graceful-fs@https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz: {}
 
-  registry.npmmirror.com/has-ansi@2.0.0:
-    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-ansi/-/has-ansi-2.0.0.tgz}
-    name: has-ansi
-    version: 2.0.0
-    engines: {node: '>=0.10.0'}
+  hard-rejection@2.1.0: {}
+
+  has-ansi@https://registry.npmmirror.com/has-ansi/-/has-ansi-2.0.0.tgz:
     dependencies:
       ansi-regex: 2.1.1
-    dev: true
 
-  registry.npmmirror.com/has-yarn@2.1.0:
-    resolution: {integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-yarn/-/has-yarn-2.1.0.tgz}
-    name: has-yarn
-    version: 2.1.0
-    engines: {node: '>=8'}
-    dev: true
+  has-flag@3.0.0: {}
 
-  registry.npmmirror.com/hosted-git-info@3.0.8:
-    resolution: {integrity: sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz}
-    name: hosted-git-info
-    version: 3.0.8
-    engines: {node: '>=10'}
+  has-flag@4.0.0: {}
+
+  has-yarn@https://registry.npmmirror.com/has-yarn/-/has-yarn-2.1.0.tgz: {}
+
+  has@1.0.3:
+    dependencies:
+      function-bind: 1.1.1
+
+  hosted-git-info@2.8.9: {}
+
+  hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
-  registry.npmmirror.com/http-cache-semantics@4.1.1:
-    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz}
-    name: http-cache-semantics
-    version: 4.1.1
-    dev: true
-
-  registry.npmmirror.com/http2-client@1.3.5:
-    resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/http2-client/-/http2-client-1.3.5.tgz}
-    name: http2-client
-    version: 1.3.5
-    dev: false
-
-  registry.npmmirror.com/iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.4.24.tgz}
-    name: iconv-lite
-    version: 0.4.24
-    engines: {node: '>=0.10.0'}
+  hosted-git-info@https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz:
     dependencies:
-      safer-buffer: registry.npmmirror.com/safer-buffer@2.1.2
-    dev: true
+      lru-cache: 6.0.0
 
-  registry.npmmirror.com/ignore-walk@3.0.4:
-    resolution: {integrity: sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ignore-walk/-/ignore-walk-3.0.4.tgz}
-    name: ignore-walk
-    version: 3.0.4
+  http-cache-semantics@https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz: {}
+
+  http2-client@https://registry.npmmirror.com/http2-client/-/http2-client-1.3.5.tgz: {}
+
+  human-signals@2.1.0: {}
+
+  iconv-lite@https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.4.24.tgz:
+    dependencies:
+      safer-buffer: https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz
+
+  ignore-walk@https://registry.npmmirror.com/ignore-walk/-/ignore-walk-3.0.4.tgz:
     dependencies:
       minimatch: 3.1.2
-    dev: true
 
-  registry.npmmirror.com/import-local@3.1.0:
-    resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-local/-/import-local-3.1.0.tgz}
-    name: import-local
-    version: 3.1.0
-    engines: {node: '>=8'}
-    hasBin: true
+  ignore@5.2.4: {}
+
+  import-fresh@3.3.0:
     dependencies:
-      pkg-dir: registry.npmmirror.com/pkg-dir@4.2.0
-      resolve-cwd: registry.npmmirror.com/resolve-cwd@3.0.0
-    dev: true
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
 
-  registry.npmmirror.com/inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz}
-    name: inflight
-    version: 1.0.6
+  import-lazy@2.1.0: {}
+
+  import-local@https://registry.npmmirror.com/import-local/-/import-local-3.1.0.tgz:
     dependencies:
-      once: registry.npmmirror.com/once@1.4.0
-      wrappy: registry.npmmirror.com/wrappy@1.0.2
-    dev: false
+      pkg-dir: https://registry.npmmirror.com/pkg-dir/-/pkg-dir-4.2.0.tgz
+      resolve-cwd: https://registry.npmmirror.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz
 
-  registry.npmmirror.com/inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz}
-    name: inherits
-    version: 2.0.4
-    dev: false
+  imurmurhash@0.1.4: {}
 
-  registry.npmmirror.com/inquirer-autosubmit-prompt@0.2.0:
-    resolution: {integrity: sha512-mzNrusCk5L6kSzlN0Ioddn8yzrhYNLli+Sn2ZxMuLechMYAzakiFCIULxsxlQb5YKzthLGfrFACcWoAvM7p04Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz}
-    name: inquirer-autosubmit-prompt
-    version: 0.2.0
+  indent-string@3.2.0: {}
+
+  indent-string@4.0.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inflight@https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz:
+    dependencies:
+      once: https://registry.npmmirror.com/once/-/once-1.4.0.tgz
+      wrappy: https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz
+
+  inherits@2.0.4: {}
+
+  inherits@https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz: {}
+
+  ini@1.3.7: {}
+
+  ini@1.3.8: {}
+
+  ini@2.0.0: {}
+
+  inquirer-autosubmit-prompt@https://registry.npmmirror.com/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz:
     dependencies:
       chalk: 2.4.2
-      inquirer: registry.npmmirror.com/inquirer@6.5.2
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
-    dev: true
+      inquirer: https://registry.npmmirror.com/inquirer/-/inquirer-6.5.2.tgz
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
 
-  registry.npmmirror.com/inquirer@6.5.2:
-    resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inquirer/-/inquirer-6.5.2.tgz}
-    name: inquirer
-    version: 6.5.2
-    engines: {node: '>=6.0.0'}
+  inquirer@https://registry.npmmirror.com/inquirer/-/inquirer-6.5.2.tgz:
     dependencies:
       ansi-escapes: 3.2.0
       chalk: 2.4.2
-      cli-cursor: registry.npmmirror.com/cli-cursor@2.1.0
-      cli-width: registry.npmmirror.com/cli-width@2.2.1
-      external-editor: registry.npmmirror.com/external-editor@3.1.0
-      figures: registry.npmmirror.com/figures@2.0.0
+      cli-cursor: https://registry.npmmirror.com/cli-cursor/-/cli-cursor-2.1.0.tgz
+      cli-width: https://registry.npmmirror.com/cli-width/-/cli-width-2.2.1.tgz
+      external-editor: https://registry.npmmirror.com/external-editor/-/external-editor-3.1.0.tgz
+      figures: https://registry.npmmirror.com/figures/-/figures-2.0.0.tgz
       lodash: 4.17.21
-      mute-stream: registry.npmmirror.com/mute-stream@0.0.7
-      run-async: registry.npmmirror.com/run-async@2.4.1
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
+      mute-stream: https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.7.tgz
+      run-async: https://registry.npmmirror.com/run-async/-/run-async-2.4.1.tgz
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
       string-width: 2.1.1
       strip-ansi: 5.2.0
-      through: registry.npmmirror.com/through@2.3.8
-    dev: true
+      through: https://registry.npmmirror.com/through/-/through-2.3.8.tgz
 
-  registry.npmmirror.com/inquirer@7.3.3:
-    resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inquirer/-/inquirer-7.3.3.tgz}
-    name: inquirer
-    version: 7.3.3
-    engines: {node: '>=8.0.0'}
+  inquirer@https://registry.npmmirror.com/inquirer/-/inquirer-7.3.3.tgz:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      cli-cursor: registry.npmmirror.com/cli-cursor@3.1.0
-      cli-width: registry.npmmirror.com/cli-width@3.0.0
-      external-editor: registry.npmmirror.com/external-editor@3.1.0
-      figures: registry.npmmirror.com/figures@3.2.0
+      cli-cursor: https://registry.npmmirror.com/cli-cursor/-/cli-cursor-3.1.0.tgz
+      cli-width: https://registry.npmmirror.com/cli-width/-/cli-width-3.0.0.tgz
+      external-editor: https://registry.npmmirror.com/external-editor/-/external-editor-3.1.0.tgz
+      figures: https://registry.npmmirror.com/figures/-/figures-3.2.0.tgz
       lodash: 4.17.21
-      mute-stream: registry.npmmirror.com/mute-stream@0.0.8
-      run-async: registry.npmmirror.com/run-async@2.4.1
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
+      mute-stream: https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.8.tgz
+      run-async: https://registry.npmmirror.com/run-async/-/run-async-2.4.1.tgz
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
       string-width: 4.2.3
       strip-ansi: 6.0.1
-      through: registry.npmmirror.com/through@2.3.8
-    dev: true
+      through: https://registry.npmmirror.com/through/-/through-2.3.8.tgz
 
-  registry.npmmirror.com/is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-binary-path/-/is-binary-path-2.1.0.tgz}
-    name: is-binary-path
-    version: 2.1.0
-    engines: {node: '>=8'}
-    requiresBuild: true
+  is-arrayish@0.2.1: {}
+
+  is-binary-path@https://registry.npmmirror.com/is-binary-path/-/is-binary-path-2.1.0.tgz:
     dependencies:
-      binary-extensions: registry.npmmirror.com/binary-extensions@2.2.0
-    dev: false
+      binary-extensions: https://registry.npmmirror.com/binary-extensions/-/binary-extensions-2.2.0.tgz
     optional: true
 
-  registry.npmmirror.com/is-ci@2.0.0:
-    resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-ci/-/is-ci-2.0.0.tgz}
-    name: is-ci
-    version: 2.0.0
-    hasBin: true
+  is-ci@https://registry.npmmirror.com/is-ci/-/is-ci-2.0.0.tgz:
     dependencies:
       ci-info: 2.0.0
-    dev: true
 
-  registry.npmmirror.com/is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-docker/-/is-docker-2.2.1.tgz}
-    name: is-docker
-    version: 2.2.1
-    engines: {node: '>=8'}
-    hasBin: true
-    dev: true
+  is-core-module@2.12.1:
+    dependencies:
+      has: 1.0.3
 
-  registry.npmmirror.com/is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz}
-    name: is-extglob
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    requiresBuild: true
-    dev: false
+  is-docker@https://registry.npmmirror.com/is-docker/-/is-docker-2.2.1.tgz: {}
+
+  is-extglob@2.1.1: {}
+
+  is-extglob@https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz:
     optional: true
 
-  registry.npmmirror.com/is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz}
-    name: is-fullwidth-code-point
-    version: 3.0.0
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz}
-    name: is-glob
-    version: 4.0.3
-    engines: {node: '>=0.10.0'}
-    requiresBuild: true
+  is-fullwidth-code-point@1.0.0:
     dependencies:
-      is-extglob: registry.npmmirror.com/is-extglob@2.1.1
-    dev: false
+      number-is-nan: https://registry.npmmirror.com/number-is-nan/-/number-is-nan-1.0.1.tgz
+
+  is-fullwidth-code-point@2.0.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-glob@https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz:
+    dependencies:
+      is-extglob: https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz
     optional: true
 
-  registry.npmmirror.com/is-installed-globally@0.3.2:
-    resolution: {integrity: sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz}
-    name: is-installed-globally
-    version: 0.3.2
-    engines: {node: '>=8'}
+  is-installed-globally@https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz:
     dependencies:
-      global-dirs: registry.npmmirror.com/global-dirs@2.1.0
-      is-path-inside: registry.npmmirror.com/is-path-inside@3.0.3
-    dev: true
+      global-dirs: https://registry.npmmirror.com/global-dirs/-/global-dirs-2.1.0.tgz
+      is-path-inside: https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz
 
-  registry.npmmirror.com/is-installed-globally@0.4.0:
-    resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz}
-    name: is-installed-globally
-    version: 0.4.0
-    engines: {node: '>=10'}
+  is-installed-globally@https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz:
     dependencies:
-      global-dirs: registry.npmmirror.com/global-dirs@3.0.1
-      is-path-inside: registry.npmmirror.com/is-path-inside@3.0.3
-    dev: true
+      global-dirs: https://registry.npmmirror.com/global-dirs/-/global-dirs-3.0.1.tgz
+      is-path-inside: https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz
 
-  registry.npmmirror.com/is-interactive@1.0.0:
-    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-interactive/-/is-interactive-1.0.0.tgz}
-    name: is-interactive
-    version: 1.0.0
-    engines: {node: '>=8'}
-    dev: true
+  is-interactive@https://registry.npmmirror.com/is-interactive/-/is-interactive-1.0.0.tgz: {}
 
-  registry.npmmirror.com/is-npm@5.0.0:
-    resolution: {integrity: sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-npm/-/is-npm-5.0.0.tgz}
-    name: is-npm
-    version: 5.0.0
-    engines: {node: '>=10'}
-    dev: true
+  is-npm@https://registry.npmmirror.com/is-npm/-/is-npm-5.0.0.tgz: {}
 
-  registry.npmmirror.com/is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz}
-    name: is-number
-    version: 7.0.0
-    engines: {node: '>=0.12.0'}
-    requiresBuild: true
-    dev: false
+  is-number@7.0.0: {}
+
+  is-number@https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz:
     optional: true
 
-  registry.npmmirror.com/is-obj@2.0.0:
-    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz}
-    name: is-obj
-    version: 2.0.0
-    engines: {node: '>=8'}
-    dev: true
+  is-obj@https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz: {}
 
-  registry.npmmirror.com/is-observable@1.1.0:
-    resolution: {integrity: sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-observable/-/is-observable-1.1.0.tgz}
-    name: is-observable
-    version: 1.1.0
-    engines: {node: '>=4'}
+  is-observable@https://registry.npmmirror.com/is-observable/-/is-observable-1.1.0.tgz:
     dependencies:
-      symbol-observable: registry.npmmirror.com/symbol-observable@1.2.0
-    dev: true
+      symbol-observable: https://registry.npmmirror.com/symbol-observable/-/symbol-observable-1.2.0.tgz
 
-  registry.npmmirror.com/is-path-cwd@2.2.0:
-    resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz}
-    name: is-path-cwd
-    version: 2.2.0
-    engines: {node: '>=6'}
-    dev: true
+  is-path-cwd@https://registry.npmmirror.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz: {}
 
-  registry.npmmirror.com/is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz}
-    name: is-path-inside
-    version: 3.0.3
-    engines: {node: '>=8'}
-    dev: true
+  is-path-inside@https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz: {}
 
-  registry.npmmirror.com/is-promise@2.2.2:
-    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-promise/-/is-promise-2.2.2.tgz}
-    name: is-promise
-    version: 2.2.2
+  is-plain-obj@1.1.0: {}
 
-  registry.npmmirror.com/is-scoped@2.1.0:
-    resolution: {integrity: sha512-Cv4OpPTHAK9kHYzkzCrof3VJh7H/PrG2MBUMvvJebaaUMbqhm0YAtXnvh0I3Hnj2tMZWwrRROWLSgfJrKqWmlQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-scoped/-/is-scoped-2.1.0.tgz}
-    name: is-scoped
-    version: 2.1.0
-    engines: {node: '>=8'}
+  is-promise@https://registry.npmmirror.com/is-promise/-/is-promise-2.2.2.tgz: {}
+
+  is-scoped@https://registry.npmmirror.com/is-scoped/-/is-scoped-2.1.0.tgz:
     dependencies:
-      scoped-regex: registry.npmmirror.com/scoped-regex@2.1.0
-    dev: true
+      scoped-regex: https://registry.npmmirror.com/scoped-regex/-/scoped-regex-2.1.0.tgz
 
-  registry.npmmirror.com/is-url-superb@4.0.0:
-    resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-url-superb/-/is-url-superb-4.0.0.tgz}
-    name: is-url-superb
-    version: 4.0.0
-    engines: {node: '>=10'}
-    dev: true
+  is-stream@1.1.0: {}
 
-  registry.npmmirror.com/is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-wsl/-/is-wsl-2.2.0.tgz}
-    name: is-wsl
-    version: 2.2.0
-    engines: {node: '>=8'}
+  is-stream@2.0.1: {}
+
+  is-typedarray@1.0.0: {}
+
+  is-unicode-supported@0.1.0: {}
+
+  is-url-superb@https://registry.npmmirror.com/is-url-superb/-/is-url-superb-4.0.0.tgz: {}
+
+  is-wsl@https://registry.npmmirror.com/is-wsl/-/is-wsl-2.2.0.tgz:
     dependencies:
-      is-docker: registry.npmmirror.com/is-docker@2.2.1
-    dev: true
+      is-docker: https://registry.npmmirror.com/is-docker/-/is-docker-2.2.1.tgz
 
-  registry.npmmirror.com/is-yarn-global@0.3.0:
-    resolution: {integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz}
-    name: is-yarn-global
-    version: 0.3.0
-    dev: true
+  is-yarn-global@https://registry.npmmirror.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz: {}
 
-  registry.npmmirror.com/issue-regex@3.1.0:
-    resolution: {integrity: sha512-0RHjbtw9QXeSYnIEY5Yrp2QZrdtz21xBDV9C/GIlY2POmgoS6a7qjkYS5siRKXScnuAj5/SPv1C3YForNCHTJA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/issue-regex/-/issue-regex-3.1.0.tgz}
-    name: issue-regex
-    version: 3.1.0
-    engines: {node: '>=10'}
-    dev: true
+  isexe@2.0.0: {}
 
-  registry.npmmirror.com/latest-version@5.1.0:
-    resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/latest-version/-/latest-version-5.1.0.tgz}
-    name: latest-version
-    version: 5.1.0
-    engines: {node: '>=8'}
+  issue-regex@https://registry.npmmirror.com/issue-regex/-/issue-regex-3.1.0.tgz: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.0:
     dependencies:
-      package-json: registry.npmmirror.com/package-json@6.5.0
-    dev: true
+      argparse: 2.0.1
 
-  registry.npmmirror.com/listr-input@0.2.1:
-    resolution: {integrity: sha512-oa8iVG870qJq+OuuMK3DjGqFcwsK1SDu+kULp9kEq09TY231aideIZenr3lFOQdASpAr6asuyJBbX62/a3IIhg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-input/-/listr-input-0.2.1.tgz}
-    name: listr-input
-    version: 0.2.1
-    engines: {node: '>=6'}
+  json-buffer@3.0.0: {}
+
+  json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  keyv@3.1.0:
     dependencies:
-      inquirer: registry.npmmirror.com/inquirer@7.3.3
-      inquirer-autosubmit-prompt: registry.npmmirror.com/inquirer-autosubmit-prompt@0.2.0
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
-      through: registry.npmmirror.com/through@2.3.8
-    dev: true
+      json-buffer: 3.0.0
 
-  registry.npmmirror.com/listr-silent-renderer@1.1.1:
-    resolution: {integrity: sha512-L26cIFm7/oZeSNVhWB6faeorXhMg4HNlb/dS/7jHhr708jxlXrtrBWo4YUxZQkc6dGoxEAe6J/D3juTRBUzjtA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz}
-    name: listr-silent-renderer
-    version: 1.1.1
-    engines: {node: '>=4'}
-    dev: true
+  keyv@4.5.2:
+    dependencies:
+      json-buffer: 3.0.1
 
-  registry.npmmirror.com/listr-update-renderer@0.5.0(listr@0.14.3):
-    resolution: {integrity: sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz}
-    id: registry.npmmirror.com/listr-update-renderer/0.5.0
-    name: listr-update-renderer
-    version: 0.5.0
-    engines: {node: '>=6'}
-    peerDependencies:
-      listr: ^0.14.2
+  kind-of@6.0.3: {}
+
+  latest-version@https://registry.npmmirror.com/latest-version/-/latest-version-5.1.0.tgz:
+    dependencies:
+      package-json: https://registry.npmmirror.com/package-json/-/package-json-6.5.0.tgz
+
+  lines-and-columns@1.2.4: {}
+
+  listr-input@https://registry.npmmirror.com/listr-input/-/listr-input-0.2.1.tgz:
+    dependencies:
+      inquirer: https://registry.npmmirror.com/inquirer/-/inquirer-7.3.3.tgz
+      inquirer-autosubmit-prompt: https://registry.npmmirror.com/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
+      through: https://registry.npmmirror.com/through/-/through-2.3.8.tgz
+
+  listr-silent-renderer@https://registry.npmmirror.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz: {}
+
+  listr-update-renderer@https://registry.npmmirror.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz(listr@0.14.3):
     dependencies:
       chalk: 1.1.3
-      cli-truncate: registry.npmmirror.com/cli-truncate@0.2.1
-      elegant-spinner: registry.npmmirror.com/elegant-spinner@1.0.1
-      figures: registry.npmmirror.com/figures@1.7.0
+      cli-truncate: https://registry.npmmirror.com/cli-truncate/-/cli-truncate-0.2.1.tgz
+      elegant-spinner: https://registry.npmmirror.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz
+      figures: https://registry.npmmirror.com/figures/-/figures-1.7.0.tgz
       indent-string: 3.2.0
-      listr: registry.npmmirror.com/listr@0.14.3
+      listr: https://registry.npmmirror.com/listr/-/listr-0.14.3.tgz
       log-symbols: 1.0.2
-      log-update: registry.npmmirror.com/log-update@2.3.0
+      log-update: https://registry.npmmirror.com/log-update/-/log-update-2.3.0.tgz
       strip-ansi: 3.0.1
-    dev: true
 
-  registry.npmmirror.com/listr-verbose-renderer@0.5.0:
-    resolution: {integrity: sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz}
-    name: listr-verbose-renderer
-    version: 0.5.0
-    engines: {node: '>=4'}
+  listr-verbose-renderer@https://registry.npmmirror.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz:
     dependencies:
       chalk: 2.4.2
-      cli-cursor: registry.npmmirror.com/cli-cursor@2.1.0
-      date-fns: registry.npmmirror.com/date-fns@1.30.1
-      figures: registry.npmmirror.com/figures@2.0.0
-    dev: true
+      cli-cursor: https://registry.npmmirror.com/cli-cursor/-/cli-cursor-2.1.0.tgz
+      date-fns: https://registry.npmmirror.com/date-fns/-/date-fns-1.30.1.tgz
+      figures: https://registry.npmmirror.com/figures/-/figures-2.0.0.tgz
 
-  registry.npmmirror.com/listr@0.14.3:
-    resolution: {integrity: sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr/-/listr-0.14.3.tgz}
-    name: listr
-    version: 0.14.3
-    engines: {node: '>=6'}
+  listr@https://registry.npmmirror.com/listr/-/listr-0.14.3.tgz:
     dependencies:
-      '@samverschueren/stream-to-observable': registry.npmmirror.com/@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7)
-      is-observable: registry.npmmirror.com/is-observable@1.1.0
-      is-promise: registry.npmmirror.com/is-promise@2.2.2
+      '@samverschueren/stream-to-observable': https://registry.npmmirror.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz(rxjs@6.6.7)
+      is-observable: https://registry.npmmirror.com/is-observable/-/is-observable-1.1.0.tgz
+      is-promise: https://registry.npmmirror.com/is-promise/-/is-promise-2.2.2.tgz
       is-stream: 1.1.0
-      listr-silent-renderer: registry.npmmirror.com/listr-silent-renderer@1.1.1
-      listr-update-renderer: registry.npmmirror.com/listr-update-renderer@0.5.0(listr@0.14.3)
-      listr-verbose-renderer: registry.npmmirror.com/listr-verbose-renderer@0.5.0
-      p-map: registry.npmmirror.com/p-map@2.1.0
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
+      listr-silent-renderer: https://registry.npmmirror.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz
+      listr-update-renderer: https://registry.npmmirror.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz(listr@0.14.3)
+      listr-verbose-renderer: https://registry.npmmirror.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz
+      p-map: https://registry.npmmirror.com/p-map/-/p-map-2.1.0.tgz
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
     transitivePeerDependencies:
       - zen-observable
       - zenObservable
-    dev: true
 
-  registry.npmmirror.com/locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz}
-    name: locate-path
-    version: 6.0.0
-    engines: {node: '>=10'}
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  locate-path@https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz:
     dependencies:
       p-locate: 5.0.0
-    dev: true
 
-  registry.npmmirror.com/lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz}
-    name: lodash.isequal
-    version: 4.5.0
-    dev: true
+  lodash.isequal@https://registry.npmmirror.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz: {}
 
-  registry.npmmirror.com/lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz}
-    name: lodash
-    version: 4.17.21
-    dev: false
+  lodash.zip@4.2.0: {}
 
-  registry.npmmirror.com/log-symbols@4.1.0:
-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/log-symbols/-/log-symbols-4.1.0.tgz}
-    name: log-symbols
-    version: 4.1.0
-    engines: {node: '>=10'}
+  lodash@4.17.21: {}
+
+  lodash@https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz: {}
+
+  log-symbols@1.0.2:
+    dependencies:
+      chalk: 1.1.3
+
+  log-symbols@https://registry.npmmirror.com/log-symbols/-/log-symbols-4.1.0.tgz:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-    dev: true
 
-  registry.npmmirror.com/log-update@2.3.0:
-    resolution: {integrity: sha512-vlP11XfFGyeNQlmEn9tJ66rEW1coA/79m5z6BCkudjbAGE83uhAcGYrBFwfs3AdLiLzGRusRPAbSPK9xZteCmg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/log-update/-/log-update-2.3.0.tgz}
-    name: log-update
-    version: 2.3.0
-    engines: {node: '>=4'}
+  log-update@https://registry.npmmirror.com/log-update/-/log-update-2.3.0.tgz:
     dependencies:
       ansi-escapes: 3.2.0
-      cli-cursor: registry.npmmirror.com/cli-cursor@2.1.0
-      wrap-ansi: registry.npmmirror.com/wrap-ansi@3.0.1
-    dev: true
+      cli-cursor: https://registry.npmmirror.com/cli-cursor/-/cli-cursor-2.1.0.tgz
+      wrap-ansi: https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz
 
-  registry.npmmirror.com/lowercase-keys@1.0.1:
-    resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz}
-    name: lowercase-keys
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dev: true
+  lowercase-keys@https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz: {}
 
-  registry.npmmirror.com/lowercase-keys@2.0.0:
-    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz}
-    name: lowercase-keys
-    version: 2.0.0
-    engines: {node: '>=8'}
-    dev: true
+  lowercase-keys@https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz: {}
 
-  registry.npmmirror.com/lru-queue@0.1.0:
-    resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lru-queue/-/lru-queue-0.1.0.tgz}
-    name: lru-queue
-    version: 0.1.0
+  lru-cache@6.0.0:
     dependencies:
-      es5-ext: registry.npmmirror.com/es5-ext@0.10.62
-    dev: false
+      yallist: 4.0.0
 
-  registry.npmmirror.com/make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/make-dir/-/make-dir-3.1.0.tgz}
-    name: make-dir
-    version: 3.1.0
-    engines: {node: '>=8'}
+  lru-queue@https://registry.npmmirror.com/lru-queue/-/lru-queue-0.1.0.tgz:
+    dependencies:
+      es5-ext: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz
+
+  make-dir@https://registry.npmmirror.com/make-dir/-/make-dir-3.1.0.tgz:
     dependencies:
       semver: 6.3.0
-    dev: true
 
-  registry.npmmirror.com/memoizee@0.4.15:
-    resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/memoizee/-/memoizee-0.4.15.tgz}
-    name: memoizee
-    version: 0.4.15
+  map-age-cleaner@0.1.3:
     dependencies:
-      d: registry.npmmirror.com/d@1.0.1
-      es5-ext: registry.npmmirror.com/es5-ext@0.10.62
-      es6-weak-map: registry.npmmirror.com/es6-weak-map@2.0.3
-      event-emitter: registry.npmmirror.com/event-emitter@0.3.5
-      is-promise: registry.npmmirror.com/is-promise@2.2.2
-      lru-queue: registry.npmmirror.com/lru-queue@0.1.0
-      next-tick: registry.npmmirror.com/next-tick@1.1.0
-      timers-ext: registry.npmmirror.com/timers-ext@0.1.7
-    dev: false
+      p-defer: 1.0.0
 
-  registry.npmmirror.com/meow@8.1.2:
-    resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/meow/-/meow-8.1.2.tgz}
-    name: meow
-    version: 8.1.2
-    engines: {node: '>=10'}
+  map-obj@1.0.1: {}
+
+  map-obj@4.3.0: {}
+
+  memoizee@https://registry.npmmirror.com/memoizee/-/memoizee-0.4.15.tgz:
+    dependencies:
+      d: https://registry.npmmirror.com/d/-/d-1.0.1.tgz
+      es5-ext: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz
+      es6-weak-map: https://registry.npmmirror.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz
+      event-emitter: https://registry.npmmirror.com/event-emitter/-/event-emitter-0.3.5.tgz
+      is-promise: https://registry.npmmirror.com/is-promise/-/is-promise-2.2.2.tgz
+      lru-queue: https://registry.npmmirror.com/lru-queue/-/lru-queue-0.1.0.tgz
+      next-tick: https://registry.npmmirror.com/next-tick/-/next-tick-1.1.0.tgz
+      timers-ext: https://registry.npmmirror.com/timers-ext/-/timers-ext-0.1.7.tgz
+
+  meow@https://registry.npmmirror.com/meow/-/meow-8.1.2.tgz:
     dependencies:
       '@types/minimist': 1.2.2
       camelcase-keys: 6.2.2
@@ -2658,1051 +3407,791 @@ packages:
       trim-newlines: 3.0.1
       type-fest: 0.18.1
       yargs-parser: 20.2.9
-    dev: true
 
-  registry.npmmirror.com/mimic-response@1.0.1:
-    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz}
-    name: mimic-response
-    version: 1.0.1
-    engines: {node: '>=4'}
-    dev: true
+  merge-stream@2.0.0: {}
 
-  registry.npmmirror.com/mimic-response@2.1.0:
-    resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mimic-response/-/mimic-response-2.1.0.tgz}
-    name: mimic-response
-    version: 2.1.0
-    engines: {node: '>=8'}
-    dev: true
+  merge2@1.4.1: {}
 
-  registry.npmmirror.com/minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz}
-    name: minimatch
-    version: 3.1.2
+  micromatch@4.0.5:
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
+
+  mimic-fn@1.2.0: {}
+
+  mimic-fn@2.1.0: {}
+
+  mimic-fn@3.1.0: {}
+
+  mimic-response@https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz: {}
+
+  mimic-response@https://registry.npmmirror.com/mimic-response/-/mimic-response-2.1.0.tgz: {}
+
+  min-indent@1.0.1: {}
+
+  minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
 
-  registry.npmmirror.com/mock.js@0.2.0:
-    resolution: {integrity: sha512-DKI8Rh/h7Mma+fg+6aD0uUvwn0QXAjKG6q3s+lTaCboCQ/kvQMBN9IXRBzgEaz4aPiYoRnKU9jVsfZp0mHpWrQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mock.js/-/mock.js-0.2.0.tgz}
-    name: mock.js
-    version: 0.2.0
-    dev: false
-
-  registry.npmmirror.com/mockjs@1.1.0:
-    resolution: {integrity: sha512-eQsKcWzIaZzEZ07NuEyO4Nw65g0hdWAyurVol1IPl1gahRwY+svqzfgfey8U8dahLwG44d6/RwEzuK52rSa/JQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mockjs/-/mockjs-1.1.0.tgz}
-    name: mockjs
-    version: 1.1.0
-    hasBin: true
+  minimatch@https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz:
     dependencies:
-      commander: registry.npmmirror.com/commander@11.0.0
-    dev: false
+      brace-expansion: 1.1.11
 
-  registry.npmmirror.com/mute-stream@0.0.7:
-    resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.7.tgz}
-    name: mute-stream
-    version: 0.0.7
-    dev: true
+  minimist-options@4.1.0:
+    dependencies:
+      arrify: 1.0.1
+      is-plain-obj: 1.1.0
+      kind-of: 6.0.3
 
-  registry.npmmirror.com/mute-stream@0.0.8:
-    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.8.tgz}
-    name: mute-stream
-    version: 0.0.8
-    dev: true
+  minimist@1.2.8: {}
 
-  registry.npmmirror.com/new-github-release-url@1.0.0:
-    resolution: {integrity: sha512-dle7yf655IMjyFUqn6Nxkb18r4AOAkzRcgcZv6WZ0IqrOH4QCEZ8Sm6I7XX21zvHdBeeMeTkhR9qT2Z0EJDx6A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/new-github-release-url/-/new-github-release-url-1.0.0.tgz}
-    name: new-github-release-url
-    version: 1.0.0
-    engines: {node: '>=10'}
+  mock.js@https://registry.npmmirror.com/mock.js/-/mock.js-0.2.0.tgz: {}
+
+  mockjs@https://registry.npmmirror.com/mockjs/-/mockjs-1.1.0.tgz:
+    dependencies:
+      commander: https://registry.npmmirror.com/commander/-/commander-11.0.0.tgz
+
+  mute-stream@https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.7.tgz: {}
+
+  mute-stream@https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.8.tgz: {}
+
+  new-github-release-url@https://registry.npmmirror.com/new-github-release-url/-/new-github-release-url-1.0.0.tgz:
     dependencies:
       type-fest: 0.4.1
-    dev: true
 
-  registry.npmmirror.com/next-tick@1.1.0:
-    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/next-tick/-/next-tick-1.1.0.tgz}
-    name: next-tick
-    version: 1.1.0
-    dev: false
+  next-tick@https://registry.npmmirror.com/next-tick/-/next-tick-1.1.0.tgz: {}
 
-  registry.npmmirror.com/node-fetch-h2@2.3.0:
-    resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz}
-    name: node-fetch-h2
-    version: 2.3.0
-    engines: {node: 4.x || >=6.0.0}
+  node-fetch-h2@https://registry.npmmirror.com/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz:
     dependencies:
-      http2-client: registry.npmmirror.com/http2-client@1.3.5
-    dev: false
+      http2-client: https://registry.npmmirror.com/http2-client/-/http2-client-1.3.5.tgz
 
-  registry.npmmirror.com/node-fetch@2.6.1:
-    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/node-fetch/-/node-fetch-2.6.1.tgz}
-    name: node-fetch
-    version: 2.6.1
-    engines: {node: 4.x || >=6.0.0}
-    dev: false
+  node-fetch@https://registry.npmmirror.com/node-fetch/-/node-fetch-2.6.1.tgz: {}
 
-  registry.npmmirror.com/node-readfiles@0.2.0:
-    resolution: {integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/node-readfiles/-/node-readfiles-0.2.0.tgz}
-    name: node-readfiles
-    version: 0.2.0
+  node-readfiles@https://registry.npmmirror.com/node-readfiles/-/node-readfiles-0.2.0.tgz:
     dependencies:
-      es6-promise: registry.npmmirror.com/es6-promise@3.3.1
-    dev: false
+      es6-promise: https://registry.npmmirror.com/es6-promise/-/es6-promise-3.3.1.tgz
 
-  registry.npmmirror.com/normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz}
-    name: normalize-path
-    version: 3.0.0
-    engines: {node: '>=0.10.0'}
-    requiresBuild: true
-    dev: false
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.2
+      semver: 5.7.1
+      validate-npm-package-license: 3.0.4
+
+  normalize-package-data@3.0.3:
+    dependencies:
+      hosted-git-info: 4.1.0
+      is-core-module: 2.12.1
+      semver: 7.5.4
+      validate-npm-package-license: 3.0.4
+
+  normalize-path@https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz:
     optional: true
 
-  registry.npmmirror.com/normalize-url@4.5.1:
-    resolution: {integrity: sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-url/-/normalize-url-4.5.1.tgz}
-    name: normalize-url
-    version: 4.5.1
-    engines: {node: '>=8'}
-    dev: true
+  normalize-url@https://registry.npmmirror.com/normalize-url/-/normalize-url-4.5.1.tgz: {}
 
-  registry.npmmirror.com/normalize-url@6.1.0:
-    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-url/-/normalize-url-6.1.0.tgz}
-    name: normalize-url
-    version: 6.1.0
-    engines: {node: '>=10'}
-    dev: true
+  normalize-url@https://registry.npmmirror.com/normalize-url/-/normalize-url-6.1.0.tgz: {}
 
-  registry.npmmirror.com/np@7.2.0:
-    resolution: {integrity: sha512-jfMFJXAJlGkCowMPGzA8Ywbmywk7I9hT96DsOcWjDsjq/zP5h6m3VZDcZ1AWYoCBPg4E/lFrJxROmiQH3OWnzA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/np/-/np-7.2.0.tgz}
-    name: np
-    version: 7.2.0
-    engines: {git: '>=2.11.0', node: '>=10', npm: '>=6.8.0', yarn: '>=1.7.0'}
-    hasBin: true
+  np@https://registry.npmmirror.com/np/-/np-7.2.0.tgz:
     dependencies:
-      '@samverschueren/stream-to-observable': registry.npmmirror.com/@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7)
-      any-observable: registry.npmmirror.com/any-observable@0.5.1(rxjs@6.6.7)
-      async-exit-hook: registry.npmmirror.com/async-exit-hook@2.0.1
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      '@samverschueren/stream-to-observable': https://registry.npmmirror.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz(rxjs@6.6.7)
+      any-observable: https://registry.npmmirror.com/any-observable/-/any-observable-0.5.1.tgz(rxjs@6.6.7)
+      async-exit-hook: https://registry.npmmirror.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz
+      chalk: https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz
       cosmiconfig: 7.1.0
-      del: registry.npmmirror.com/del@6.1.1
-      escape-goat: registry.npmmirror.com/escape-goat@3.0.0
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@4.0.0
-      execa: registry.npmmirror.com/execa@5.1.1
-      github-url-from-git: registry.npmmirror.com/github-url-from-git@1.5.0
-      has-yarn: registry.npmmirror.com/has-yarn@2.1.0
-      hosted-git-info: registry.npmmirror.com/hosted-git-info@3.0.8
-      ignore-walk: registry.npmmirror.com/ignore-walk@3.0.4
-      import-local: registry.npmmirror.com/import-local@3.1.0
-      inquirer: registry.npmmirror.com/inquirer@7.3.3
-      is-installed-globally: registry.npmmirror.com/is-installed-globally@0.3.2
-      is-interactive: registry.npmmirror.com/is-interactive@1.0.0
-      is-scoped: registry.npmmirror.com/is-scoped@2.1.0
-      issue-regex: registry.npmmirror.com/issue-regex@3.1.0
-      listr: registry.npmmirror.com/listr@0.14.3
-      listr-input: registry.npmmirror.com/listr-input@0.2.1
-      log-symbols: registry.npmmirror.com/log-symbols@4.1.0
-      meow: registry.npmmirror.com/meow@8.1.2
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-      new-github-release-url: registry.npmmirror.com/new-github-release-url@1.0.0
-      npm-name: registry.npmmirror.com/npm-name@6.0.1
-      onetime: registry.npmmirror.com/onetime@5.1.2
-      open: registry.npmmirror.com/open@7.4.2
-      ow: registry.npmmirror.com/ow@0.21.0
-      p-memoize: registry.npmmirror.com/p-memoize@4.0.4
-      p-timeout: registry.npmmirror.com/p-timeout@4.1.0
-      pkg-dir: registry.npmmirror.com/pkg-dir@5.0.0
-      read-pkg-up: registry.npmmirror.com/read-pkg-up@7.0.1
-      rxjs: registry.npmmirror.com/rxjs@6.6.7
-      semver: registry.npmmirror.com/semver@7.5.4
-      split: registry.npmmirror.com/split@1.0.1
-      symbol-observable: registry.npmmirror.com/symbol-observable@3.0.0
-      terminal-link: registry.npmmirror.com/terminal-link@2.1.1
-      update-notifier: registry.npmmirror.com/update-notifier@5.1.0
+      del: https://registry.npmmirror.com/del/-/del-6.1.1.tgz
+      escape-goat: https://registry.npmmirror.com/escape-goat/-/escape-goat-3.0.0.tgz
+      escape-string-regexp: https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+      execa: https://registry.npmmirror.com/execa/-/execa-5.1.1.tgz
+      github-url-from-git: https://registry.npmmirror.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz
+      has-yarn: https://registry.npmmirror.com/has-yarn/-/has-yarn-2.1.0.tgz
+      hosted-git-info: https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz
+      ignore-walk: https://registry.npmmirror.com/ignore-walk/-/ignore-walk-3.0.4.tgz
+      import-local: https://registry.npmmirror.com/import-local/-/import-local-3.1.0.tgz
+      inquirer: https://registry.npmmirror.com/inquirer/-/inquirer-7.3.3.tgz
+      is-installed-globally: https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz
+      is-interactive: https://registry.npmmirror.com/is-interactive/-/is-interactive-1.0.0.tgz
+      is-scoped: https://registry.npmmirror.com/is-scoped/-/is-scoped-2.1.0.tgz
+      issue-regex: https://registry.npmmirror.com/issue-regex/-/issue-regex-3.1.0.tgz
+      listr: https://registry.npmmirror.com/listr/-/listr-0.14.3.tgz
+      listr-input: https://registry.npmmirror.com/listr-input/-/listr-input-0.2.1.tgz
+      log-symbols: https://registry.npmmirror.com/log-symbols/-/log-symbols-4.1.0.tgz
+      meow: https://registry.npmmirror.com/meow/-/meow-8.1.2.tgz
+      minimatch: https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz
+      new-github-release-url: https://registry.npmmirror.com/new-github-release-url/-/new-github-release-url-1.0.0.tgz
+      npm-name: https://registry.npmmirror.com/npm-name/-/npm-name-6.0.1.tgz
+      onetime: https://registry.npmmirror.com/onetime/-/onetime-5.1.2.tgz
+      open: https://registry.npmmirror.com/open/-/open-7.4.2.tgz
+      ow: https://registry.npmmirror.com/ow/-/ow-0.21.0.tgz
+      p-memoize: https://registry.npmmirror.com/p-memoize/-/p-memoize-4.0.4.tgz
+      p-timeout: https://registry.npmmirror.com/p-timeout/-/p-timeout-4.1.0.tgz
+      pkg-dir: https://registry.npmmirror.com/pkg-dir/-/pkg-dir-5.0.0.tgz
+      read-pkg-up: https://registry.npmmirror.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz
+      rxjs: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz
+      semver: https://registry.npmmirror.com/semver/-/semver-7.5.4.tgz
+      split: https://registry.npmmirror.com/split/-/split-1.0.1.tgz
+      symbol-observable: https://registry.npmmirror.com/symbol-observable/-/symbol-observable-3.0.0.tgz
+      terminal-link: https://registry.npmmirror.com/terminal-link/-/terminal-link-2.1.1.tgz
+      update-notifier: https://registry.npmmirror.com/update-notifier/-/update-notifier-5.1.0.tgz
     transitivePeerDependencies:
       - zen-observable
       - zenObservable
-    dev: true
 
-  registry.npmmirror.com/npm-name@6.0.1:
-    resolution: {integrity: sha512-fhKRvUAxaYzMEUZim4mXWyfFbVS+M1CbrCLdAo3txWzrctxKka/h+KaBW0O9Cz5uOM00Nldn2JLWhuwnyW3SUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/npm-name/-/npm-name-6.0.1.tgz}
-    name: npm-name
-    version: 6.0.1
-    engines: {node: '>=10'}
+  npm-name@https://registry.npmmirror.com/npm-name/-/npm-name-6.0.1.tgz:
     dependencies:
-      got: registry.npmmirror.com/got@10.7.0
-      is-scoped: registry.npmmirror.com/is-scoped@2.1.0
-      is-url-superb: registry.npmmirror.com/is-url-superb@4.0.0
+      got: https://registry.npmmirror.com/got/-/got-10.7.0.tgz
+      is-scoped: https://registry.npmmirror.com/is-scoped/-/is-scoped-2.1.0.tgz
+      is-url-superb: https://registry.npmmirror.com/is-url-superb/-/is-url-superb-4.0.0.tgz
       lodash.zip: 4.2.0
-      org-regex: registry.npmmirror.com/org-regex@1.0.0
-      p-map: registry.npmmirror.com/p-map@3.0.0
-      registry-auth-token: registry.npmmirror.com/registry-auth-token@4.2.2
-      registry-url: registry.npmmirror.com/registry-url@5.1.0
-      validate-npm-package-name: registry.npmmirror.com/validate-npm-package-name@3.0.0
-    dev: true
+      org-regex: https://registry.npmmirror.com/org-regex/-/org-regex-1.0.0.tgz
+      p-map: https://registry.npmmirror.com/p-map/-/p-map-3.0.0.tgz
+      registry-auth-token: https://registry.npmmirror.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz
+      registry-url: https://registry.npmmirror.com/registry-url/-/registry-url-5.1.0.tgz
+      validate-npm-package-name: https://registry.npmmirror.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz
 
-  registry.npmmirror.com/number-is-nan@1.0.1:
-    resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/number-is-nan/-/number-is-nan-1.0.1.tgz}
-    name: number-is-nan
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmmirror.com/nunjucks@3.2.2:
-    resolution: {integrity: sha512-KUi85OoF2NMygwODAy28Lh9qHmq5hO3rBlbkYoC8v377h4l8Pt5qFjILl0LWpMbOrZ18CzfVVUvIHUIrtED3sA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/nunjucks/-/nunjucks-3.2.2.tgz}
-    name: nunjucks
-    version: 3.2.2
-    engines: {node: '>= 6.9.0'}
-    hasBin: true
+  npm-run-path@4.0.1:
     dependencies:
-      a-sync-waterfall: registry.npmmirror.com/a-sync-waterfall@1.0.1
-      asap: registry.npmmirror.com/asap@2.0.6
-      commander: registry.npmmirror.com/commander@5.1.0
+      path-key: 3.1.1
+
+  number-is-nan@https://registry.npmmirror.com/number-is-nan/-/number-is-nan-1.0.1.tgz: {}
+
+  nunjucks@https://registry.npmmirror.com/nunjucks/-/nunjucks-3.2.2.tgz:
+    dependencies:
+      a-sync-waterfall: https://registry.npmmirror.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz
+      asap: https://registry.npmmirror.com/asap/-/asap-2.0.6.tgz
+      commander: https://registry.npmmirror.com/commander/-/commander-5.1.0.tgz
     optionalDependencies:
       chokidar: 3.5.3
-    dev: false
 
-  registry.npmmirror.com/oas-kit-common@1.0.8:
-    resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-kit-common/-/oas-kit-common-1.0.8.tgz}
-    name: oas-kit-common
-    version: 1.0.8
+  oas-kit-common@https://registry.npmmirror.com/oas-kit-common/-/oas-kit-common-1.0.8.tgz:
     dependencies:
-      fast-safe-stringify: registry.npmmirror.com/fast-safe-stringify@2.1.1
-    dev: false
+      fast-safe-stringify: https://registry.npmmirror.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz
 
-  registry.npmmirror.com/oas-linter@3.2.2:
-    resolution: {integrity: sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-linter/-/oas-linter-3.2.2.tgz}
-    name: oas-linter
-    version: 3.2.2
+  oas-linter@https://registry.npmmirror.com/oas-linter/-/oas-linter-3.2.2.tgz:
     dependencies:
-      '@exodus/schemasafe': registry.npmmirror.com/@exodus/schemasafe@1.0.1
-      should: registry.npmmirror.com/should@13.2.3
-      yaml: registry.npmmirror.com/yaml@1.10.2
-    dev: false
+      '@exodus/schemasafe': https://registry.npmmirror.com/@exodus/schemasafe/-/schemasafe-1.0.1.tgz
+      should: https://registry.npmmirror.com/should/-/should-13.2.3.tgz
+      yaml: https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz
 
-  registry.npmmirror.com/oas-resolver@2.5.6:
-    resolution: {integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-resolver/-/oas-resolver-2.5.6.tgz}
-    name: oas-resolver
-    version: 2.5.6
-    hasBin: true
+  oas-resolver@https://registry.npmmirror.com/oas-resolver/-/oas-resolver-2.5.6.tgz:
     dependencies:
-      node-fetch-h2: registry.npmmirror.com/node-fetch-h2@2.3.0
-      oas-kit-common: registry.npmmirror.com/oas-kit-common@1.0.8
-      reftools: registry.npmmirror.com/reftools@1.1.9
-      yaml: registry.npmmirror.com/yaml@1.10.2
-      yargs: registry.npmmirror.com/yargs@17.7.2
-    dev: false
+      node-fetch-h2: https://registry.npmmirror.com/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz
+      oas-kit-common: https://registry.npmmirror.com/oas-kit-common/-/oas-kit-common-1.0.8.tgz
+      reftools: https://registry.npmmirror.com/reftools/-/reftools-1.1.9.tgz
+      yaml: https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz
+      yargs: https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz
 
-  registry.npmmirror.com/oas-schema-walker@1.1.5:
-    resolution: {integrity: sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz}
-    name: oas-schema-walker
-    version: 1.1.5
-    dev: false
+  oas-schema-walker@https://registry.npmmirror.com/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz: {}
 
-  registry.npmmirror.com/oas-validator@5.0.8:
-    resolution: {integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/oas-validator/-/oas-validator-5.0.8.tgz}
-    name: oas-validator
-    version: 5.0.8
+  oas-validator@https://registry.npmmirror.com/oas-validator/-/oas-validator-5.0.8.tgz:
     dependencies:
-      call-me-maybe: registry.npmmirror.com/call-me-maybe@1.0.2
-      oas-kit-common: registry.npmmirror.com/oas-kit-common@1.0.8
-      oas-linter: registry.npmmirror.com/oas-linter@3.2.2
-      oas-resolver: registry.npmmirror.com/oas-resolver@2.5.6
-      oas-schema-walker: registry.npmmirror.com/oas-schema-walker@1.1.5
-      reftools: registry.npmmirror.com/reftools@1.1.9
-      should: registry.npmmirror.com/should@13.2.3
-      yaml: registry.npmmirror.com/yaml@1.10.2
-    dev: false
+      call-me-maybe: https://registry.npmmirror.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz
+      oas-kit-common: https://registry.npmmirror.com/oas-kit-common/-/oas-kit-common-1.0.8.tgz
+      oas-linter: https://registry.npmmirror.com/oas-linter/-/oas-linter-3.2.2.tgz
+      oas-resolver: https://registry.npmmirror.com/oas-resolver/-/oas-resolver-2.5.6.tgz
+      oas-schema-walker: https://registry.npmmirror.com/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz
+      reftools: https://registry.npmmirror.com/reftools/-/reftools-1.1.9.tgz
+      should: https://registry.npmmirror.com/should/-/should-13.2.3.tgz
+      yaml: https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz
 
-  registry.npmmirror.com/once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/once/-/once-1.4.0.tgz}
-    name: once
-    version: 1.4.0
+  object-assign@4.1.1: {}
+
+  once@1.4.0:
     dependencies:
-      wrappy: registry.npmmirror.com/wrappy@1.0.2
-    dev: false
+      wrappy: 1.0.2
 
-  registry.npmmirror.com/onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/onetime/-/onetime-5.1.2.tgz}
-    name: onetime
-    version: 5.1.2
-    engines: {node: '>=6'}
+  once@https://registry.npmmirror.com/once/-/once-1.4.0.tgz:
+    dependencies:
+      wrappy: https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz
+
+  onetime@2.0.1:
+    dependencies:
+      mimic-fn: 1.2.0
+
+  onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-    dev: true
 
-  registry.npmmirror.com/open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/open/-/open-7.4.2.tgz}
-    name: open
-    version: 7.4.2
-    engines: {node: '>=8'}
+  onetime@https://registry.npmmirror.com/onetime/-/onetime-5.1.2.tgz:
     dependencies:
-      is-docker: registry.npmmirror.com/is-docker@2.2.1
-      is-wsl: registry.npmmirror.com/is-wsl@2.2.0
-    dev: true
+      mimic-fn: 2.1.0
 
-  registry.npmmirror.com/openapi3-ts@2.0.1:
-    resolution: {integrity: sha512-v6X3iwddhi276siej96jHGIqTx3wzVfMTmpGJEQDt7GPI7pI6sywItURLzpEci21SBRpPN/aOWSF5mVfFVNmcg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/openapi3-ts/-/openapi3-ts-2.0.1.tgz}
-    name: openapi3-ts
-    version: 2.0.1
+  open@https://registry.npmmirror.com/open/-/open-7.4.2.tgz:
     dependencies:
-      yaml: registry.npmmirror.com/yaml@1.10.2
-    dev: false
+      is-docker: https://registry.npmmirror.com/is-docker/-/is-docker-2.2.1.tgz
+      is-wsl: https://registry.npmmirror.com/is-wsl/-/is-wsl-2.2.0.tgz
 
-  registry.npmmirror.com/org-regex@1.0.0:
-    resolution: {integrity: sha512-7bqkxkEJwzJQUAlyYniqEZ3Ilzjh0yoa62c7gL6Ijxj5bEpPL+8IE1Z0PFj0ywjjXQcdrwR51g9MIcLezR0hKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/org-regex/-/org-regex-1.0.0.tgz}
-    name: org-regex
-    version: 1.0.0
-    engines: {node: '>=8'}
-    dev: true
-
-  registry.npmmirror.com/os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz}
-    name: os-tmpdir
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmmirror.com/ow@0.21.0:
-    resolution: {integrity: sha512-dlsoDe39g7mhdsdrC1R/YwjT7yjVqE3svWwOlMGvN690waBkgEZBmKBdkmKvSt5/wZ6E0Jn/nIesPqMZOpPKqw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ow/-/ow-0.21.0.tgz}
-    name: ow
-    version: 0.21.0
-    engines: {node: '>=10'}
+  openapi3-ts@https://registry.npmmirror.com/openapi3-ts/-/openapi3-ts-2.0.1.tgz:
     dependencies:
-      '@sindresorhus/is': registry.npmmirror.com/@sindresorhus/is@4.6.0
+      yaml: https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz
+
+  org-regex@https://registry.npmmirror.com/org-regex/-/org-regex-1.0.0.tgz: {}
+
+  os-tmpdir@https://registry.npmmirror.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz: {}
+
+  ow@https://registry.npmmirror.com/ow/-/ow-0.21.0.tgz:
+    dependencies:
+      '@sindresorhus/is': https://registry.npmmirror.com/@sindresorhus/is/-/is-4.6.0.tgz
       callsites: 3.1.0
-      dot-prop: registry.npmmirror.com/dot-prop@6.0.1
-      lodash.isequal: registry.npmmirror.com/lodash.isequal@4.5.0
+      dot-prop: https://registry.npmmirror.com/dot-prop/-/dot-prop-6.0.1.tgz
+      lodash.isequal: https://registry.npmmirror.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz
       type-fest: 0.20.2
-      vali-date: registry.npmmirror.com/vali-date@1.0.0
-    dev: true
+      vali-date: https://registry.npmmirror.com/vali-date/-/vali-date-1.0.0.tgz
 
-  registry.npmmirror.com/p-cancelable@1.1.0:
-    resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-cancelable/-/p-cancelable-1.1.0.tgz}
-    name: p-cancelable
-    version: 1.1.0
-    engines: {node: '>=6'}
-    dev: true
+  p-cancelable@https://registry.npmmirror.com/p-cancelable/-/p-cancelable-1.1.0.tgz: {}
 
-  registry.npmmirror.com/p-cancelable@2.1.1:
-    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz}
-    name: p-cancelable
-    version: 2.1.1
-    engines: {node: '>=8'}
-    dev: true
+  p-cancelable@https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz: {}
 
-  registry.npmmirror.com/p-event@4.2.0:
-    resolution: {integrity: sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-event/-/p-event-4.2.0.tgz}
-    name: p-event
-    version: 4.2.0
-    engines: {node: '>=8'}
+  p-defer@1.0.0: {}
+
+  p-event@https://registry.npmmirror.com/p-event/-/p-event-4.2.0.tgz:
     dependencies:
-      p-timeout: registry.npmmirror.com/p-timeout@3.2.0
-    dev: true
+      p-timeout: https://registry.npmmirror.com/p-timeout/-/p-timeout-3.2.0.tgz
 
-  registry.npmmirror.com/p-finally@1.0.0:
-    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-finally/-/p-finally-1.0.0.tgz}
-    name: p-finally
-    version: 1.0.0
-    engines: {node: '>=4'}
-    dev: true
+  p-finally@https://registry.npmmirror.com/p-finally/-/p-finally-1.0.0.tgz: {}
 
-  registry.npmmirror.com/p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-limit/-/p-limit-2.3.0.tgz}
-    name: p-limit
-    version: 2.3.0
-    engines: {node: '>=6'}
+  p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
-    dev: true
 
-  registry.npmmirror.com/p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-map/-/p-map-2.1.0.tgz}
-    name: p-map
-    version: 2.1.0
-    engines: {node: '>=6'}
-    dev: true
-
-  registry.npmmirror.com/p-map@3.0.0:
-    resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-map/-/p-map-3.0.0.tgz}
-    name: p-map
-    version: 3.0.0
-    engines: {node: '>=8'}
+  p-limit@3.1.0:
     dependencies:
-      aggregate-error: registry.npmmirror.com/aggregate-error@3.1.0
-    dev: true
+      yocto-queue: https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz
 
-  registry.npmmirror.com/p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-map/-/p-map-4.0.0.tgz}
-    name: p-map
-    version: 4.0.0
-    engines: {node: '>=10'}
+  p-limit@https://registry.npmmirror.com/p-limit/-/p-limit-2.3.0.tgz:
     dependencies:
-      aggregate-error: registry.npmmirror.com/aggregate-error@3.1.0
-    dev: true
+      p-try: 2.2.0
 
-  registry.npmmirror.com/p-memoize@4.0.4:
-    resolution: {integrity: sha512-ijdh0DP4Mk6J4FXlOM6vPPoCjPytcEseW8p/k5SDTSSfGV3E9bpt9Yzfifvzp6iohIieoLTkXRb32OWV0fB2Lw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-memoize/-/p-memoize-4.0.4.tgz}
-    name: p-memoize
-    version: 4.0.4
-    engines: {node: '>=10'}
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  p-map@https://registry.npmmirror.com/p-map/-/p-map-2.1.0.tgz: {}
+
+  p-map@https://registry.npmmirror.com/p-map/-/p-map-3.0.0.tgz:
+    dependencies:
+      aggregate-error: https://registry.npmmirror.com/aggregate-error/-/aggregate-error-3.1.0.tgz
+
+  p-map@https://registry.npmmirror.com/p-map/-/p-map-4.0.0.tgz:
+    dependencies:
+      aggregate-error: https://registry.npmmirror.com/aggregate-error/-/aggregate-error-3.1.0.tgz
+
+  p-memoize@https://registry.npmmirror.com/p-memoize/-/p-memoize-4.0.4.tgz:
     dependencies:
       map-age-cleaner: 0.1.3
       mimic-fn: 3.1.0
-      p-settle: registry.npmmirror.com/p-settle@4.1.1
-    dev: true
+      p-settle: https://registry.npmmirror.com/p-settle/-/p-settle-4.1.1.tgz
 
-  registry.npmmirror.com/p-reflect@2.1.0:
-    resolution: {integrity: sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-reflect/-/p-reflect-2.1.0.tgz}
-    name: p-reflect
-    version: 2.1.0
-    engines: {node: '>=8'}
-    dev: true
+  p-reflect@https://registry.npmmirror.com/p-reflect/-/p-reflect-2.1.0.tgz: {}
 
-  registry.npmmirror.com/p-settle@4.1.1:
-    resolution: {integrity: sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-settle/-/p-settle-4.1.1.tgz}
-    name: p-settle
-    version: 4.1.1
-    engines: {node: '>=10'}
+  p-settle@https://registry.npmmirror.com/p-settle/-/p-settle-4.1.1.tgz:
     dependencies:
-      p-limit: registry.npmmirror.com/p-limit@2.3.0
-      p-reflect: registry.npmmirror.com/p-reflect@2.1.0
-    dev: true
+      p-limit: https://registry.npmmirror.com/p-limit/-/p-limit-2.3.0.tgz
+      p-reflect: https://registry.npmmirror.com/p-reflect/-/p-reflect-2.1.0.tgz
 
-  registry.npmmirror.com/p-timeout@3.2.0:
-    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-timeout/-/p-timeout-3.2.0.tgz}
-    name: p-timeout
-    version: 3.2.0
-    engines: {node: '>=8'}
+  p-timeout@https://registry.npmmirror.com/p-timeout/-/p-timeout-3.2.0.tgz:
     dependencies:
-      p-finally: registry.npmmirror.com/p-finally@1.0.0
-    dev: true
+      p-finally: https://registry.npmmirror.com/p-finally/-/p-finally-1.0.0.tgz
 
-  registry.npmmirror.com/p-timeout@4.1.0:
-    resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-timeout/-/p-timeout-4.1.0.tgz}
-    name: p-timeout
-    version: 4.1.0
-    engines: {node: '>=10'}
-    dev: true
+  p-timeout@https://registry.npmmirror.com/p-timeout/-/p-timeout-4.1.0.tgz: {}
 
-  registry.npmmirror.com/package-json@6.5.0:
-    resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/package-json/-/package-json-6.5.0.tgz}
-    name: package-json
-    version: 6.5.0
-    engines: {node: '>=8'}
+  p-try@2.2.0: {}
+
+  package-json@https://registry.npmmirror.com/package-json/-/package-json-6.5.0.tgz:
     dependencies:
-      got: registry.npmmirror.com/got@9.6.0
-      registry-auth-token: registry.npmmirror.com/registry-auth-token@4.2.2
-      registry-url: registry.npmmirror.com/registry-url@5.1.0
+      got: https://registry.npmmirror.com/got/-/got-9.6.0.tgz
+      registry-auth-token: https://registry.npmmirror.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz
+      registry-url: https://registry.npmmirror.com/registry-url/-/registry-url-5.1.0.tgz
       semver: 6.3.0
-    dev: true
 
-  registry.npmmirror.com/path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz}
-    name: path-exists
-    version: 4.0.0
-    engines: {node: '>=8'}
-    dev: true
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
 
-  registry.npmmirror.com/path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz}
-    name: path-is-absolute
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dev: false
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
-  registry.npmmirror.com/picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz}
-    name: picomatch
-    version: 2.3.1
-    engines: {node: '>=8.6'}
-    requiresBuild: true
-    dev: false
+  path-exists@4.0.0: {}
+
+  path-exists@https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-is-absolute@https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-type@4.0.0: {}
+
+  picomatch@2.3.1: {}
+
+  picomatch@https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz:
     optional: true
 
-  registry.npmmirror.com/pkg-dir@4.2.0:
-    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pkg-dir/-/pkg-dir-4.2.0.tgz}
-    name: pkg-dir
-    version: 4.2.0
-    engines: {node: '>=8'}
+  pkg-dir@https://registry.npmmirror.com/pkg-dir/-/pkg-dir-4.2.0.tgz:
     dependencies:
       find-up: 4.1.0
-    dev: true
 
-  registry.npmmirror.com/pkg-dir@5.0.0:
-    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pkg-dir/-/pkg-dir-5.0.0.tgz}
-    name: pkg-dir
-    version: 5.0.0
-    engines: {node: '>=10'}
+  pkg-dir@https://registry.npmmirror.com/pkg-dir/-/pkg-dir-5.0.0.tgz:
     dependencies:
       find-up: 5.0.0
-    dev: true
 
-  registry.npmmirror.com/prepend-http@2.0.0:
-    resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prepend-http/-/prepend-http-2.0.0.tgz}
-    name: prepend-http
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: true
+  prepend-http@https://registry.npmmirror.com/prepend-http/-/prepend-http-2.0.0.tgz: {}
 
-  registry.npmmirror.com/prettier@2.2.1:
-    resolution: {integrity: sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prettier/-/prettier-2.2.1.tgz}
-    name: prettier
-    version: 2.2.1
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dev: false
+  prettier@https://registry.npmmirror.com/prettier/-/prettier-2.2.1.tgz: {}
 
-  registry.npmmirror.com/pupa@2.1.1:
-    resolution: {integrity: sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pupa/-/pupa-2.1.1.tgz}
-    name: pupa
-    version: 2.1.1
-    engines: {node: '>=8'}
+  pump@3.0.0:
     dependencies:
-      escape-goat: registry.npmmirror.com/escape-goat@2.1.1
-    dev: true
+      end-of-stream: 1.4.4
+      once: 1.4.0
 
-  registry.npmmirror.com/rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rc/-/rc-1.2.8.tgz}
-    name: rc
-    version: 1.2.8
-    hasBin: true
+  pupa@https://registry.npmmirror.com/pupa/-/pupa-2.1.1.tgz:
     dependencies:
-      deep-extend: registry.npmmirror.com/deep-extend@0.6.0
+      escape-goat: https://registry.npmmirror.com/escape-goat/-/escape-goat-2.1.1.tgz
+
+  queue-microtask@1.2.3: {}
+
+  quick-lru@4.0.1: {}
+
+  rc@https://registry.npmmirror.com/rc/-/rc-1.2.8.tgz:
+    dependencies:
+      deep-extend: https://registry.npmmirror.com/deep-extend/-/deep-extend-0.6.0.tgz
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    dev: true
 
-  registry.npmmirror.com/read-pkg-up@7.0.1:
-    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz}
-    name: read-pkg-up
-    version: 7.0.1
-    engines: {node: '>=8'}
+  read-pkg-up@7.0.1:
     dependencies:
       find-up: 4.1.0
       read-pkg: 5.2.0
       type-fest: 0.8.1
-    dev: true
 
-  registry.npmmirror.com/readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz}
-    name: readdirp
-    version: 3.6.0
-    engines: {node: '>=8.10.0'}
-    requiresBuild: true
+  read-pkg-up@https://registry.npmmirror.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz:
     dependencies:
-      picomatch: registry.npmmirror.com/picomatch@2.3.1
-    dev: false
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+
+  read-pkg@5.2.0:
+    dependencies:
+      '@types/normalize-package-data': 2.4.1
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
+
+  readdirp@https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz:
+    dependencies:
+      picomatch: https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz
     optional: true
 
-  registry.npmmirror.com/reftools@1.1.9:
-    resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/reftools/-/reftools-1.1.9.tgz}
-    name: reftools
-    version: 1.1.9
-    dev: false
-
-  registry.npmmirror.com/registry-auth-token@4.2.2:
-    resolution: {integrity: sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz}
-    name: registry-auth-token
-    version: 4.2.2
-    engines: {node: '>=6.0.0'}
+  redent@3.0.0:
     dependencies:
-      rc: registry.npmmirror.com/rc@1.2.8
-    dev: true
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
-  registry.npmmirror.com/registry-url@5.1.0:
-    resolution: {integrity: sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/registry-url/-/registry-url-5.1.0.tgz}
-    name: registry-url
-    version: 5.1.0
-    engines: {node: '>=8'}
+  reftools@https://registry.npmmirror.com/reftools/-/reftools-1.1.9.tgz: {}
+
+  registry-auth-token@https://registry.npmmirror.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz:
     dependencies:
-      rc: registry.npmmirror.com/rc@1.2.8
-    dev: true
+      rc: https://registry.npmmirror.com/rc/-/rc-1.2.8.tgz
 
-  registry.npmmirror.com/require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz}
-    name: require-directory
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dev: false
+  registry-url@https://registry.npmmirror.com/registry-url/-/registry-url-5.1.0.tgz:
+    dependencies:
+      rc: https://registry.npmmirror.com/rc/-/rc-1.2.8.tgz
 
-  registry.npmmirror.com/reserved-words@0.1.2:
-    resolution: {integrity: sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/reserved-words/-/reserved-words-0.1.2.tgz}
-    name: reserved-words
-    version: 0.1.2
-    dev: false
+  require-directory@https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz: {}
 
-  registry.npmmirror.com/resolve-cwd@3.0.0:
-    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz}
-    name: resolve-cwd
-    version: 3.0.0
-    engines: {node: '>=8'}
+  reserved-words@https://registry.npmmirror.com/reserved-words/-/reserved-words-0.1.2.tgz: {}
+
+  resolve-cwd@https://registry.npmmirror.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz:
     dependencies:
       resolve-from: 5.0.0
-    dev: true
 
-  registry.npmmirror.com/responselike@1.0.2:
-    resolution: {integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/responselike/-/responselike-1.0.2.tgz}
-    name: responselike
-    version: 1.0.2
+  resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve@1.22.2:
     dependencies:
-      lowercase-keys: registry.npmmirror.com/lowercase-keys@1.0.1
-    dev: true
+      is-core-module: 2.12.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
-  registry.npmmirror.com/responselike@2.0.1:
-    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/responselike/-/responselike-2.0.1.tgz}
-    name: responselike
-    version: 2.0.1
+  responselike@https://registry.npmmirror.com/responselike/-/responselike-1.0.2.tgz:
     dependencies:
-      lowercase-keys: registry.npmmirror.com/lowercase-keys@2.0.0
-    dev: true
+      lowercase-keys: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz
 
-  registry.npmmirror.com/restore-cursor@2.0.0:
-    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/restore-cursor/-/restore-cursor-2.0.0.tgz}
-    name: restore-cursor
-    version: 2.0.0
-    engines: {node: '>=4'}
+  responselike@https://registry.npmmirror.com/responselike/-/responselike-2.0.1.tgz:
+    dependencies:
+      lowercase-keys: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz
+
+  restore-cursor@https://registry.npmmirror.com/restore-cursor/-/restore-cursor-2.0.0.tgz:
     dependencies:
       onetime: 2.0.1
       signal-exit: 3.0.7
-    dev: true
 
-  registry.npmmirror.com/restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/restore-cursor/-/restore-cursor-3.1.0.tgz}
-    name: restore-cursor
-    version: 3.1.0
-    engines: {node: '>=8'}
+  restore-cursor@https://registry.npmmirror.com/restore-cursor/-/restore-cursor-3.1.0.tgz:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    dev: true
 
-  registry.npmmirror.com/rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz}
-    name: rimraf
-    version: 3.0.2
-    hasBin: true
+  reusify@1.0.4: {}
+
+  rimraf@3.0.2:
     dependencies:
-      glob: registry.npmmirror.com/glob@7.1.6
-    dev: false
+      glob: 7.1.6
 
-  registry.npmmirror.com/run-async@2.4.1:
-    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/run-async/-/run-async-2.4.1.tgz}
-    name: run-async
-    version: 2.4.1
-    engines: {node: '>=0.12.0'}
-    dev: true
-
-  registry.npmmirror.com/rxjs@6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz}
-    name: rxjs
-    version: 6.6.7
-    engines: {npm: '>=2.0.0'}
+  rimraf@https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz:
     dependencies:
-      tslib: registry.npmmirror.com/tslib@1.14.1
-    dev: true
+      glob: https://registry.npmmirror.com/glob/-/glob-7.1.6.tgz
 
-  registry.npmmirror.com/safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz}
-    name: safer-buffer
-    version: 2.1.2
-    dev: true
+  run-async@https://registry.npmmirror.com/run-async/-/run-async-2.4.1.tgz: {}
 
-  registry.npmmirror.com/scoped-regex@2.1.0:
-    resolution: {integrity: sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/scoped-regex/-/scoped-regex-2.1.0.tgz}
-    name: scoped-regex
-    version: 2.1.0
-    engines: {node: '>=8'}
-    dev: true
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
-  registry.npmmirror.com/semver-diff@3.1.1:
-    resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/semver-diff/-/semver-diff-3.1.1.tgz}
-    name: semver-diff
-    version: 3.1.1
-    engines: {node: '>=8'}
+  rxjs@https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz:
+    dependencies:
+      tslib: https://registry.npmmirror.com/tslib/-/tslib-1.14.1.tgz
+
+  safer-buffer@https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz: {}
+
+  scoped-regex@https://registry.npmmirror.com/scoped-regex/-/scoped-regex-2.1.0.tgz: {}
+
+  semver-diff@https://registry.npmmirror.com/semver-diff/-/semver-diff-3.1.1.tgz:
     dependencies:
       semver: 6.3.0
-    dev: true
 
-  registry.npmmirror.com/semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/semver/-/semver-7.5.4.tgz}
-    name: semver
-    version: 7.5.4
-    engines: {node: '>=10'}
-    hasBin: true
+  semver@5.7.1: {}
+
+  semver@6.3.0: {}
+
+  semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
-  registry.npmmirror.com/should-equal@2.0.0:
-    resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-equal/-/should-equal-2.0.0.tgz}
-    name: should-equal
-    version: 2.0.0
+  semver@https://registry.npmmirror.com/semver/-/semver-7.5.4.tgz:
     dependencies:
-      should-type: registry.npmmirror.com/should-type@1.4.0
-    dev: false
+      lru-cache: 6.0.0
 
-  registry.npmmirror.com/should-format@3.0.3:
-    resolution: {integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-format/-/should-format-3.0.3.tgz}
-    name: should-format
-    version: 3.0.3
+  shebang-command@2.0.0:
     dependencies:
-      should-type: registry.npmmirror.com/should-type@1.4.0
-      should-type-adaptors: registry.npmmirror.com/should-type-adaptors@1.1.0
-    dev: false
+      shebang-regex: 3.0.0
 
-  registry.npmmirror.com/should-type-adaptors@1.1.0:
-    resolution: {integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz}
-    name: should-type-adaptors
-    version: 1.1.0
+  shebang-regex@3.0.0: {}
+
+  should-equal@https://registry.npmmirror.com/should-equal/-/should-equal-2.0.0.tgz:
     dependencies:
-      should-type: registry.npmmirror.com/should-type@1.4.0
-      should-util: registry.npmmirror.com/should-util@1.0.1
-    dev: false
+      should-type: https://registry.npmmirror.com/should-type/-/should-type-1.4.0.tgz
 
-  registry.npmmirror.com/should-type@1.4.0:
-    resolution: {integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-type/-/should-type-1.4.0.tgz}
-    name: should-type
-    version: 1.4.0
-    dev: false
-
-  registry.npmmirror.com/should-util@1.0.1:
-    resolution: {integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-util/-/should-util-1.0.1.tgz}
-    name: should-util
-    version: 1.0.1
-    dev: false
-
-  registry.npmmirror.com/should@13.2.3:
-    resolution: {integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should/-/should-13.2.3.tgz}
-    name: should
-    version: 13.2.3
+  should-format@https://registry.npmmirror.com/should-format/-/should-format-3.0.3.tgz:
     dependencies:
-      should-equal: registry.npmmirror.com/should-equal@2.0.0
-      should-format: registry.npmmirror.com/should-format@3.0.3
-      should-type: registry.npmmirror.com/should-type@1.4.0
-      should-type-adaptors: registry.npmmirror.com/should-type-adaptors@1.1.0
-      should-util: registry.npmmirror.com/should-util@1.0.1
-    dev: false
+      should-type: https://registry.npmmirror.com/should-type/-/should-type-1.4.0.tgz
+      should-type-adaptors: https://registry.npmmirror.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz
 
-  registry.npmmirror.com/split@1.0.1:
-    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/split/-/split-1.0.1.tgz}
-    name: split
-    version: 1.0.1
+  should-type-adaptors@https://registry.npmmirror.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz:
     dependencies:
-      through: registry.npmmirror.com/through@2.3.8
-    dev: true
+      should-type: https://registry.npmmirror.com/should-type/-/should-type-1.4.0.tgz
+      should-util: https://registry.npmmirror.com/should-util/-/should-util-1.0.1.tgz
 
-  registry.npmmirror.com/string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz}
-    name: string-width
-    version: 4.2.3
-    engines: {node: '>=8'}
+  should-type@https://registry.npmmirror.com/should-type/-/should-type-1.4.0.tgz: {}
+
+  should-util@https://registry.npmmirror.com/should-util/-/should-util-1.0.1.tgz: {}
+
+  should@https://registry.npmmirror.com/should/-/should-13.2.3.tgz:
     dependencies:
-      emoji-regex: registry.npmmirror.com/emoji-regex@8.0.0
-      is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@3.0.0
-      strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
+      should-equal: https://registry.npmmirror.com/should-equal/-/should-equal-2.0.0.tgz
+      should-format: https://registry.npmmirror.com/should-format/-/should-format-3.0.3.tgz
+      should-type: https://registry.npmmirror.com/should-type/-/should-type-1.4.0.tgz
+      should-type-adaptors: https://registry.npmmirror.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz
+      should-util: https://registry.npmmirror.com/should-util/-/should-util-1.0.1.tgz
 
-  registry.npmmirror.com/strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz}
-    name: strip-ansi
-    version: 6.0.1
-    engines: {node: '>=8'}
+  signal-exit@3.0.7: {}
+
+  slash@3.0.0: {}
+
+  slice-ansi@0.0.4: {}
+
+  spdx-correct@3.2.0:
     dependencies:
-      ansi-regex: registry.npmmirror.com/ansi-regex@5.0.1
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.13
 
-  registry.npmmirror.com/supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz}
-    name: supports-color
-    version: 7.2.0
-    engines: {node: '>=8'}
+  spdx-exceptions@2.3.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.3.0
+      spdx-license-ids: 3.0.13
+
+  spdx-license-ids@3.0.13: {}
+
+  split@https://registry.npmmirror.com/split/-/split-1.0.1.tgz:
+    dependencies:
+      through: https://registry.npmmirror.com/through/-/through-2.3.8.tgz
+
+  string-width@1.0.2:
+    dependencies:
+      code-point-at: https://registry.npmmirror.com/code-point-at/-/code-point-at-1.1.0.tgz
+      is-fullwidth-code-point: 1.0.0
+      strip-ansi: 3.0.1
+
+  string-width@2.1.1:
+    dependencies:
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 4.0.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz:
+    dependencies:
+      emoji-regex: https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz
+      is-fullwidth-code-point: https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz
+      strip-ansi: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz
+
+  strip-ansi@3.0.1:
+    dependencies:
+      ansi-regex: 2.1.1
+
+  strip-ansi@4.0.0:
+    dependencies:
+      ansi-regex: 3.0.1
+
+  strip-ansi@5.2.0:
+    dependencies:
+      ansi-regex: 4.1.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz:
+    dependencies:
+      ansi-regex: https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz
+
+  strip-final-newline@2.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
+
+  supports-color@2.0.0: {}
+
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
+  supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
-  registry.npmmirror.com/swagger2openapi@7.0.4:
-    resolution: {integrity: sha512-MGzJU44XSXHKxvtx/NbBnP3z5s1KzN5xhqIBERoZEKfRiZ56lNUo5TGOv0dJ8n7JGeheCeU0CydfvbSOh+DaXg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/swagger2openapi/-/swagger2openapi-7.0.4.tgz}
-    name: swagger2openapi
-    version: 7.0.4
-    hasBin: true
+  supports-color@https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz:
     dependencies:
-      call-me-maybe: registry.npmmirror.com/call-me-maybe@1.0.2
-      node-fetch: registry.npmmirror.com/node-fetch@2.6.1
-      node-fetch-h2: registry.npmmirror.com/node-fetch-h2@2.3.0
-      node-readfiles: registry.npmmirror.com/node-readfiles@0.2.0
-      oas-kit-common: registry.npmmirror.com/oas-kit-common@1.0.8
-      oas-resolver: registry.npmmirror.com/oas-resolver@2.5.6
-      oas-schema-walker: registry.npmmirror.com/oas-schema-walker@1.1.5
-      oas-validator: registry.npmmirror.com/oas-validator@5.0.8
-      reftools: registry.npmmirror.com/reftools@1.1.9
-      yaml: registry.npmmirror.com/yaml@1.10.2
-      yargs: registry.npmmirror.com/yargs@16.2.0
-    dev: false
+      has-flag: 4.0.0
 
-  registry.npmmirror.com/symbol-observable@1.2.0:
-    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/symbol-observable/-/symbol-observable-1.2.0.tgz}
-    name: symbol-observable
-    version: 1.2.0
-    engines: {node: '>=0.10.0'}
-    dev: true
+  supports-hyperlinks@2.3.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
 
-  registry.npmmirror.com/symbol-observable@3.0.0:
-    resolution: {integrity: sha512-6tDOXSHiVjuCaasQSWTmHUWn4PuG7qa3+1WT031yTc/swT7+rLiw3GOrFxaH1E3lLP09dH3bVuVDf2gK5rxG3Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/symbol-observable/-/symbol-observable-3.0.0.tgz}
-    name: symbol-observable
-    version: 3.0.0
-    engines: {node: '>=0.10'}
-    dev: true
+  supports-preserve-symlinks-flag@1.0.0: {}
 
-  registry.npmmirror.com/terminal-link@2.1.1:
-    resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/terminal-link/-/terminal-link-2.1.1.tgz}
-    name: terminal-link
-    version: 2.1.1
-    engines: {node: '>=8'}
+  swagger2openapi@https://registry.npmmirror.com/swagger2openapi/-/swagger2openapi-7.0.4.tgz:
+    dependencies:
+      call-me-maybe: https://registry.npmmirror.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz
+      node-fetch: https://registry.npmmirror.com/node-fetch/-/node-fetch-2.6.1.tgz
+      node-fetch-h2: https://registry.npmmirror.com/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz
+      node-readfiles: https://registry.npmmirror.com/node-readfiles/-/node-readfiles-0.2.0.tgz
+      oas-kit-common: https://registry.npmmirror.com/oas-kit-common/-/oas-kit-common-1.0.8.tgz
+      oas-resolver: https://registry.npmmirror.com/oas-resolver/-/oas-resolver-2.5.6.tgz
+      oas-schema-walker: https://registry.npmmirror.com/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz
+      oas-validator: https://registry.npmmirror.com/oas-validator/-/oas-validator-5.0.8.tgz
+      reftools: https://registry.npmmirror.com/reftools/-/reftools-1.1.9.tgz
+      yaml: https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz
+      yargs: https://registry.npmmirror.com/yargs/-/yargs-16.2.0.tgz
+
+  symbol-observable@https://registry.npmmirror.com/symbol-observable/-/symbol-observable-1.2.0.tgz: {}
+
+  symbol-observable@https://registry.npmmirror.com/symbol-observable/-/symbol-observable-3.0.0.tgz: {}
+
+  terminal-link@https://registry.npmmirror.com/terminal-link/-/terminal-link-2.1.1.tgz:
     dependencies:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
-    dev: true
 
-  registry.npmmirror.com/through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/through/-/through-2.3.8.tgz}
-    name: through
-    version: 2.3.8
-    dev: true
+  through@https://registry.npmmirror.com/through/-/through-2.3.8.tgz: {}
 
-  registry.npmmirror.com/timers-ext@0.1.7:
-    resolution: {integrity: sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/timers-ext/-/timers-ext-0.1.7.tgz}
-    name: timers-ext
-    version: 0.1.7
+  timers-ext@https://registry.npmmirror.com/timers-ext/-/timers-ext-0.1.7.tgz:
     dependencies:
-      es5-ext: registry.npmmirror.com/es5-ext@0.10.62
-      next-tick: registry.npmmirror.com/next-tick@1.1.0
-    dev: false
+      es5-ext: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz
+      next-tick: https://registry.npmmirror.com/next-tick/-/next-tick-1.1.0.tgz
 
-  registry.npmmirror.com/tiny-pinyin@1.3.2:
-    resolution: {integrity: sha512-uHNGu4evFt/8eNLldazeAM1M8JrMc1jshhJJfVRARTN3yT8HEEibofeQ7QETWQ5ISBjd6fKtTVBCC/+mGS6FpA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tiny-pinyin/-/tiny-pinyin-1.3.2.tgz}
-    name: tiny-pinyin
-    version: 1.3.2
-    dev: false
+  tiny-pinyin@https://registry.npmmirror.com/tiny-pinyin/-/tiny-pinyin-1.3.2.tgz: {}
 
-  registry.npmmirror.com/tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tmp/-/tmp-0.0.33.tgz}
-    name: tmp
-    version: 0.0.33
-    engines: {node: '>=0.6.0'}
+  tmp@https://registry.npmmirror.com/tmp/-/tmp-0.0.33.tgz:
     dependencies:
-      os-tmpdir: registry.npmmirror.com/os-tmpdir@1.0.2
-    dev: true
+      os-tmpdir: https://registry.npmmirror.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz
 
-  registry.npmmirror.com/to-readable-stream@1.0.0:
-    resolution: {integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz}
-    name: to-readable-stream
-    version: 1.0.0
-    engines: {node: '>=6'}
-    dev: true
+  to-readable-stream@https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz: {}
 
-  registry.npmmirror.com/to-readable-stream@2.1.0:
-    resolution: {integrity: sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-2.1.0.tgz}
-    name: to-readable-stream
-    version: 2.1.0
-    engines: {node: '>=8'}
-    dev: true
+  to-readable-stream@https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-2.1.0.tgz: {}
 
-  registry.npmmirror.com/to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz}
-    name: to-regex-range
-    version: 5.0.1
-    engines: {node: '>=8.0'}
-    requiresBuild: true
+  to-regex-range@5.0.1:
     dependencies:
-      is-number: registry.npmmirror.com/is-number@7.0.0
-    dev: false
+      is-number: 7.0.0
+
+  to-regex-range@https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz:
+    dependencies:
+      is-number: https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz
     optional: true
 
-  registry.npmmirror.com/tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tslib/-/tslib-1.14.1.tgz}
-    name: tslib
-    version: 1.14.1
-    dev: true
+  trim-newlines@3.0.1: {}
 
-  registry.npmmirror.com/tslib@2.6.0:
-    resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tslib/-/tslib-2.6.0.tgz}
-    name: tslib
-    version: 2.6.0
-    dev: true
+  tslib@https://registry.npmmirror.com/tslib/-/tslib-1.14.1.tgz: {}
 
-  registry.npmmirror.com/type@1.2.0:
-    resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type/-/type-1.2.0.tgz}
-    name: type
-    version: 1.2.0
-    dev: false
+  tslib@https://registry.npmmirror.com/tslib/-/tslib-2.6.0.tgz: {}
 
-  registry.npmmirror.com/type@2.7.2:
-    resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type/-/type-2.7.2.tgz}
-    name: type
-    version: 2.7.2
-    dev: false
+  type-fest@0.10.0: {}
 
-  registry.npmmirror.com/typescript@4.1.3:
-    resolution: {integrity: sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/typescript/-/typescript-4.1.3.tgz}
-    name: typescript
-    version: 4.1.3
-    engines: {node: '>=4.2.0'}
-    hasBin: true
+  type-fest@0.18.1: {}
 
-  registry.npmmirror.com/unique-string@2.0.0:
-    resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unique-string/-/unique-string-2.0.0.tgz}
-    name: unique-string
-    version: 2.0.0
-    engines: {node: '>=8'}
+  type-fest@0.20.2: {}
+
+  type-fest@0.21.3: {}
+
+  type-fest@0.4.1: {}
+
+  type-fest@0.6.0: {}
+
+  type-fest@0.8.1: {}
+
+  type@https://registry.npmmirror.com/type/-/type-1.2.0.tgz: {}
+
+  type@https://registry.npmmirror.com/type/-/type-2.7.2.tgz: {}
+
+  typedarray-to-buffer@3.1.5:
     dependencies:
-      crypto-random-string: registry.npmmirror.com/crypto-random-string@2.0.0
-    dev: true
+      is-typedarray: 1.0.0
 
-  registry.npmmirror.com/update-notifier@5.1.0:
-    resolution: {integrity: sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/update-notifier/-/update-notifier-5.1.0.tgz}
-    name: update-notifier
-    version: 5.1.0
-    engines: {node: '>=10'}
+  typescript@https://registry.npmmirror.com/typescript/-/typescript-4.1.3.tgz: {}
+
+  unique-string@https://registry.npmmirror.com/unique-string/-/unique-string-2.0.0.tgz:
     dependencies:
-      boxen: registry.npmmirror.com/boxen@5.1.2
+      crypto-random-string: https://registry.npmmirror.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz
+
+  update-notifier@https://registry.npmmirror.com/update-notifier/-/update-notifier-5.1.0.tgz:
+    dependencies:
+      boxen: https://registry.npmmirror.com/boxen/-/boxen-5.1.2.tgz
       chalk: 4.1.2
-      configstore: registry.npmmirror.com/configstore@5.0.1
-      has-yarn: registry.npmmirror.com/has-yarn@2.1.0
+      configstore: https://registry.npmmirror.com/configstore/-/configstore-5.0.1.tgz
+      has-yarn: https://registry.npmmirror.com/has-yarn/-/has-yarn-2.1.0.tgz
       import-lazy: 2.1.0
-      is-ci: registry.npmmirror.com/is-ci@2.0.0
-      is-installed-globally: registry.npmmirror.com/is-installed-globally@0.4.0
-      is-npm: registry.npmmirror.com/is-npm@5.0.0
-      is-yarn-global: registry.npmmirror.com/is-yarn-global@0.3.0
-      latest-version: registry.npmmirror.com/latest-version@5.1.0
-      pupa: registry.npmmirror.com/pupa@2.1.1
+      is-ci: https://registry.npmmirror.com/is-ci/-/is-ci-2.0.0.tgz
+      is-installed-globally: https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz
+      is-npm: https://registry.npmmirror.com/is-npm/-/is-npm-5.0.0.tgz
+      is-yarn-global: https://registry.npmmirror.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz
+      latest-version: https://registry.npmmirror.com/latest-version/-/latest-version-5.1.0.tgz
+      pupa: https://registry.npmmirror.com/pupa/-/pupa-2.1.1.tgz
       semver: 7.5.4
-      semver-diff: registry.npmmirror.com/semver-diff@3.1.1
-      xdg-basedir: registry.npmmirror.com/xdg-basedir@4.0.0
-    dev: true
+      semver-diff: https://registry.npmmirror.com/semver-diff/-/semver-diff-3.1.1.tgz
+      xdg-basedir: https://registry.npmmirror.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz
 
-  registry.npmmirror.com/url-parse-lax@3.0.0:
-    resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz}
-    name: url-parse-lax
-    version: 3.0.0
-    engines: {node: '>=4'}
+  url-parse-lax@https://registry.npmmirror.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz:
     dependencies:
-      prepend-http: registry.npmmirror.com/prepend-http@2.0.0
-    dev: true
+      prepend-http: https://registry.npmmirror.com/prepend-http/-/prepend-http-2.0.0.tgz
 
-  registry.npmmirror.com/vali-date@1.0.0:
-    resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vali-date/-/vali-date-1.0.0.tgz}
-    name: vali-date
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dev: true
+  vali-date@https://registry.npmmirror.com/vali-date/-/vali-date-1.0.0.tgz: {}
 
-  registry.npmmirror.com/validate-npm-package-name@3.0.0:
-    resolution: {integrity: sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz}
-    name: validate-npm-package-name
-    version: 3.0.0
+  validate-npm-package-license@3.0.4:
     dependencies:
-      builtins: registry.npmmirror.com/builtins@1.0.3
-    dev: true
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
 
-  registry.npmmirror.com/widest-line@3.1.0:
-    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/widest-line/-/widest-line-3.1.0.tgz}
-    name: widest-line
-    version: 3.1.0
-    engines: {node: '>=8'}
+  validate-npm-package-name@https://registry.npmmirror.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz:
+    dependencies:
+      builtins: https://registry.npmmirror.com/builtins/-/builtins-1.0.3.tgz
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  widest-line@https://registry.npmmirror.com/widest-line/-/widest-line-3.1.0.tgz:
     dependencies:
       string-width: 4.2.3
-    dev: true
 
-  registry.npmmirror.com/wrap-ansi@3.0.1:
-    resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz}
-    name: wrap-ansi
-    version: 3.0.1
-    engines: {node: '>=4'}
+  wrap-ansi@https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz:
     dependencies:
       string-width: 2.1.1
       strip-ansi: 4.0.0
-    dev: true
 
-  registry.npmmirror.com/wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz}
-    name: wrap-ansi
-    version: 7.0.0
-    engines: {node: '>=10'}
+  wrap-ansi@https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz:
     dependencies:
       ansi-styles: 4.3.0
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
+      string-width: https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz
+      strip-ansi: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz
 
-  registry.npmmirror.com/wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz}
-    name: wrappy
-    version: 1.0.2
-    dev: false
+  wrappy@1.0.2: {}
 
-  registry.npmmirror.com/xdg-basedir@4.0.0:
-    resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz}
-    name: xdg-basedir
-    version: 4.0.0
-    engines: {node: '>=8'}
-    dev: true
+  wrappy@https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz: {}
 
-  registry.npmmirror.com/y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz}
-    name: y18n
-    version: 5.0.8
-    engines: {node: '>=10'}
-    dev: false
-
-  registry.npmmirror.com/yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz}
-    name: yaml
-    version: 1.10.2
-    engines: {node: '>= 6'}
-    dev: false
-
-  registry.npmmirror.com/yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs-parser/-/yargs-parser-20.2.9.tgz}
-    name: yargs-parser
-    version: 20.2.9
-    engines: {node: '>=10'}
-    dev: false
-
-  registry.npmmirror.com/yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz}
-    name: yargs-parser
-    version: 21.1.1
-    engines: {node: '>=12'}
-    dev: false
-
-  registry.npmmirror.com/yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs/-/yargs-16.2.0.tgz}
-    name: yargs
-    version: 16.2.0
-    engines: {node: '>=10'}
+  write-file-atomic@3.0.3:
     dependencies:
-      cliui: registry.npmmirror.com/cliui@7.0.4
-      escalade: registry.npmmirror.com/escalade@3.1.1
-      get-caller-file: registry.npmmirror.com/get-caller-file@2.0.5
-      require-directory: registry.npmmirror.com/require-directory@2.1.1
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      y18n: registry.npmmirror.com/y18n@5.0.8
-      yargs-parser: registry.npmmirror.com/yargs-parser@20.2.9
-    dev: false
+      imurmurhash: 0.1.4
+      is-typedarray: 1.0.0
+      signal-exit: 3.0.7
+      typedarray-to-buffer: 3.1.5
 
-  registry.npmmirror.com/yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz}
-    name: yargs
-    version: 17.7.2
-    engines: {node: '>=12'}
+  xdg-basedir@https://registry.npmmirror.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz: {}
+
+  y18n@https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz: {}
+
+  yallist@4.0.0: {}
+
+  yaml@1.10.2: {}
+
+  yaml@https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs-parser@https://registry.npmmirror.com/yargs-parser/-/yargs-parser-20.2.9.tgz: {}
+
+  yargs-parser@https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz: {}
+
+  yargs@https://registry.npmmirror.com/yargs/-/yargs-16.2.0.tgz:
     dependencies:
-      cliui: registry.npmmirror.com/cliui@8.0.1
-      escalade: registry.npmmirror.com/escalade@3.1.1
-      get-caller-file: registry.npmmirror.com/get-caller-file@2.0.5
-      require-directory: registry.npmmirror.com/require-directory@2.1.1
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      y18n: registry.npmmirror.com/y18n@5.0.8
-      yargs-parser: registry.npmmirror.com/yargs-parser@21.1.1
-    dev: false
+      cliui: https://registry.npmmirror.com/cliui/-/cliui-7.0.4.tgz
+      escalade: https://registry.npmmirror.com/escalade/-/escalade-3.1.1.tgz
+      get-caller-file: https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz
+      require-directory: https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz
+      string-width: https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz
+      y18n: https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz
+      yargs-parser: https://registry.npmmirror.com/yargs-parser/-/yargs-parser-20.2.9.tgz
 
-  registry.npmmirror.com/yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz}
-    name: yocto-queue
-    version: 0.1.0
-    engines: {node: '>=10'}
-    dev: true
+  yargs@https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz:
+    dependencies:
+      cliui: https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz
+      escalade: https://registry.npmmirror.com/escalade/-/escalade-3.1.1.tgz
+      get-caller-file: https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz
+      require-directory: https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz
+      string-width: https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz
+      y18n: https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz
+      yargs-parser: https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz
+
+  yocto-queue@https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@umijs/fabric':
-    specifier: ^2.5.6
-    version: registry.npmmirror.com/@umijs/fabric@2.5.6(prettier@2.2.1)
   chalk:
     specifier: ^4.1.2
     version: registry.npmmirror.com/chalk@4.1.2
@@ -73,6 +70,189 @@ devDependencies:
 
 packages:
 
+  /@babel/code-frame@7.22.5:
+    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.22.5
+    dev: true
+
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/highlight@7.22.5:
+    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
+  /@nodelib/fs.scandir@2.1.5:
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+    dev: true
+
+  /@nodelib/fs.stat@2.0.5:
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /@nodelib/fs.walk@1.2.8:
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.15.0
+    dev: true
+
+  /@types/minimist@1.2.2:
+    resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
+    dev: true
+
+  /@types/normalize-package-data@2.4.1:
+    resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
+    dev: true
+
+  /@types/parse-json@4.0.0:
+    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    dev: true
+
+  /ansi-escapes@3.2.0:
+    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.21.3
+    dev: true
+
+  /ansi-regex@2.1.1:
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /ansi-regex@3.0.1:
+    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /ansi-regex@4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /ansi-styles@2.2.1:
+    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: true
+
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: true
+
+  /array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /arrify@1.0.1:
+    resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  /braces@3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
+    dev: true
+
+  /callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /camelcase-keys@6.2.2:
+    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
+    engines: {node: '>=8'}
+    dependencies:
+      camelcase: 5.3.1
+      map-obj: 4.3.0
+      quick-lru: 4.0.1
+    dev: true
+
+  /camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /chalk@1.1.3:
+    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-styles: 2.2.1
+      escape-string-regexp: 1.0.5
+      has-ansi: registry.npmmirror.com/has-ansi@2.0.0
+      strip-ansi: 3.0.1
+      supports-color: 2.0.0
+    dev: true
+
+  /chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: true
+
+  /chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -90,6 +270,128 @@ packages:
     dev: false
     optional: true
 
+  /ci-info@2.0.0:
+    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
+    dev: true
+
+  /color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: true
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: true
+
+  /color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
+
+  /color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  /cross-spawn@7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: true
+
+  /decamelize-keys@1.1.1:
+    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      decamelize: 1.2.0
+      map-obj: 1.0.1
+    dev: true
+
+  /decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-type: 4.0.0
+    dev: true
+
+  /emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
+  /end-of-stream@1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    dependencies:
+      once: 1.4.0
+    dev: true
+
+  /error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    dependencies:
+      is-arrayish: 0.2.1
+    dev: true
+
+  /escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
+  /fast-glob@3.3.0:
+    resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
+
+  /fastq@1.15.0:
+    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
+    dependencies:
+      reusify: 1.0.4
+    dev: true
+
+  /fill-range@7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: true
+
+  /find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+    dev: true
+
+  /find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+    dependencies:
+      locate-path: registry.npmmirror.com/locate-path@6.0.0
+      path-exists: registry.npmmirror.com/path-exists@4.0.0
+    dev: true
+
+  /fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -98,1846 +400,849 @@ packages:
     dev: false
     optional: true
 
-  registry.npmmirror.com/@aashutoshrathi/word-wrap@1.2.6:
-    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz}
-    name: '@aashutoshrathi/word-wrap'
-    version: 1.2.6
+  /function-bind@1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
+
+  /get-stream@4.1.0:
+    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
+    engines: {node: '>=6'}
+    dependencies:
+      pump: 3.0.0
+    dev: true
+
+  /get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+    dependencies:
+      pump: 3.0.0
+    dev: true
+
+  /get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
+  /glob@7.1.6:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
+  /globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.0
+      ignore: 5.2.4
+      merge2: 1.4.1
+      slash: 3.0.0
+    dev: true
+
+  /hard-rejection@2.1.0:
+    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /has@1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: true
+
+  /hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+    dev: true
+
+  /hosted-git-info@4.1.0:
+    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+    engines: {node: '>=10'}
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+    dev: true
+
+  /ignore@5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+    engines: {node: '>= 4'}
+    dev: true
+
+  /import-fresh@3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    dev: true
+
+  /import-lazy@2.1.0:
+    resolution: {integrity: sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+    dev: true
+
+  /indent-string@3.2.0:
+    resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
+  /inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
+
+  /ini@1.3.7:
+    resolution: {integrity: sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==}
+    dev: true
+
+  /ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: true
+
+  /ini@2.0.0:
+    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: true
+
+  /is-core-module@2.12.1:
+    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
+  /is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
+    dev: true
 
-  registry.npmmirror.com/@ampproject/remapping@2.2.1:
-    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@ampproject/remapping/-/remapping-2.2.1.tgz}
-    name: '@ampproject/remapping'
-    version: 2.2.1
-    engines: {node: '>=6.0.0'}
+  /is-fullwidth-code-point@1.0.0:
+    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
+    engines: {node: '>=0.10.0'}
     dependencies:
-      '@jridgewell/gen-mapping': registry.npmmirror.com/@jridgewell/gen-mapping@0.3.3
-      '@jridgewell/trace-mapping': registry.npmmirror.com/@jridgewell/trace-mapping@0.3.18
-    dev: false
+      number-is-nan: registry.npmmirror.com/number-is-nan@1.0.1
+    dev: true
 
-  registry.npmmirror.com/@babel/code-frame@7.12.11:
-    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.12.11.tgz}
-    name: '@babel/code-frame'
-    version: 7.12.11
+  /is-fullwidth-code-point@2.0.0:
+    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
     dependencies:
-      '@babel/highlight': registry.npmmirror.com/@babel/highlight@7.22.5
-    dev: false
+      is-extglob: 2.1.1
+    dev: true
 
-  registry.npmmirror.com/@babel/code-frame@7.22.5:
-    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.22.5.tgz}
-    name: '@babel/code-frame'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
+  /is-plain-obj@1.1.0:
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-stream@1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+    dev: true
+
+  /is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /json-buffer@3.0.0:
+    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
+    dev: true
+
+  /json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
+  /json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: true
+
+  /keyv@3.1.0:
+    resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
     dependencies:
-      '@babel/highlight': registry.npmmirror.com/@babel/highlight@7.22.5
+      json-buffer: 3.0.0
+    dev: true
 
-  registry.npmmirror.com/@babel/compat-data@7.22.6:
-    resolution: {integrity: sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/compat-data/-/compat-data-7.22.6.tgz}
-    name: '@babel/compat-data'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
-    dev: false
-
-  registry.npmmirror.com/@babel/core@7.22.8:
-    resolution: {integrity: sha512-75+KxFB4CZqYRXjx4NlR4J7yGvKumBuZTmV4NV6v09dVXXkuYVYLT68N6HCzLvfJ+fWCxQsntNzKwwIXL4bHnw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/core/-/core-7.22.8.tgz}
-    name: '@babel/core'
-    version: 7.22.8
-    engines: {node: '>=6.9.0'}
+  /keyv@4.5.2:
+    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
     dependencies:
-      '@ampproject/remapping': registry.npmmirror.com/@ampproject/remapping@2.2.1
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.22.5
-      '@babel/generator': registry.npmmirror.com/@babel/generator@7.22.7
-      '@babel/helper-compilation-targets': registry.npmmirror.com/@babel/helper-compilation-targets@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-module-transforms': registry.npmmirror.com/@babel/helper-module-transforms@7.22.5
-      '@babel/helpers': registry.npmmirror.com/@babel/helpers@7.22.6
-      '@babel/parser': registry.npmmirror.com/@babel/parser@7.22.7
-      '@babel/template': registry.npmmirror.com/@babel/template@7.22.5
-      '@babel/traverse': registry.npmmirror.com/@babel/traverse@7.22.8
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-      '@nicolo-ribaudo/semver-v6': registry.npmmirror.com/@nicolo-ribaudo/semver-v6@6.3.3
-      convert-source-map: registry.npmmirror.com/convert-source-map@1.9.0
-      debug: registry.npmmirror.com/debug@4.3.4
-      gensync: registry.npmmirror.com/gensync@1.0.0-beta.2
-      json5: registry.npmmirror.com/json5@2.2.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      json-buffer: 3.0.1
+    dev: true
 
-  registry.npmmirror.com/@babel/eslint-parser@7.22.7(@babel/core@7.22.8)(eslint@7.32.0):
-    resolution: {integrity: sha512-LH6HJqjOyu/Qtp7LuSycZXK/CYXQ4ohdkliEaL1QTdtOXVdOVpTBKVxAo/+eeyt+x/2SRzB+zUPduVl+xiEvdg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/eslint-parser/-/eslint-parser-7.22.7.tgz}
-    id: registry.npmmirror.com/@babel/eslint-parser/7.22.7
-    name: '@babel/eslint-parser'
-    version: 7.22.7
-    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
-    peerDependencies:
-      '@babel/core': '>=7.11.0'
-      eslint: ^7.5.0 || ^8.0.0
+  /kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    dev: true
+
+  /locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@nicolo-ribaudo/eslint-scope-5-internals': registry.npmmirror.com/@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1
-      '@nicolo-ribaudo/semver-v6': registry.npmmirror.com/@nicolo-ribaudo/semver-v6@6.3.3
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys@2.1.0
-    dev: false
+      p-locate: 4.1.0
+    dev: true
 
-  registry.npmmirror.com/@babel/generator@7.22.7:
-    resolution: {integrity: sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/generator/-/generator-7.22.7.tgz}
-    name: '@babel/generator'
-    version: 7.22.7
-    engines: {node: '>=6.9.0'}
+  /lodash.zip@4.2.0:
+    resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
+    dev: true
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
+  /log-symbols@1.0.2:
+    resolution: {integrity: sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==}
+    engines: {node: '>=0.10.0'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-      '@jridgewell/gen-mapping': registry.npmmirror.com/@jridgewell/gen-mapping@0.3.3
-      '@jridgewell/trace-mapping': registry.npmmirror.com/@jridgewell/trace-mapping@0.3.18
-      jsesc: registry.npmmirror.com/jsesc@2.5.2
-    dev: false
+      chalk: 1.1.3
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5:
-    resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz}
-    name: '@babel/helper-annotate-as-pure'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      yallist: 4.0.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-builder-binary-assignment-operator-visitor@7.22.5:
-    resolution: {integrity: sha512-m1EP3lVOPptR+2DwD125gziZNcmoNSHGmJROKoy87loWUQyJaVXDgpmruWqDARZSmtYQ+Dl25okU8+qhVzuykw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.5.tgz}
-    name: '@babel/helper-builder-binary-assignment-operator-visitor'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /map-age-cleaner@0.1.3:
+    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
+    engines: {node: '>=6'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      p-defer: 1.0.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-compilation-targets@7.22.6(@babel/core@7.22.8):
-    resolution: {integrity: sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz}
-    id: registry.npmmirror.com/@babel/helper-compilation-targets/7.22.6
-    name: '@babel/helper-compilation-targets'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
+  /map-obj@1.0.1:
+    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: true
+
+  /merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /micromatch@4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
     dependencies:
-      '@babel/compat-data': registry.npmmirror.com/@babel/compat-data@7.22.6
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-validator-option': registry.npmmirror.com/@babel/helper-validator-option@7.22.5
-      '@nicolo-ribaudo/semver-v6': registry.npmmirror.com/@nicolo-ribaudo/semver-v6@6.3.3
-      browserslist: registry.npmmirror.com/browserslist@4.21.9
-      lru-cache: registry.npmmirror.com/lru-cache@5.1.1
-    dev: false
+      braces: 3.0.2
+      picomatch: 2.3.1
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.8):
-    resolution: {integrity: sha512-iwdzgtSiBxF6ni6mzVnZCF3xt5qE6cEA0J7nFt8QOAWZ0zjCFceEgpn3vtb2V7WFR6QzP2jmIFOHMTRo7eNJjQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.6.tgz}
-    id: registry.npmmirror.com/@babel/helper-create-class-features-plugin/7.22.6
-    name: '@babel/helper-create-class-features-plugin'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
+  /mimic-fn@1.2.0:
+    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /mimic-fn@3.1.0:
+    resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-annotate-as-pure': registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5
-      '@babel/helper-environment-visitor': registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5
-      '@babel/helper-function-name': registry.npmmirror.com/@babel/helper-function-name@7.22.5
-      '@babel/helper-member-expression-to-functions': registry.npmmirror.com/@babel/helper-member-expression-to-functions@7.22.5
-      '@babel/helper-optimise-call-expression': registry.npmmirror.com/@babel/helper-optimise-call-expression@7.22.5
-      '@babel/helper-replace-supers': registry.npmmirror.com/@babel/helper-replace-supers@7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': registry.npmmirror.com/@babel/helper-skip-transparent-expression-wrappers@7.22.5
-      '@babel/helper-split-export-declaration': registry.npmmirror.com/@babel/helper-split-export-declaration@7.22.6
-      '@nicolo-ribaudo/semver-v6': registry.npmmirror.com/@nicolo-ribaudo/semver-v6@6.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      brace-expansion: 1.1.11
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-create-regexp-features-plugin@7.22.6(@babel/core@7.22.8):
-    resolution: {integrity: sha512-nBookhLKxAWo/TUCmhnaEJyLz2dekjQvv5SRpE9epWQBcpedWLKt8aZdsuT9XV5ovzR3fENLjRXVT0GsSlGGhA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.6.tgz}
-    id: registry.npmmirror.com/@babel/helper-create-regexp-features-plugin/7.22.6
-    name: '@babel/helper-create-regexp-features-plugin'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
+  /minimist-options@4.1.0:
+    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
+    engines: {node: '>= 6'}
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-annotate-as-pure': registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5
-      '@nicolo-ribaudo/semver-v6': registry.npmmirror.com/@nicolo-ribaudo/semver-v6@6.3.3
-      regexpu-core: registry.npmmirror.com/regexpu-core@5.3.2
-    dev: false
+      arrify: 1.0.1
+      is-plain-obj: 1.1.0
+      kind-of: 6.0.3
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-define-polyfill-provider@0.4.1(@babel/core@7.22.8):
-    resolution: {integrity: sha512-kX4oXixDxG197yhX+J3Wp+NpL2wuCFjWQAr6yX2jtCnflK9ulMI51ULFGIrWiX1jGfvAxdHp+XQCcP2bZGPs9A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.1.tgz}
-    id: registry.npmmirror.com/@babel/helper-define-polyfill-provider/0.4.1
-    name: '@babel/helper-define-polyfill-provider'
-    version: 0.4.1
-    peerDependencies:
-      '@babel/core': ^7.4.0-0
+  /minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: true
+
+  /normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-compilation-targets': registry.npmmirror.com/@babel/helper-compilation-targets@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      debug: registry.npmmirror.com/debug@4.3.4
-      lodash.debounce: registry.npmmirror.com/lodash.debounce@4.0.8
-      resolve: registry.npmmirror.com/resolve@1.22.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      hosted-git-info: 2.8.9
+      resolve: 1.22.2
+      semver: 5.7.1
+      validate-npm-package-license: 3.0.4
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5:
-    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz}
-    name: '@babel/helper-environment-visitor'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    dev: false
-
-  registry.npmmirror.com/@babel/helper-function-name@7.22.5:
-    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz}
-    name: '@babel/helper-function-name'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /normalize-package-data@3.0.3:
+    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
+    engines: {node: '>=10'}
     dependencies:
-      '@babel/template': registry.npmmirror.com/@babel/template@7.22.5
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      hosted-git-info: 4.1.0
+      is-core-module: 2.12.1
+      semver: 7.5.4
+      validate-npm-package-license: 3.0.4
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-hoist-variables@7.22.5:
-    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz}
-    name: '@babel/helper-hoist-variables'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      path-key: 3.1.1
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-member-expression-to-functions@7.22.5:
-    resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.5.tgz}
-    name: '@babel/helper-member-expression-to-functions'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      wrappy: 1.0.2
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-module-imports@7.22.5:
-    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz}
-    name: '@babel/helper-module-imports'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /onetime@2.0.1:
+    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
+    engines: {node: '>=4'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      mimic-fn: 1.2.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-module-transforms@7.22.5:
-    resolution: {integrity: sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz}
-    name: '@babel/helper-module-transforms'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
     dependencies:
-      '@babel/helper-environment-visitor': registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5
-      '@babel/helper-module-imports': registry.npmmirror.com/@babel/helper-module-imports@7.22.5
-      '@babel/helper-simple-access': registry.npmmirror.com/@babel/helper-simple-access@7.22.5
-      '@babel/helper-split-export-declaration': registry.npmmirror.com/@babel/helper-split-export-declaration@7.22.6
-      '@babel/helper-validator-identifier': registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5
-      '@babel/template': registry.npmmirror.com/@babel/template@7.22.5
-      '@babel/traverse': registry.npmmirror.com/@babel/traverse@7.22.8
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      mimic-fn: 2.1.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-optimise-call-expression@7.22.5:
-    resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz}
-    name: '@babel/helper-optimise-call-expression'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /p-defer@1.0.0:
+    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      p-try: 2.2.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5:
-    resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz}
-    name: '@babel/helper-plugin-utils'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    dev: false
-
-  registry.npmmirror.com/@babel/helper-remap-async-to-generator@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-cU0Sq1Rf4Z55fgz7haOakIyM7+x/uCFwXpLPaeRzfoUtAEAuUZjZvFPjL/rk5rW693dIgn2hng1W7xbT7lWT4g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/helper-remap-async-to-generator/7.22.5
-    name: '@babel/helper-remap-async-to-generator'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
+  /p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-annotate-as-pure': registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5
-      '@babel/helper-environment-visitor': registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5
-      '@babel/helper-wrap-function': registry.npmmirror.com/@babel/helper-wrap-function@7.22.5
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      yocto-queue: registry.npmmirror.com/yocto-queue@0.1.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-replace-supers@7.22.5:
-    resolution: {integrity: sha512-aLdNM5I3kdI/V9xGNyKSF3X/gTyMUBohTZ+/3QdQKAA9vxIiy12E+8E2HoOP1/DjeqU+g6as35QHJNMDDYpuCg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-replace-supers/-/helper-replace-supers-7.22.5.tgz}
-    name: '@babel/helper-replace-supers'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-environment-visitor': registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5
-      '@babel/helper-member-expression-to-functions': registry.npmmirror.com/@babel/helper-member-expression-to-functions@7.22.5
-      '@babel/helper-optimise-call-expression': registry.npmmirror.com/@babel/helper-optimise-call-expression@7.22.5
-      '@babel/template': registry.npmmirror.com/@babel/template@7.22.5
-      '@babel/traverse': registry.npmmirror.com/@babel/traverse@7.22.8
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      p-limit: 2.3.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-simple-access@7.22.5:
-    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz}
-    name: '@babel/helper-simple-access'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      p-limit: 3.1.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-skip-transparent-expression-wrappers@7.22.5:
-    resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz}
-    name: '@babel/helper-skip-transparent-expression-wrappers'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      callsites: 3.1.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-split-export-declaration@7.22.6:
-    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz}
-    name: '@babel/helper-split-export-declaration'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
+  /parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      '@babel/code-frame': 7.22.5
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-string-parser@7.22.5:
-    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz}
-    name: '@babel/helper-string-parser'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    dev: false
+  /path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5:
-    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz}
-    name: '@babel/helper-validator-identifier'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-validator-option@7.22.5:
-    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz}
-    name: '@babel/helper-validator-option'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    dev: false
+  /path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+    dev: true
 
-  registry.npmmirror.com/@babel/helper-wrap-function@7.22.5:
-    resolution: {integrity: sha512-bYqLIBSEshYcYQyfks8ewYA8S30yaGSeRslcvKMvoUk6HHPySbxHq9YRi6ghhzEU+yhQv9bP/jXnygkStOcqZw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helper-wrap-function/-/helper-wrap-function-7.22.5.tgz}
-    name: '@babel/helper-wrap-function'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
+  /pump@3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
-      '@babel/helper-function-name': registry.npmmirror.com/@babel/helper-function-name@7.22.5
-      '@babel/template': registry.npmmirror.com/@babel/template@7.22.5
-      '@babel/traverse': registry.npmmirror.com/@babel/traverse@7.22.8
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      end-of-stream: 1.4.4
+      once: 1.4.0
+    dev: true
 
-  registry.npmmirror.com/@babel/helpers@7.22.6:
-    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/helpers/-/helpers-7.22.6.tgz}
-    name: '@babel/helpers'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
+  /queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
+  /quick-lru@4.0.1:
+    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
     dependencies:
-      '@babel/template': registry.npmmirror.com/@babel/template@7.22.5
-      '@babel/traverse': registry.npmmirror.com/@babel/traverse@7.22.8
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+    dev: true
 
-  registry.npmmirror.com/@babel/highlight@7.22.5:
-    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/highlight/-/highlight-7.22.5.tgz}
-    name: '@babel/highlight'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-validator-identifier': registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5
-      chalk: registry.npmmirror.com/chalk@2.4.2
-      js-tokens: registry.npmmirror.com/js-tokens@4.0.0
+      '@types/normalize-package-data': 2.4.1
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
+    dev: true
 
-  registry.npmmirror.com/@babel/parser@7.22.7:
-    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/parser/-/parser-7.22.7.tgz}
-    name: '@babel/parser'
-    version: 7.22.7
-    engines: {node: '>=6.0.0'}
+  /redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+    dev: true
+
+  /resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /resolve@1.22.2:
+    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
     dependencies:
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
+      is-core-module: 2.12.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
 
-  registry.npmmirror.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.22.5
-    name: '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
+  /reusify@1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: true
+
+  /rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
+      glob: 7.1.6
+    dev: true
 
-  registry.npmmirror.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-31Bb65aZaUwqCbWMnZPduIZxCBngHFlzyN6Dq6KAJjtx+lx6ohKHubc61OomYi7XwVD4Ol0XCVz4h+pYFR048g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.22.5
-    name: '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.13.0
+  /run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': registry.npmmirror.com/@babel/helper-skip-transparent-expression-wrappers@7.22.5
-      '@babel/plugin-transform-optional-chaining': registry.npmmirror.com/@babel/plugin-transform-optional-chaining@7.22.6(@babel/core@7.22.8)
-    dev: false
+      queue-microtask: 1.2.3
+    dev: true
 
-  registry.npmmirror.com/@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.8):
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz}
-    id: registry.npmmirror.com/@babel/plugin-proposal-class-properties/7.18.6
-    name: '@babel/plugin-proposal-class-properties'
-    version: 7.18.6
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
+  /semver@5.7.1:
+    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+    hasBin: true
+    dev: true
+
+  /semver@6.3.0:
+    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    hasBin: true
+    dev: true
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-class-features-plugin': registry.npmmirror.com/@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      lru-cache: 6.0.0
+    dev: true
 
-  registry.npmmirror.com/@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.8):
-    resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz}
-    id: registry.npmmirror.com/@babel/plugin-proposal-private-property-in-object/7.21.0-placeholder-for-preset-env.2
-    name: '@babel/plugin-proposal-private-property-in-object'
-    version: 7.21.0-placeholder-for-preset-env.2
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
+  /shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-    dev: false
+      shebang-regex: 3.0.0
+    dev: true
 
-  registry.npmmirror.com/@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.22.8):
-    resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz}
-    id: registry.npmmirror.com/@babel/plugin-proposal-unicode-property-regex/7.18.6
-    name: '@babel/plugin-proposal-unicode-property-regex'
-    version: 7.18.6
+  /shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
+
+  /slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /slice-ansi@0.0.4:
+    resolution: {integrity: sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.13
+    dev: true
+
+  /spdx-exceptions@2.3.0:
+    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
+    dev: true
+
+  /spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    dependencies:
+      spdx-exceptions: 2.3.0
+      spdx-license-ids: 3.0.13
+    dev: true
+
+  /spdx-license-ids@3.0.13:
+    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
+    dev: true
+
+  /string-width@1.0.2:
+    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      code-point-at: registry.npmmirror.com/code-point-at@1.1.0
+      is-fullwidth-code-point: 1.0.0
+      strip-ansi: 3.0.1
+    dev: true
+
+  /string-width@2.1.1:
+    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
     engines: {node: '>=4'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-regexp-features-plugin': registry.npmmirror.com/@babel/helper-create-regexp-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 4.0.0
+    dev: true
 
-  registry.npmmirror.com/@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.8):
-    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-async-generators/7.8.4
-    name: '@babel/plugin-syntax-async-generators'
-    version: 7.8.4
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
+  /string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
     dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
 
-  registry.npmmirror.com/@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.22.8):
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-class-properties/7.12.13
-    name: '@babel/plugin-syntax-class-properties'
-    version: 7.12.13
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-class-static-block/7.14.5
-    name: '@babel/plugin-syntax-class-static-block'
-    version: 7.14.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.8):
-    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-dynamic-import/7.8.3
-    name: '@babel/plugin-syntax-dynamic-import'
-    version: 7.8.3
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.8):
-    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-export-namespace-from/7.8.3
-    name: '@babel/plugin-syntax-export-namespace-from'
-    version: 7.8.3
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-import-assertions/7.22.5
-    name: '@babel/plugin-syntax-import-assertions'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-import-attributes/7.22.5
-    name: '@babel/plugin-syntax-import-attributes'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.22.8):
-    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-import-meta/7.10.4
-    name: '@babel/plugin-syntax-import-meta'
-    version: 7.10.4
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.22.8):
-    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-json-strings/7.8.3
-    name: '@babel/plugin-syntax-json-strings'
-    version: 7.8.3
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-jsx/7.22.5
-    name: '@babel/plugin-syntax-jsx'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.22.8):
-    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-logical-assignment-operators/7.10.4
-    name: '@babel/plugin-syntax-logical-assignment-operators'
-    version: 7.10.4
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.8):
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-nullish-coalescing-operator/7.8.3
-    name: '@babel/plugin-syntax-nullish-coalescing-operator'
-    version: 7.8.3
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.22.8):
-    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-numeric-separator/7.10.4
-    name: '@babel/plugin-syntax-numeric-separator'
-    version: 7.10.4
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.8):
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-object-rest-spread/7.8.3
-    name: '@babel/plugin-syntax-object-rest-spread'
-    version: 7.8.3
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.22.8):
-    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-optional-catch-binding/7.8.3
-    name: '@babel/plugin-syntax-optional-catch-binding'
-    version: 7.8.3
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.8):
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-optional-chaining/7.8.3
-    name: '@babel/plugin-syntax-optional-chaining'
-    version: 7.8.3
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-private-property-in-object/7.14.5
-    name: '@babel/plugin-syntax-private-property-in-object'
-    version: 7.14.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-top-level-await/7.14.5
-    name: '@babel/plugin-syntax-top-level-await'
-    version: 7.14.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-typescript/7.22.5
-    name: '@babel/plugin-syntax-typescript'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.8):
-    resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz}
-    id: registry.npmmirror.com/@babel/plugin-syntax-unicode-sets-regex/7.18.6
-    name: '@babel/plugin-syntax-unicode-sets-regex'
-    version: 7.18.6
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-regexp-features-plugin': registry.npmmirror.com/@babel/helper-create-regexp-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-arrow-functions/7.22.5
-    name: '@babel/plugin-transform-arrow-functions'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-async-generator-functions@7.22.7(@babel/core@7.22.8):
-    resolution: {integrity: sha512-7HmE7pk/Fmke45TODvxvkxRMV9RazV+ZZzhOL9AG8G29TLrr3jkjwF7uJfxZ30EoXpO+LJkq4oA8NjO2DTnEDg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.7.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-async-generator-functions/7.22.7
-    name: '@babel/plugin-transform-async-generator-functions'
-    version: 7.22.7
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-environment-visitor': registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-remap-async-to-generator': registry.npmmirror.com/@babel/helper-remap-async-to-generator@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-syntax-async-generators': registry.npmmirror.com/@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-async-to-generator/7.22.5
-    name: '@babel/plugin-transform-async-to-generator'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-module-imports': registry.npmmirror.com/@babel/helper-module-imports@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-remap-async-to-generator': registry.npmmirror.com/@babel/helper-remap-async-to-generator@7.22.5(@babel/core@7.22.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-block-scoped-functions/7.22.5
-    name: '@babel/plugin-transform-block-scoped-functions'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-block-scoping/7.22.5
-    name: '@babel/plugin-transform-block-scoping'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-nDkQ0NfkOhPTq8YCLiWNxp1+f9fCobEjCb0n8WdbNUBc4IB5V7P1QnX9IjpSoquKrXF5SKojHleVNs2vGeHCHQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-class-properties/7.22.5
-    name: '@babel/plugin-transform-class-properties'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-class-features-plugin': registry.npmmirror.com/@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-SPToJ5eYZLxlnp1UzdARpOGeC2GbHvr9d/UV0EukuVx8atktg194oe+C5BqQ8jRTkgLRVOPYeXRSBg1IlMoVRA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-class-static-block/7.22.5
-    name: '@babel/plugin-transform-class-static-block'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.12.0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-class-features-plugin': registry.npmmirror.com/@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-class-static-block': registry.npmmirror.com/@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-classes@7.22.6(@babel/core@7.22.8):
-    resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.6.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-classes/7.22.6
-    name: '@babel/plugin-transform-classes'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-annotate-as-pure': registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5
-      '@babel/helper-compilation-targets': registry.npmmirror.com/@babel/helper-compilation-targets@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-environment-visitor': registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5
-      '@babel/helper-function-name': registry.npmmirror.com/@babel/helper-function-name@7.22.5
-      '@babel/helper-optimise-call-expression': registry.npmmirror.com/@babel/helper-optimise-call-expression@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-replace-supers': registry.npmmirror.com/@babel/helper-replace-supers@7.22.5
-      '@babel/helper-split-export-declaration': registry.npmmirror.com/@babel/helper-split-export-declaration@7.22.6
-      globals: registry.npmmirror.com/globals@11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-computed-properties/7.22.5
-    name: '@babel/plugin-transform-computed-properties'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/template': registry.npmmirror.com/@babel/template@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-destructuring@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-destructuring/7.22.5
-    name: '@babel/plugin-transform-destructuring'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-dotall-regex/7.22.5
-    name: '@babel/plugin-transform-dotall-regex'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-regexp-features-plugin': registry.npmmirror.com/@babel/helper-create-regexp-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-duplicate-keys/7.22.5
-    name: '@babel/plugin-transform-duplicate-keys'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-0MC3ppTB1AMxd8fXjSrbPa7LT9hrImt+/fcj+Pg5YMD7UQyWp/02+JWpdnCymmsXwIx5Z+sYn1bwCn4ZJNvhqQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-dynamic-import/7.22.5
-    name: '@babel/plugin-transform-dynamic-import'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-dynamic-import': registry.npmmirror.com/@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-exponentiation-operator/7.22.5
-    name: '@babel/plugin-transform-exponentiation-operator'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-builder-binary-assignment-operator-visitor': registry.npmmirror.com/@babel/helper-builder-binary-assignment-operator-visitor@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-X4hhm7FRnPgd4nDA4b/5V280xCx6oL7Oob5+9qVS5C13Zq4bh1qq7LU0GgRU6b5dBWBvhGaXYVB4AcN6+ol6vg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-export-namespace-from/7.22.5
-    name: '@babel/plugin-transform-export-namespace-from'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-export-namespace-from': registry.npmmirror.com/@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-for-of@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-for-of/7.22.5
-    name: '@babel/plugin-transform-for-of'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-function-name@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-function-name/7.22.5
-    name: '@babel/plugin-transform-function-name'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-compilation-targets': registry.npmmirror.com/@babel/helper-compilation-targets@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-function-name': registry.npmmirror.com/@babel/helper-function-name@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-DuCRB7fu8MyTLbEQd1ew3R85nx/88yMoqo2uPSjevMj3yoN7CDM8jkgrY0wmVxfJZyJ/B9fE1iq7EQppWQmR5A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-json-strings/7.22.5
-    name: '@babel/plugin-transform-json-strings'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-json-strings': registry.npmmirror.com/@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-literals@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-literals/7.22.5
-    name: '@babel/plugin-transform-literals'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-MQQOUW1KL8X0cDWfbwYP+TbVbZm16QmQXJQ+vndPtH/BoO0lOKpVoEDMI7+PskYxH+IiE0tS8xZye0qr1lGzSA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-logical-assignment-operators/7.22.5
-    name: '@babel/plugin-transform-logical-assignment-operators'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-logical-assignment-operators': registry.npmmirror.com/@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-member-expression-literals/7.22.5
-    name: '@babel/plugin-transform-member-expression-literals'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-modules-amd/7.22.5
-    name: '@babel/plugin-transform-modules-amd'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-module-transforms': registry.npmmirror.com/@babel/helper-module-transforms@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-modules-commonjs/7.22.5
-    name: '@babel/plugin-transform-modules-commonjs'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-module-transforms': registry.npmmirror.com/@babel/helper-module-transforms@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-simple-access': registry.npmmirror.com/@babel/helper-simple-access@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-modules-systemjs/7.22.5
-    name: '@babel/plugin-transform-modules-systemjs'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-hoist-variables': registry.npmmirror.com/@babel/helper-hoist-variables@7.22.5
-      '@babel/helper-module-transforms': registry.npmmirror.com/@babel/helper-module-transforms@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-validator-identifier': registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-modules-umd/7.22.5
-    name: '@babel/plugin-transform-modules-umd'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-module-transforms': registry.npmmirror.com/@babel/helper-module-transforms@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-named-capturing-groups-regex/7.22.5
-    name: '@babel/plugin-transform-named-capturing-groups-regex'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-regexp-features-plugin': registry.npmmirror.com/@babel/helper-create-regexp-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-new-target@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-new-target/7.22.5
-    name: '@babel/plugin-transform-new-target'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-6CF8g6z1dNYZ/VXok5uYkkBBICHZPiGEl7oDnAx2Mt1hlHVHOSIKWJaXHjQJA5VB43KZnXZDIexMchY4y2PGdA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-nullish-coalescing-operator/7.22.5
-    name: '@babel/plugin-transform-nullish-coalescing-operator'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': registry.npmmirror.com/@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-NbslED1/6M+sXiwwtcAB/nieypGw02Ejf4KtDeMkCEpP6gWFMX1wI9WKYua+4oBneCCEmulOkRpwywypVZzs/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-numeric-separator/7.22.5
-    name: '@babel/plugin-transform-numeric-separator'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-numeric-separator': registry.npmmirror.com/@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-Kk3lyDmEslH9DnvCDA1s1kkd3YWQITiBOHngOtDL9Pt6BZjzqb6hiOlb8VfjiiQJ2unmegBqZu0rx5RxJb5vmQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-object-rest-spread/7.22.5
-    name: '@babel/plugin-transform-object-rest-spread'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': registry.npmmirror.com/@babel/compat-data@7.22.6
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-compilation-targets': registry.npmmirror.com/@babel/helper-compilation-targets@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-object-rest-spread': registry.npmmirror.com/@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.8)
-      '@babel/plugin-transform-parameters': registry.npmmirror.com/@babel/plugin-transform-parameters@7.22.5(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-object-super@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-object-super/7.22.5
-    name: '@babel/plugin-transform-object-super'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-replace-supers': registry.npmmirror.com/@babel/helper-replace-supers@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-pH8orJahy+hzZje5b8e2QIlBWQvGpelS76C63Z+jhZKsmzfNaPQ+LaW6dcJ9bxTpo1mtXbgHwy765Ro3jftmUg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-optional-catch-binding/7.22.5
-    name: '@babel/plugin-transform-optional-catch-binding'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-optional-catch-binding': registry.npmmirror.com/@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-optional-chaining@7.22.6(@babel/core@7.22.8):
-    resolution: {integrity: sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.6.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-optional-chaining/7.22.6
-    name: '@babel/plugin-transform-optional-chaining'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': registry.npmmirror.com/@babel/helper-skip-transparent-expression-wrappers@7.22.5
-      '@babel/plugin-syntax-optional-chaining': registry.npmmirror.com/@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-parameters@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-parameters/7.22.5
-    name: '@babel/plugin-transform-parameters'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-PPjh4gyrQnGe97JTalgRGMuU4icsZFnWkzicB/fUtzlKUqvsWBKEpPPfr5a2JiyirZkHxnAqkQMO5Z5B2kK3fA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-private-methods/7.22.5
-    name: '@babel/plugin-transform-private-methods'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-class-features-plugin': registry.npmmirror.com/@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-/9xnaTTJcVoBtSSmrVyhtSvO3kbqS2ODoh2juEU72c3aYonNF0OMGiaz2gjukyKM2wBBYJP38S4JiE0Wfb5VMQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-private-property-in-object/7.22.5
-    name: '@babel/plugin-transform-private-property-in-object'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-annotate-as-pure': registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5
-      '@babel/helper-create-class-features-plugin': registry.npmmirror.com/@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-private-property-in-object': registry.npmmirror.com/@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-property-literals/7.22.5
-    name: '@babel/plugin-transform-property-literals'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-react-display-name/7.22.5
-    name: '@babel/plugin-transform-react-display-name'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-react-jsx-development/7.22.5
-    name: '@babel/plugin-transform-react-jsx-development'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/plugin-transform-react-jsx': registry.npmmirror.com/@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-react-jsx/7.22.5
-    name: '@babel/plugin-transform-react-jsx'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-annotate-as-pure': registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5
-      '@babel/helper-module-imports': registry.npmmirror.com/@babel/helper-module-imports@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-jsx': registry.npmmirror.com/@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.8)
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-react-pure-annotations/7.22.5
-    name: '@babel/plugin-transform-react-pure-annotations'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-annotate-as-pure': registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-regenerator/7.22.5
-    name: '@babel/plugin-transform-regenerator'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      regenerator-transform: registry.npmmirror.com/regenerator-transform@0.15.1
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-reserved-words/7.22.5
-    name: '@babel/plugin-transform-reserved-words'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-shorthand-properties/7.22.5
-    name: '@babel/plugin-transform-shorthand-properties'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-spread@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-spread/7.22.5
-    name: '@babel/plugin-transform-spread'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': registry.npmmirror.com/@babel/helper-skip-transparent-expression-wrappers@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-sticky-regex/7.22.5
-    name: '@babel/plugin-transform-sticky-regex'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-template-literals/7.22.5
-    name: '@babel/plugin-transform-template-literals'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-typeof-symbol/7.22.5
-    name: '@babel/plugin-transform-typeof-symbol'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-typescript@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-SMubA9S7Cb5sGSFFUlqxyClTA9zWJ8qGQrppNUm05LtFuN1ELRFNndkix4zUJrC9F+YivWwa1dHMSyo0e0N9dA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-typescript/7.22.5
-    name: '@babel/plugin-transform-typescript'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-annotate-as-pure': registry.npmmirror.com/@babel/helper-annotate-as-pure@7.22.5
-      '@babel/helper-create-class-features-plugin': registry.npmmirror.com/@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-syntax-typescript': registry.npmmirror.com/@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.22.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-unicode-escapes@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-unicode-escapes/7.22.5
-    name: '@babel/plugin-transform-unicode-escapes'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-HCCIb+CbJIAE6sXn5CjFQXMwkCClcOfPCzTlilJ8cUatfzwHlWQkbtV0zD338u9dZskwvuOYTuuaMaA8J5EI5A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-unicode-property-regex/7.22.5
-    name: '@babel/plugin-transform-unicode-property-regex'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-regexp-features-plugin': registry.npmmirror.com/@babel/helper-create-regexp-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-unicode-regex/7.22.5
-    name: '@babel/plugin-transform-unicode-regex'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-regexp-features-plugin': registry.npmmirror.com/@babel/helper-create-regexp-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-lhMfi4FC15j13eKrh3DnYHjpGj6UKQHtNKTbtc1igvAhRy4+kLhV07OpLcsN0VgDEw/MjAvJO4BdMJsHwMhzCg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/plugin-transform-unicode-sets-regex/7.22.5
-    name: '@babel/plugin-transform-unicode-sets-regex'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-create-regexp-features-plugin': registry.npmmirror.com/@babel/helper-create-regexp-features-plugin@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/preset-env@7.22.7(@babel/core@7.22.8):
-    resolution: {integrity: sha512-1whfDtW+CzhETuzYXfcgZAh8/GFMeEbz0V5dVgya8YeJyCU6Y/P2Gnx4Qb3MylK68Zu9UiwUvbPMPTpFAOJ+sQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/preset-env/-/preset-env-7.22.7.tgz}
-    id: registry.npmmirror.com/@babel/preset-env/7.22.7
-    name: '@babel/preset-env'
-    version: 7.22.7
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': registry.npmmirror.com/@babel/compat-data@7.22.6
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-compilation-targets': registry.npmmirror.com/@babel/helper-compilation-targets@7.22.6(@babel/core@7.22.8)
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-validator-option': registry.npmmirror.com/@babel/helper-validator-option@7.22.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': registry.npmmirror.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': registry.npmmirror.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-proposal-private-property-in-object': registry.npmmirror.com/@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.8)
-      '@babel/plugin-syntax-async-generators': registry.npmmirror.com/@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.8)
-      '@babel/plugin-syntax-class-properties': registry.npmmirror.com/@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.22.8)
-      '@babel/plugin-syntax-class-static-block': registry.npmmirror.com/@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.8)
-      '@babel/plugin-syntax-dynamic-import': registry.npmmirror.com/@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.8)
-      '@babel/plugin-syntax-export-namespace-from': registry.npmmirror.com/@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.8)
-      '@babel/plugin-syntax-import-assertions': registry.npmmirror.com/@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-syntax-import-attributes': registry.npmmirror.com/@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-syntax-import-meta': registry.npmmirror.com/@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.22.8)
-      '@babel/plugin-syntax-json-strings': registry.npmmirror.com/@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.22.8)
-      '@babel/plugin-syntax-logical-assignment-operators': registry.npmmirror.com/@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.22.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': registry.npmmirror.com/@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.8)
-      '@babel/plugin-syntax-numeric-separator': registry.npmmirror.com/@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.22.8)
-      '@babel/plugin-syntax-object-rest-spread': registry.npmmirror.com/@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.8)
-      '@babel/plugin-syntax-optional-catch-binding': registry.npmmirror.com/@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.22.8)
-      '@babel/plugin-syntax-optional-chaining': registry.npmmirror.com/@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.8)
-      '@babel/plugin-syntax-private-property-in-object': registry.npmmirror.com/@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.8)
-      '@babel/plugin-syntax-top-level-await': registry.npmmirror.com/@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.22.8)
-      '@babel/plugin-syntax-unicode-sets-regex': registry.npmmirror.com/@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.8)
-      '@babel/plugin-transform-arrow-functions': registry.npmmirror.com/@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-async-generator-functions': registry.npmmirror.com/@babel/plugin-transform-async-generator-functions@7.22.7(@babel/core@7.22.8)
-      '@babel/plugin-transform-async-to-generator': registry.npmmirror.com/@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-block-scoped-functions': registry.npmmirror.com/@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-block-scoping': registry.npmmirror.com/@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-class-properties': registry.npmmirror.com/@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-class-static-block': registry.npmmirror.com/@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-classes': registry.npmmirror.com/@babel/plugin-transform-classes@7.22.6(@babel/core@7.22.8)
-      '@babel/plugin-transform-computed-properties': registry.npmmirror.com/@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-destructuring': registry.npmmirror.com/@babel/plugin-transform-destructuring@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-dotall-regex': registry.npmmirror.com/@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-duplicate-keys': registry.npmmirror.com/@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-dynamic-import': registry.npmmirror.com/@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-exponentiation-operator': registry.npmmirror.com/@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-export-namespace-from': registry.npmmirror.com/@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-for-of': registry.npmmirror.com/@babel/plugin-transform-for-of@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-function-name': registry.npmmirror.com/@babel/plugin-transform-function-name@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-json-strings': registry.npmmirror.com/@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-literals': registry.npmmirror.com/@babel/plugin-transform-literals@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-logical-assignment-operators': registry.npmmirror.com/@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-member-expression-literals': registry.npmmirror.com/@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-modules-amd': registry.npmmirror.com/@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-modules-commonjs': registry.npmmirror.com/@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-modules-systemjs': registry.npmmirror.com/@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-modules-umd': registry.npmmirror.com/@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-named-capturing-groups-regex': registry.npmmirror.com/@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-new-target': registry.npmmirror.com/@babel/plugin-transform-new-target@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-nullish-coalescing-operator': registry.npmmirror.com/@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-numeric-separator': registry.npmmirror.com/@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-object-rest-spread': registry.npmmirror.com/@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-object-super': registry.npmmirror.com/@babel/plugin-transform-object-super@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-optional-catch-binding': registry.npmmirror.com/@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-optional-chaining': registry.npmmirror.com/@babel/plugin-transform-optional-chaining@7.22.6(@babel/core@7.22.8)
-      '@babel/plugin-transform-parameters': registry.npmmirror.com/@babel/plugin-transform-parameters@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-private-methods': registry.npmmirror.com/@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-private-property-in-object': registry.npmmirror.com/@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-property-literals': registry.npmmirror.com/@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-regenerator': registry.npmmirror.com/@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-reserved-words': registry.npmmirror.com/@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-shorthand-properties': registry.npmmirror.com/@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-spread': registry.npmmirror.com/@babel/plugin-transform-spread@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-sticky-regex': registry.npmmirror.com/@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-template-literals': registry.npmmirror.com/@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-typeof-symbol': registry.npmmirror.com/@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-unicode-escapes': registry.npmmirror.com/@babel/plugin-transform-unicode-escapes@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-unicode-property-regex': registry.npmmirror.com/@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-unicode-regex': registry.npmmirror.com/@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-unicode-sets-regex': registry.npmmirror.com/@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.8)
-      '@babel/preset-modules': registry.npmmirror.com/@babel/preset-modules@0.1.5(@babel/core@7.22.8)
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-      '@nicolo-ribaudo/semver-v6': registry.npmmirror.com/@nicolo-ribaudo/semver-v6@6.3.3
-      babel-plugin-polyfill-corejs2: registry.npmmirror.com/babel-plugin-polyfill-corejs2@0.4.4(@babel/core@7.22.8)
-      babel-plugin-polyfill-corejs3: registry.npmmirror.com/babel-plugin-polyfill-corejs3@0.8.2(@babel/core@7.22.8)
-      babel-plugin-polyfill-regenerator: registry.npmmirror.com/babel-plugin-polyfill-regenerator@0.5.1(@babel/core@7.22.8)
-      core-js-compat: registry.npmmirror.com/core-js-compat@3.31.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/preset-modules@0.1.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/preset-modules/-/preset-modules-0.1.5.tgz}
-    id: registry.npmmirror.com/@babel/preset-modules/0.1.5
-    name: '@babel/preset-modules'
-    version: 0.1.5
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/plugin-proposal-unicode-property-regex': registry.npmmirror.com/@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.22.8)
-      '@babel/plugin-transform-dotall-regex': registry.npmmirror.com/@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.8)
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-      esutils: registry.npmmirror.com/esutils@2.0.3
-    dev: false
-
-  registry.npmmirror.com/@babel/preset-react@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-M+Is3WikOpEJHgR385HbuCITPTaPRaNkibTEa9oiofmJvIsrceb4yp9RL9Kb+TE8LznmeyZqpP+Lopwcx59xPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/preset-react/-/preset-react-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/preset-react/7.22.5
-    name: '@babel/preset-react'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-validator-option': registry.npmmirror.com/@babel/helper-validator-option@7.22.5
-      '@babel/plugin-transform-react-display-name': registry.npmmirror.com/@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-react-jsx': registry.npmmirror.com/@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-react-jsx-development': registry.npmmirror.com/@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-react-pure-annotations': registry.npmmirror.com/@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.22.8)
-    dev: false
-
-  registry.npmmirror.com/@babel/preset-typescript@7.22.5(@babel/core@7.22.8):
-    resolution: {integrity: sha512-YbPaal9LxztSGhmndR46FmAbkJ/1fAsw293tSU+I5E5h+cnJ3d4GTwyUgGYmOXJYdGA+uNePle4qbaRzj2NISQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/preset-typescript/-/preset-typescript-7.22.5.tgz}
-    id: registry.npmmirror.com/@babel/preset-typescript/7.22.5
-    name: '@babel/preset-typescript'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-plugin-utils': registry.npmmirror.com/@babel/helper-plugin-utils@7.22.5
-      '@babel/helper-validator-option': registry.npmmirror.com/@babel/helper-validator-option@7.22.5
-      '@babel/plugin-syntax-jsx': registry.npmmirror.com/@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-modules-commonjs': registry.npmmirror.com/@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.22.8)
-      '@babel/plugin-transform-typescript': registry.npmmirror.com/@babel/plugin-transform-typescript@7.22.5(@babel/core@7.22.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@babel/regjsgen@0.8.0:
-    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz}
-    name: '@babel/regjsgen'
-    version: 0.8.0
-    dev: false
-
-  registry.npmmirror.com/@babel/runtime@7.22.6:
-    resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/runtime/-/runtime-7.22.6.tgz}
-    name: '@babel/runtime'
-    version: 7.22.6
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: registry.npmmirror.com/regenerator-runtime@0.13.11
-    dev: false
-
-  registry.npmmirror.com/@babel/template@7.22.5:
-    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/template/-/template-7.22.5.tgz}
-    name: '@babel/template'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.22.5
-      '@babel/parser': registry.npmmirror.com/@babel/parser@7.22.7
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-    dev: false
-
-  registry.npmmirror.com/@babel/traverse@7.22.8:
-    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/traverse/-/traverse-7.22.8.tgz}
-    name: '@babel/traverse'
-    version: 7.22.8
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.22.5
-      '@babel/generator': registry.npmmirror.com/@babel/generator@7.22.7
-      '@babel/helper-environment-visitor': registry.npmmirror.com/@babel/helper-environment-visitor@7.22.5
-      '@babel/helper-function-name': registry.npmmirror.com/@babel/helper-function-name@7.22.5
-      '@babel/helper-hoist-variables': registry.npmmirror.com/@babel/helper-hoist-variables@7.22.5
-      '@babel/helper-split-export-declaration': registry.npmmirror.com/@babel/helper-split-export-declaration@7.22.6
-      '@babel/parser': registry.npmmirror.com/@babel/parser@7.22.7
-      '@babel/types': registry.npmmirror.com/@babel/types@7.22.5
-      debug: registry.npmmirror.com/debug@4.3.4
-      globals: registry.npmmirror.com/globals@11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+  /strip-ansi@3.0.1:
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-regex: 2.1.1
+    dev: true
 
-  registry.npmmirror.com/@babel/types@7.22.5:
-    resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@babel/types/-/types-7.22.5.tgz}
-    name: '@babel/types'
-    version: 7.22.5
-    engines: {node: '>=6.9.0'}
+  /strip-ansi@4.0.0:
+    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
+    engines: {node: '>=4'}
     dependencies:
-      '@babel/helper-string-parser': registry.npmmirror.com/@babel/helper-string-parser@7.22.5
-      '@babel/helper-validator-identifier': registry.npmmirror.com/@babel/helper-validator-identifier@7.22.5
-      to-fast-properties: registry.npmmirror.com/to-fast-properties@2.0.0
-    dev: false
+      ansi-regex: 3.0.1
+    dev: true
+
+  /strip-ansi@5.2.0:
+    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
+    engines: {node: '>=6'}
+    dependencies:
+      ansi-regex: 4.1.1
+    dev: true
+
+  /strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: true
+
+  /strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      min-indent: 1.0.1
+    dev: true
+
+  /strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /supports-color@2.0.0:
+    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
+    engines: {node: '>=0.8.0'}
+    dev: true
 
-  registry.npmmirror.com/@eslint/eslintrc@0.4.3:
-    resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz}
-    name: '@eslint/eslintrc'
-    version: 0.4.3
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
     dependencies:
-      ajv: registry.npmmirror.com/ajv@6.12.6
-      debug: registry.npmmirror.com/debug@4.3.4
-      espree: registry.npmmirror.com/espree@7.3.1
-      globals: registry.npmmirror.com/globals@13.20.0
-      ignore: registry.npmmirror.com/ignore@4.0.6
-      import-fresh: registry.npmmirror.com/import-fresh@3.3.0
-      js-yaml: registry.npmmirror.com/js-yaml@3.14.1
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-      strip-json-comments: registry.npmmirror.com/strip-json-comments@3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+      has-flag: 3.0.0
+    dev: true
+
+  /supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
+  /supports-hyperlinks@2.3.0:
+    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+    dev: true
+
+  /trim-newlines@3.0.1:
+    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /type-fest@0.10.0:
+    resolution: {integrity: sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /type-fest@0.18.1:
+    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@0.4.1:
+    resolution: {integrity: sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+    dependencies:
+      is-typedarray: 1.0.0
+    dev: true
+
+  /validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+    dev: true
+
+  /which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: true
+
+  /wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /write-file-atomic@3.0.3:
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+    dependencies:
+      imurmurhash: 0.1.4
+      is-typedarray: 1.0.0
+      signal-exit: 3.0.7
+      typedarray-to-buffer: 3.1.5
+    dev: true
+
+  /yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
+
+  /yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+    dev: true
+
+  /yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+    dev: true
 
   registry.npmmirror.com/@exodus/schemasafe@1.0.1:
     resolution: {integrity: sha512-PQdbF8dGd4LnbwBlcc4ML8RKYdplm+e9sUeWBTr4zgF13/Shiuov9XznvM4T8cb1CfyKK21yTUkuAIIh/DAH/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@exodus/schemasafe/-/schemasafe-1.0.1.tgz}
     name: '@exodus/schemasafe'
     version: 1.0.1
     dev: false
-
-  registry.npmmirror.com/@humanwhocodes/config-array@0.5.0:
-    resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz}
-    name: '@humanwhocodes/config-array'
-    version: 0.5.0
-    engines: {node: '>=10.10.0'}
-    dependencies:
-      '@humanwhocodes/object-schema': registry.npmmirror.com/@humanwhocodes/object-schema@1.2.1
-      debug: registry.npmmirror.com/debug@4.3.4
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@humanwhocodes/object-schema@1.2.1:
-    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz}
-    name: '@humanwhocodes/object-schema'
-    version: 1.2.1
-    dev: false
-
-  registry.npmmirror.com/@jridgewell/gen-mapping@0.3.3:
-    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz}
-    name: '@jridgewell/gen-mapping'
-    version: 0.3.3
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/set-array': registry.npmmirror.com/@jridgewell/set-array@1.1.2
-      '@jridgewell/sourcemap-codec': registry.npmmirror.com/@jridgewell/sourcemap-codec@1.4.15
-      '@jridgewell/trace-mapping': registry.npmmirror.com/@jridgewell/trace-mapping@0.3.18
-    dev: false
-
-  registry.npmmirror.com/@jridgewell/resolve-uri@3.1.0:
-    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz}
-    name: '@jridgewell/resolve-uri'
-    version: 3.1.0
-    engines: {node: '>=6.0.0'}
-    dev: false
-
-  registry.npmmirror.com/@jridgewell/set-array@1.1.2:
-    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@jridgewell/set-array/-/set-array-1.1.2.tgz}
-    name: '@jridgewell/set-array'
-    version: 1.1.2
-    engines: {node: '>=6.0.0'}
-    dev: false
-
-  registry.npmmirror.com/@jridgewell/sourcemap-codec@1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz}
-    name: '@jridgewell/sourcemap-codec'
-    version: 1.4.14
-    dev: false
-
-  registry.npmmirror.com/@jridgewell/sourcemap-codec@1.4.15:
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz}
-    name: '@jridgewell/sourcemap-codec'
-    version: 1.4.15
-    dev: false
-
-  registry.npmmirror.com/@jridgewell/trace-mapping@0.3.18:
-    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz}
-    name: '@jridgewell/trace-mapping'
-    version: 0.3.18
-    dependencies:
-      '@jridgewell/resolve-uri': registry.npmmirror.com/@jridgewell/resolve-uri@3.1.0
-      '@jridgewell/sourcemap-codec': registry.npmmirror.com/@jridgewell/sourcemap-codec@1.4.14
-    dev: false
-
-  registry.npmmirror.com/@mdn/browser-compat-data@3.3.14:
-    resolution: {integrity: sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz}
-    name: '@mdn/browser-compat-data'
-    version: 3.3.14
-    dev: false
-
-  registry.npmmirror.com/@mrmlnc/readdir-enhanced@2.2.1:
-    resolution: {integrity: sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz}
-    name: '@mrmlnc/readdir-enhanced'
-    version: 2.2.1
-    engines: {node: '>=4'}
-    dependencies:
-      call-me-maybe: registry.npmmirror.com/call-me-maybe@1.0.2
-      glob-to-regexp: registry.npmmirror.com/glob-to-regexp@0.3.0
-    dev: false
-
-  registry.npmmirror.com/@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1:
-    resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz}
-    name: '@nicolo-ribaudo/eslint-scope-5-internals'
-    version: 5.1.1-v1
-    dependencies:
-      eslint-scope: registry.npmmirror.com/eslint-scope@5.1.1
-    dev: false
-
-  registry.npmmirror.com/@nicolo-ribaudo/semver-v6@6.3.3:
-    resolution: {integrity: sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz}
-    name: '@nicolo-ribaudo/semver-v6'
-    version: 6.3.3
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/@nodelib/fs.scandir@2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz}
-    name: '@nodelib/fs.scandir'
-    version: 2.1.5
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.stat': registry.npmmirror.com/@nodelib/fs.stat@2.0.5
-      run-parallel: registry.npmmirror.com/run-parallel@1.2.0
-
-  registry.npmmirror.com/@nodelib/fs.stat@1.1.3:
-    resolution: {integrity: sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz}
-    name: '@nodelib/fs.stat'
-    version: 1.1.3
-    engines: {node: '>= 6'}
-    dev: false
-
-  registry.npmmirror.com/@nodelib/fs.stat@2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz}
-    name: '@nodelib/fs.stat'
-    version: 2.0.5
-    engines: {node: '>= 8'}
-
-  registry.npmmirror.com/@nodelib/fs.walk@1.2.8:
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz}
-    name: '@nodelib/fs.walk'
-    version: 1.2.8
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.scandir': registry.npmmirror.com/@nodelib/fs.scandir@2.1.5
-      fastq: registry.npmmirror.com/fastq@1.15.0
 
   registry.npmmirror.com/@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7):
     resolution: {integrity: sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz}
@@ -1980,41 +1285,6 @@ packages:
     version: 4.6.0
     engines: {node: '>=10'}
     dev: true
-
-  registry.npmmirror.com/@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39):
-    resolution: {integrity: sha512-scLk3cSH1H9KggSniseb2KNAU5D9FWc3H7BxCSAIdtU9OWIyw0zkEZ9qEKHryRM+SExYXRKNb7tOOVNAsQ3iwg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.3.tgz}
-    id: registry.npmmirror.com/@stylelint/postcss-css-in-js/0.37.3
-    name: '@stylelint/postcss-css-in-js'
-    version: 0.37.3
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    peerDependencies:
-      postcss: '>=7.0.0'
-      postcss-syntax: '>=0.36.2'
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39):
-    resolution: {integrity: sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz}
-    id: registry.npmmirror.com/@stylelint/postcss-markdown/0.36.2
-    name: '@stylelint/postcss-markdown'
-    version: 0.36.2
-    deprecated: 'Use the original unforked package instead: postcss-markdown'
-    peerDependencies:
-      postcss: '>=7.0.0'
-      postcss-syntax: '>=0.36.2'
-    dependencies:
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
-      remark: registry.npmmirror.com/remark@13.0.0
-      unist-util-find-all-after: registry.npmmirror.com/unist-util-find-all-after@3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   registry.npmmirror.com/@szmarczak/http-timer@1.1.2:
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz}
@@ -2062,21 +1332,6 @@ packages:
       '@types/node': registry.npmmirror.com/@types/node@14.14.22
     dev: true
 
-  registry.npmmirror.com/@types/eslint@7.29.0:
-    resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/eslint/-/eslint-7.29.0.tgz}
-    name: '@types/eslint'
-    version: 7.29.0
-    dependencies:
-      '@types/estree': registry.npmmirror.com/@types/estree@1.0.1
-      '@types/json-schema': registry.npmmirror.com/@types/json-schema@7.0.12
-    dev: false
-
-  registry.npmmirror.com/@types/estree@1.0.1:
-    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/estree/-/estree-1.0.1.tgz}
-    name: '@types/estree'
-    version: 1.0.1
-    dev: false
-
   registry.npmmirror.com/@types/express-serve-static-core@4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz}
     name: '@types/express-serve-static-core'
@@ -2099,15 +1354,6 @@ packages:
       '@types/serve-static': registry.npmmirror.com/@types/serve-static@1.15.2
     dev: true
 
-  registry.npmmirror.com/@types/glob@7.2.0:
-    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/glob/-/glob-7.2.0.tgz}
-    name: '@types/glob'
-    version: 7.2.0
-    dependencies:
-      '@types/minimatch': registry.npmmirror.com/@types/minimatch@5.1.2
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-    dev: false
-
   registry.npmmirror.com/@types/http-cache-semantics@4.0.1:
     resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz}
     name: '@types/http-cache-semantics'
@@ -2120,18 +1366,6 @@ packages:
     version: 2.0.1
     dev: true
 
-  registry.npmmirror.com/@types/json-schema@7.0.12:
-    resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.12.tgz}
-    name: '@types/json-schema'
-    version: 7.0.12
-    dev: false
-
-  registry.npmmirror.com/@types/json5@0.0.29:
-    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/json5/-/json5-0.0.29.tgz}
-    name: '@types/json5'
-    version: 0.0.29
-    dev: false
-
   registry.npmmirror.com/@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz}
     name: '@types/keyv'
@@ -2139,14 +1373,6 @@ packages:
     dependencies:
       '@types/node': registry.npmmirror.com/@types/node@14.14.22
     dev: true
-
-  registry.npmmirror.com/@types/mdast@3.0.11:
-    resolution: {integrity: sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/mdast/-/mdast-3.0.11.tgz}
-    name: '@types/mdast'
-    version: 3.0.11
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@3.0.0
-    dev: false
 
   registry.npmmirror.com/@types/mime@1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/mime/-/mime-1.3.2.tgz}
@@ -2160,37 +1386,11 @@ packages:
     version: 3.0.1
     dev: true
 
-  registry.npmmirror.com/@types/minimatch@3.0.5:
-    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/minimatch/-/minimatch-3.0.5.tgz}
-    name: '@types/minimatch'
-    version: 3.0.5
-    dev: false
-
-  registry.npmmirror.com/@types/minimatch@5.1.2:
-    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/minimatch/-/minimatch-5.1.2.tgz}
-    name: '@types/minimatch'
-    version: 5.1.2
-    dev: false
-
-  registry.npmmirror.com/@types/minimist@1.2.2:
-    resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/minimist/-/minimist-1.2.2.tgz}
-    name: '@types/minimist'
-    version: 1.2.2
-
   registry.npmmirror.com/@types/node@14.14.22:
     resolution: {integrity: sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/node/-/node-14.14.22.tgz}
     name: '@types/node'
     version: 14.14.22
-
-  registry.npmmirror.com/@types/normalize-package-data@2.4.1:
-    resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz}
-    name: '@types/normalize-package-data'
-    version: 2.4.1
-
-  registry.npmmirror.com/@types/parse-json@4.0.0:
-    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/parse-json/-/parse-json-4.0.0.tgz}
-    name: '@types/parse-json'
-    version: 4.0.0
+    dev: true
 
   registry.npmmirror.com/@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/qs/-/qs-6.9.7.tgz}
@@ -2231,233 +1431,10 @@ packages:
       '@types/node': registry.npmmirror.com/@types/node@14.14.22
     dev: true
 
-  registry.npmmirror.com/@types/unist@2.0.6:
-    resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/unist/-/unist-2.0.6.tgz}
-    name: '@types/unist'
-    version: 2.0.6
-    dev: false
-
-  registry.npmmirror.com/@types/unist@3.0.0:
-    resolution: {integrity: sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/unist/-/unist-3.0.0.tgz}
-    name: '@types/unist'
-    version: 3.0.0
-    dev: false
-
-  registry.npmmirror.com/@types/vfile-message@2.0.0:
-    resolution: {integrity: sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/vfile-message/-/vfile-message-2.0.0.tgz}
-    name: '@types/vfile-message'
-    version: 2.0.0
-    deprecated: This is a stub types definition. vfile-message provides its own type definitions, so you do not need this installed.
-    dependencies:
-      vfile-message: registry.npmmirror.com/vfile-message@4.0.2
-    dev: false
-
-  registry.npmmirror.com/@types/vfile@3.0.2:
-    resolution: {integrity: sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@types/vfile/-/vfile-3.0.2.tgz}
-    name: '@types/vfile'
-    version: 3.0.2
-    dependencies:
-      '@types/node': registry.npmmirror.com/@types/node@14.14.22
-      '@types/unist': registry.npmmirror.com/@types/unist@2.0.6
-      '@types/vfile-message': registry.npmmirror.com/@types/vfile-message@2.0.0
-    dev: false
-
-  registry.npmmirror.com/@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@4.1.3):
-    resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz}
-    id: registry.npmmirror.com/@typescript-eslint/eslint-plugin/4.33.0
-    name: '@typescript-eslint/eslint-plugin'
-    version: 4.33.0
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/experimental-utils': registry.npmmirror.com/@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@4.1.3)
-      '@typescript-eslint/parser': registry.npmmirror.com/@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.1.3)
-      '@typescript-eslint/scope-manager': registry.npmmirror.com/@typescript-eslint/scope-manager@4.33.0
-      debug: registry.npmmirror.com/debug@4.3.4
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      functional-red-black-tree: registry.npmmirror.com/functional-red-black-tree@1.0.1
-      ignore: registry.npmmirror.com/ignore@5.2.4
-      regexpp: registry.npmmirror.com/regexpp@3.2.0
-      semver: registry.npmmirror.com/semver@7.5.4
-      tsutils: registry.npmmirror.com/tsutils@3.21.0(typescript@4.1.3)
-      typescript: registry.npmmirror.com/typescript@4.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@4.1.3):
-    resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz}
-    id: registry.npmmirror.com/@typescript-eslint/experimental-utils/4.33.0
-    name: '@typescript-eslint/experimental-utils'
-    version: 4.33.0
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': registry.npmmirror.com/@types/json-schema@7.0.12
-      '@typescript-eslint/scope-manager': registry.npmmirror.com/@typescript-eslint/scope-manager@4.33.0
-      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types@4.33.0
-      '@typescript-eslint/typescript-estree': registry.npmmirror.com/@typescript-eslint/typescript-estree@4.33.0(typescript@4.1.3)
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-scope: registry.npmmirror.com/eslint-scope@5.1.1
-      eslint-utils: registry.npmmirror.com/eslint-utils@3.0.0(eslint@7.32.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
-
-  registry.npmmirror.com/@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.1.3):
-    resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-4.33.0.tgz}
-    id: registry.npmmirror.com/@typescript-eslint/parser/4.33.0
-    name: '@typescript-eslint/parser'
-    version: 4.33.0
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': registry.npmmirror.com/@typescript-eslint/scope-manager@4.33.0
-      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types@4.33.0
-      '@typescript-eslint/typescript-estree': registry.npmmirror.com/@typescript-eslint/typescript-estree@4.33.0(typescript@4.1.3)
-      debug: registry.npmmirror.com/debug@4.3.4
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      typescript: registry.npmmirror.com/typescript@4.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@typescript-eslint/scope-manager@4.33.0:
-    resolution: {integrity: sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz}
-    name: '@typescript-eslint/scope-manager'
-    version: 4.33.0
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dependencies:
-      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types@4.33.0
-      '@typescript-eslint/visitor-keys': registry.npmmirror.com/@typescript-eslint/visitor-keys@4.33.0
-    dev: false
-
-  registry.npmmirror.com/@typescript-eslint/types@4.33.0:
-    resolution: {integrity: sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/types/-/types-4.33.0.tgz}
-    name: '@typescript-eslint/types'
-    version: 4.33.0
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dev: false
-
-  registry.npmmirror.com/@typescript-eslint/typescript-estree@4.33.0(typescript@4.1.3):
-    resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz}
-    id: registry.npmmirror.com/@typescript-eslint/typescript-estree/4.33.0
-    name: '@typescript-eslint/typescript-estree'
-    version: 4.33.0
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types@4.33.0
-      '@typescript-eslint/visitor-keys': registry.npmmirror.com/@typescript-eslint/visitor-keys@4.33.0
-      debug: registry.npmmirror.com/debug@4.3.4
-      globby: registry.npmmirror.com/globby@11.1.0
-      is-glob: registry.npmmirror.com/is-glob@4.0.3
-      semver: registry.npmmirror.com/semver@7.5.4
-      tsutils: registry.npmmirror.com/tsutils@3.21.0(typescript@4.1.3)
-      typescript: registry.npmmirror.com/typescript@4.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/@typescript-eslint/visitor-keys@4.33.0:
-    resolution: {integrity: sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz}
-    name: '@typescript-eslint/visitor-keys'
-    version: 4.33.0
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dependencies:
-      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types@4.33.0
-      eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys@2.1.0
-    dev: false
-
-  registry.npmmirror.com/@umijs/fabric@2.5.6(prettier@2.2.1):
-    resolution: {integrity: sha512-rpfbQxy+hbO9yScRuFpOHE6d+6KOzsCN2gpQpGsAtgM0TlUQ8Aa6QtrG35bsPylNITp7qf+SOy31StRCC1xW/Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/@umijs/fabric/-/fabric-2.5.6.tgz}
-    id: registry.npmmirror.com/@umijs/fabric/2.5.6
-    name: '@umijs/fabric'
-    version: 2.5.6
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/eslint-parser': registry.npmmirror.com/@babel/eslint-parser@7.22.7(@babel/core@7.22.8)(eslint@7.32.0)
-      '@babel/plugin-proposal-class-properties': registry.npmmirror.com/@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.8)
-      '@babel/preset-env': registry.npmmirror.com/@babel/preset-env@7.22.7(@babel/core@7.22.8)
-      '@babel/preset-react': registry.npmmirror.com/@babel/preset-react@7.22.5(@babel/core@7.22.8)
-      '@babel/preset-typescript': registry.npmmirror.com/@babel/preset-typescript@7.22.5(@babel/core@7.22.8)
-      '@typescript-eslint/eslint-plugin': registry.npmmirror.com/@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@4.1.3)
-      '@typescript-eslint/parser': registry.npmmirror.com/@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.1.3)
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-config-airbnb-base: registry.npmmirror.com/eslint-config-airbnb-base@14.2.1(eslint-plugin-import@2.27.5)(eslint@7.32.0)
-      eslint-config-prettier: registry.npmmirror.com/eslint-config-prettier@6.15.0(eslint@7.32.0)
-      eslint-formatter-pretty: registry.npmmirror.com/eslint-formatter-pretty@4.1.0
-      eslint-plugin-babel: registry.npmmirror.com/eslint-plugin-babel@5.3.1(eslint@7.32.0)
-      eslint-plugin-compat: registry.npmmirror.com/eslint-plugin-compat@3.13.0(eslint@7.32.0)
-      eslint-plugin-eslint-comments: registry.npmmirror.com/eslint-plugin-eslint-comments@3.2.0(eslint@7.32.0)
-      eslint-plugin-import: registry.npmmirror.com/eslint-plugin-import@2.27.5(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)
-      eslint-plugin-jest: registry.npmmirror.com/eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@4.33.0)(eslint@7.32.0)(typescript@4.1.3)
-      eslint-plugin-jsx-a11y: registry.npmmirror.com/eslint-plugin-jsx-a11y@6.7.1(eslint@7.32.0)
-      eslint-plugin-markdown: registry.npmmirror.com/eslint-plugin-markdown@1.0.2
-      eslint-plugin-promise: registry.npmmirror.com/eslint-plugin-promise@4.3.1
-      eslint-plugin-react: registry.npmmirror.com/eslint-plugin-react@7.32.2(eslint@7.32.0)
-      eslint-plugin-react-hooks: registry.npmmirror.com/eslint-plugin-react-hooks@4.6.0(eslint@7.32.0)
-      eslint-plugin-unicorn: registry.npmmirror.com/eslint-plugin-unicorn@20.1.0(eslint@7.32.0)
-      fast-glob: registry.npmmirror.com/fast-glob@3.3.0
-      prettier-plugin-style-order: registry.npmmirror.com/prettier-plugin-style-order@0.2.2(prettier@2.2.1)
-      stylelint: registry.npmmirror.com/stylelint@13.13.1
-      stylelint-config-css-modules: registry.npmmirror.com/stylelint-config-css-modules@2.3.0(stylelint@13.13.1)
-      stylelint-config-prettier: registry.npmmirror.com/stylelint-config-prettier@8.0.2(stylelint@13.13.1)
-      stylelint-config-rational-order: registry.npmmirror.com/stylelint-config-rational-order@0.1.2
-      stylelint-config-standard: registry.npmmirror.com/stylelint-config-standard@20.0.0(stylelint@13.13.1)
-      stylelint-declaration-block-no-ignored-properties: registry.npmmirror.com/stylelint-declaration-block-no-ignored-properties@2.7.0(stylelint@13.13.1)
-      stylelint-no-unsupported-browser-features: registry.npmmirror.com/stylelint-no-unsupported-browser-features@4.1.4(stylelint@13.13.1)
-      stylelint-order: registry.npmmirror.com/stylelint-order@4.1.0(stylelint@13.13.1)
-      typescript: registry.npmmirror.com/typescript@4.1.3
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - postcss-jsx
-      - postcss-markdown
-      - prettier
-      - supports-color
-    dev: false
-
   registry.npmmirror.com/a-sync-waterfall@1.0.1:
     resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz}
     name: a-sync-waterfall
     version: 1.0.1
-    dev: false
-
-  registry.npmmirror.com/acorn-jsx@5.3.2(acorn@7.4.1):
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz}
-    id: registry.npmmirror.com/acorn-jsx/5.3.2
-    name: acorn-jsx
-    version: 5.3.2
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: registry.npmmirror.com/acorn@7.4.1
-    dev: false
-
-  registry.npmmirror.com/acorn@7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/acorn/-/acorn-7.4.1.tgz}
-    name: acorn
-    version: 7.4.1
-    engines: {node: '>=0.4.0'}
-    hasBin: true
     dev: false
 
   registry.npmmirror.com/aggregate-error@3.1.0:
@@ -2467,101 +1444,22 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       clean-stack: registry.npmmirror.com/clean-stack@2.2.0
-      indent-string: registry.npmmirror.com/indent-string@4.0.0
+      indent-string: 4.0.0
     dev: true
-
-  registry.npmmirror.com/ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz}
-    name: ajv
-    version: 6.12.6
-    dependencies:
-      fast-deep-equal: registry.npmmirror.com/fast-deep-equal@3.1.3
-      fast-json-stable-stringify: registry.npmmirror.com/fast-json-stable-stringify@2.1.0
-      json-schema-traverse: registry.npmmirror.com/json-schema-traverse@0.4.1
-      uri-js: registry.npmmirror.com/uri-js@4.4.1
-    dev: false
-
-  registry.npmmirror.com/ajv@8.12.0:
-    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ajv/-/ajv-8.12.0.tgz}
-    name: ajv
-    version: 8.12.0
-    dependencies:
-      fast-deep-equal: registry.npmmirror.com/fast-deep-equal@3.1.3
-      json-schema-traverse: registry.npmmirror.com/json-schema-traverse@1.0.0
-      require-from-string: registry.npmmirror.com/require-from-string@2.0.2
-      uri-js: registry.npmmirror.com/uri-js@4.4.1
-    dev: false
 
   registry.npmmirror.com/ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-align/-/ansi-align-3.0.1.tgz}
     name: ansi-align
     version: 3.0.1
     dependencies:
-      string-width: registry.npmmirror.com/string-width@4.2.3
+      string-width: 4.2.3
     dev: true
-
-  registry.npmmirror.com/ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-colors/-/ansi-colors-4.1.3.tgz}
-    name: ansi-colors
-    version: 4.1.3
-    engines: {node: '>=6'}
-    dev: false
-
-  registry.npmmirror.com/ansi-escapes@3.2.0:
-    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz}
-    name: ansi-escapes
-    version: 3.2.0
-    engines: {node: '>=4'}
-    dev: true
-
-  registry.npmmirror.com/ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz}
-    name: ansi-escapes
-    version: 4.3.2
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: registry.npmmirror.com/type-fest@0.21.3
-
-  registry.npmmirror.com/ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-regex/-/ansi-regex-2.1.1.tgz}
-    name: ansi-regex
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmmirror.com/ansi-regex@3.0.1:
-    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-regex/-/ansi-regex-3.0.1.tgz}
-    name: ansi-regex
-    version: 3.0.1
-    engines: {node: '>=4'}
-    dev: true
-
-  registry.npmmirror.com/ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-regex/-/ansi-regex-4.1.1.tgz}
-    name: ansi-regex
-    version: 4.1.1
-    engines: {node: '>=6'}
 
   registry.npmmirror.com/ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz}
     name: ansi-regex
     version: 5.0.1
     engines: {node: '>=8'}
-
-  registry.npmmirror.com/ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-styles/-/ansi-styles-2.2.1.tgz}
-    name: ansi-styles
-    version: 2.2.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmmirror.com/ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-styles/-/ansi-styles-3.2.1.tgz}
-    name: ansi-styles
-    version: 3.2.1
-    engines: {node: '>=4'}
-    dependencies:
-      color-convert: registry.npmmirror.com/color-convert@1.9.3
 
   registry.npmmirror.com/ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz}
@@ -2612,202 +1510,17 @@ packages:
     name: anymatch
     version: 3.1.3
     engines: {node: '>= 8'}
+    requiresBuild: true
     dependencies:
       normalize-path: registry.npmmirror.com/normalize-path@3.0.0
       picomatch: registry.npmmirror.com/picomatch@2.3.1
     dev: false
     optional: true
 
-  registry.npmmirror.com/argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/argparse/-/argparse-1.0.10.tgz}
-    name: argparse
-    version: 1.0.10
-    dependencies:
-      sprintf-js: registry.npmmirror.com/sprintf-js@1.0.3
-    dev: false
-
-  registry.npmmirror.com/aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/aria-query/-/aria-query-5.3.0.tgz}
-    name: aria-query
-    version: 5.3.0
-    dependencies:
-      dequal: registry.npmmirror.com/dequal@2.0.3
-    dev: false
-
-  registry.npmmirror.com/arr-diff@4.0.0:
-    resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/arr-diff/-/arr-diff-4.0.0.tgz}
-    name: arr-diff
-    version: 4.0.0
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/arr-flatten@1.1.0:
-    resolution: {integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/arr-flatten/-/arr-flatten-1.1.0.tgz}
-    name: arr-flatten
-    version: 1.1.0
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/arr-union@3.1.0:
-    resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/arr-union/-/arr-union-3.1.0.tgz}
-    name: arr-union
-    version: 3.1.0
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/array-buffer-byte-length@1.0.0:
-    resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz}
-    name: array-buffer-byte-length
-    version: 1.0.0
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      is-array-buffer: registry.npmmirror.com/is-array-buffer@3.0.2
-    dev: false
-
-  registry.npmmirror.com/array-differ@3.0.0:
-    resolution: {integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array-differ/-/array-differ-3.0.0.tgz}
-    name: array-differ
-    version: 3.0.0
-    engines: {node: '>=8'}
-    dev: false
-
-  registry.npmmirror.com/array-find-index@1.0.2:
-    resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array-find-index/-/array-find-index-1.0.2.tgz}
-    name: array-find-index
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/array-includes@3.1.6:
-    resolution: {integrity: sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array-includes/-/array-includes-3.1.6.tgz}
-    name: array-includes
-    version: 3.1.6
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-      is-string: registry.npmmirror.com/is-string@1.0.7
-    dev: false
-
-  registry.npmmirror.com/array-union@1.0.2:
-    resolution: {integrity: sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array-union/-/array-union-1.0.2.tgz}
-    name: array-union
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-uniq: registry.npmmirror.com/array-uniq@1.0.3
-    dev: false
-
-  registry.npmmirror.com/array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array-union/-/array-union-2.1.0.tgz}
-    name: array-union
-    version: 2.1.0
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/array-uniq@1.0.3:
-    resolution: {integrity: sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array-uniq/-/array-uniq-1.0.3.tgz}
-    name: array-uniq
-    version: 1.0.3
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/array-unique@0.3.2:
-    resolution: {integrity: sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array-unique/-/array-unique-0.3.2.tgz}
-    name: array-unique
-    version: 0.3.2
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/array.prototype.flat@1.3.1:
-    resolution: {integrity: sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz}
-    name: array.prototype.flat
-    version: 1.3.1
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-      es-shim-unscopables: registry.npmmirror.com/es-shim-unscopables@1.0.0
-    dev: false
-
-  registry.npmmirror.com/array.prototype.flatmap@1.3.1:
-    resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz}
-    name: array.prototype.flatmap
-    version: 1.3.1
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-      es-shim-unscopables: registry.npmmirror.com/es-shim-unscopables@1.0.0
-    dev: false
-
-  registry.npmmirror.com/array.prototype.tosorted@1.1.1:
-    resolution: {integrity: sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz}
-    name: array.prototype.tosorted
-    version: 1.1.1
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-      es-shim-unscopables: registry.npmmirror.com/es-shim-unscopables@1.0.0
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-    dev: false
-
-  registry.npmmirror.com/arrify@1.0.1:
-    resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/arrify/-/arrify-1.0.1.tgz}
-    name: arrify
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-
-  registry.npmmirror.com/arrify@2.0.1:
-    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/arrify/-/arrify-2.0.1.tgz}
-    name: arrify
-    version: 2.0.1
-    engines: {node: '>=8'}
-    dev: false
-
   registry.npmmirror.com/asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/asap/-/asap-2.0.6.tgz}
     name: asap
     version: 2.0.6
-    dev: false
-
-  registry.npmmirror.com/assign-symbols@1.0.0:
-    resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/assign-symbols/-/assign-symbols-1.0.0.tgz}
-    name: assign-symbols
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/ast-metadata-inferer@0.7.0:
-    resolution: {integrity: sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz}
-    name: ast-metadata-inferer
-    version: 0.7.0
-    dependencies:
-      '@mdn/browser-compat-data': registry.npmmirror.com/@mdn/browser-compat-data@3.3.14
-    dev: false
-
-  registry.npmmirror.com/ast-types-flow@0.0.7:
-    resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz}
-    name: ast-types-flow
-    version: 0.0.7
-    dev: false
-
-  registry.npmmirror.com/astral-regex@1.0.0:
-    resolution: {integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/astral-regex/-/astral-regex-1.0.0.tgz}
-    name: astral-regex
-    version: 1.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/astral-regex/-/astral-regex-2.0.0.tgz}
-    name: astral-regex
-    version: 2.0.0
-    engines: {node: '>=8'}
     dev: false
 
   registry.npmmirror.com/async-exit-hook@2.0.1:
@@ -2817,133 +1530,12 @@ packages:
     engines: {node: '>=0.12.0'}
     dev: true
 
-  registry.npmmirror.com/atob@2.1.2:
-    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/atob/-/atob-2.1.2.tgz}
-    name: atob
-    version: 2.1.2
-    engines: {node: '>= 4.5.0'}
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/autoprefixer@9.8.8:
-    resolution: {integrity: sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/autoprefixer/-/autoprefixer-9.8.8.tgz}
-    name: autoprefixer
-    version: 9.8.8
-    hasBin: true
-    dependencies:
-      browserslist: registry.npmmirror.com/browserslist@4.21.9
-      caniuse-lite: registry.npmmirror.com/caniuse-lite@1.0.30001514
-      normalize-range: registry.npmmirror.com/normalize-range@0.1.2
-      num2fraction: registry.npmmirror.com/num2fraction@1.2.2
-      picocolors: registry.npmmirror.com/picocolors@0.2.1
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-value-parser: registry.npmmirror.com/postcss-value-parser@4.2.0
-    dev: false
-
-  registry.npmmirror.com/available-typed-arrays@1.0.5:
-    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz}
-    name: available-typed-arrays
-    version: 1.0.5
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  registry.npmmirror.com/axe-core@4.7.2:
-    resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/axe-core/-/axe-core-4.7.2.tgz}
-    name: axe-core
-    version: 4.7.2
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/axobject-query@3.2.1:
-    resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/axobject-query/-/axobject-query-3.2.1.tgz}
-    name: axobject-query
-    version: 3.2.1
-    dependencies:
-      dequal: registry.npmmirror.com/dequal@2.0.3
-    dev: false
-
-  registry.npmmirror.com/babel-plugin-polyfill-corejs2@0.4.4(@babel/core@7.22.8):
-    resolution: {integrity: sha512-9WeK9snM1BfxB38goUEv2FLnA6ja07UMfazFHzCXUb3NyDZAwfXvQiURQ6guTTMeHcOsdknULm1PDhs4uWtKyA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.4.tgz}
-    id: registry.npmmirror.com/babel-plugin-polyfill-corejs2/0.4.4
-    name: babel-plugin-polyfill-corejs2
-    version: 0.4.4
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': registry.npmmirror.com/@babel/compat-data@7.22.6
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-define-polyfill-provider': registry.npmmirror.com/@babel/helper-define-polyfill-provider@0.4.1(@babel/core@7.22.8)
-      '@nicolo-ribaudo/semver-v6': registry.npmmirror.com/@nicolo-ribaudo/semver-v6@6.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/babel-plugin-polyfill-corejs3@0.8.2(@babel/core@7.22.8):
-    resolution: {integrity: sha512-Cid+Jv1BrY9ReW9lIfNlNpsI53N+FN7gE+f73zLAUbr9C52W4gKLWSByx47pfDJsEysojKArqOtOKZSVIIUTuQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.2.tgz}
-    id: registry.npmmirror.com/babel-plugin-polyfill-corejs3/0.8.2
-    name: babel-plugin-polyfill-corejs3
-    version: 0.8.2
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-define-polyfill-provider': registry.npmmirror.com/@babel/helper-define-polyfill-provider@0.4.1(@babel/core@7.22.8)
-      core-js-compat: registry.npmmirror.com/core-js-compat@3.31.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/babel-plugin-polyfill-regenerator@0.5.1(@babel/core@7.22.8):
-    resolution: {integrity: sha512-L8OyySuI6OSQ5hFy9O+7zFjyr4WhAfRjLIOkhQGYl+emwJkd/S4XXT1JpfrgR1jrQ1NcGiOh+yAdGlF8pnC3Jw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.1.tgz}
-    id: registry.npmmirror.com/babel-plugin-polyfill-regenerator/0.5.1
-    name: babel-plugin-polyfill-regenerator
-    version: 0.5.1
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/helper-define-polyfill-provider': registry.npmmirror.com/@babel/helper-define-polyfill-provider@0.4.1(@babel/core@7.22.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/bail@1.0.5:
-    resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/bail/-/bail-1.0.5.tgz}
-    name: bail
-    version: 1.0.5
-    dev: false
-
-  registry.npmmirror.com/balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz}
-    name: balanced-match
-    version: 1.0.2
-
-  registry.npmmirror.com/balanced-match@2.0.0:
-    resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/balanced-match/-/balanced-match-2.0.0.tgz}
-    name: balanced-match
-    version: 2.0.0
-    dev: false
-
-  registry.npmmirror.com/base@0.11.2:
-    resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/base/-/base-0.11.2.tgz}
-    name: base
-    version: 0.11.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      cache-base: registry.npmmirror.com/cache-base@1.0.1
-      class-utils: registry.npmmirror.com/class-utils@0.3.6
-      component-emitter: registry.npmmirror.com/component-emitter@1.3.0
-      define-property: registry.npmmirror.com/define-property@1.0.0
-      isobject: registry.npmmirror.com/isobject@3.0.1
-      mixin-deep: registry.npmmirror.com/mixin-deep@1.3.2
-      pascalcase: registry.npmmirror.com/pascalcase@0.1.1
-    dev: false
-
   registry.npmmirror.com/binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/binary-extensions/-/binary-extensions-2.2.0.tgz}
     name: binary-extensions
     version: 2.2.0
     engines: {node: '>=8'}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -2954,86 +1546,31 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       ansi-align: registry.npmmirror.com/ansi-align@3.0.1
-      camelcase: registry.npmmirror.com/camelcase@6.3.0
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      camelcase: 6.3.0
+      chalk: 4.1.2
       cli-boxes: registry.npmmirror.com/cli-boxes@2.2.1
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      type-fest: registry.npmmirror.com/type-fest@0.20.2
+      string-width: 4.2.3
+      type-fest: 0.20.2
       widest-line: registry.npmmirror.com/widest-line@3.1.0
       wrap-ansi: registry.npmmirror.com/wrap-ansi@7.0.0
     dev: true
-
-  registry.npmmirror.com/brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.11.tgz}
-    name: brace-expansion
-    version: 1.1.11
-    dependencies:
-      balanced-match: registry.npmmirror.com/balanced-match@1.0.2
-      concat-map: registry.npmmirror.com/concat-map@0.0.1
-
-  registry.npmmirror.com/braces@2.3.2:
-    resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/braces/-/braces-2.3.2.tgz}
-    name: braces
-    version: 2.3.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-flatten: registry.npmmirror.com/arr-flatten@1.1.0
-      array-unique: registry.npmmirror.com/array-unique@0.3.2
-      extend-shallow: registry.npmmirror.com/extend-shallow@2.0.1
-      fill-range: registry.npmmirror.com/fill-range@4.0.0
-      isobject: registry.npmmirror.com/isobject@3.0.1
-      repeat-element: registry.npmmirror.com/repeat-element@1.1.4
-      snapdragon: registry.npmmirror.com/snapdragon@0.8.2
-      snapdragon-node: registry.npmmirror.com/snapdragon-node@2.1.1
-      split-string: registry.npmmirror.com/split-string@3.1.0
-      to-regex: registry.npmmirror.com/to-regex@3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   registry.npmmirror.com/braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/braces/-/braces-3.0.2.tgz}
     name: braces
     version: 3.0.2
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       fill-range: registry.npmmirror.com/fill-range@7.0.1
-
-  registry.npmmirror.com/browserslist@4.21.9:
-    resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/browserslist/-/browserslist-4.21.9.tgz}
-    name: browserslist
-    version: 4.21.9
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: registry.npmmirror.com/caniuse-lite@1.0.30001514
-      electron-to-chromium: registry.npmmirror.com/electron-to-chromium@1.4.454
-      node-releases: registry.npmmirror.com/node-releases@2.0.13
-      update-browserslist-db: registry.npmmirror.com/update-browserslist-db@1.0.11(browserslist@4.21.9)
     dev: false
+    optional: true
 
   registry.npmmirror.com/builtins@1.0.3:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/builtins/-/builtins-1.0.3.tgz}
     name: builtins
     version: 1.0.3
     dev: true
-
-  registry.npmmirror.com/cache-base@1.0.1:
-    resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cache-base/-/cache-base-1.0.1.tgz}
-    name: cache-base
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      collection-visit: registry.npmmirror.com/collection-visit@1.0.0
-      component-emitter: registry.npmmirror.com/component-emitter@1.3.0
-      get-value: registry.npmmirror.com/get-value@2.0.6
-      has-value: registry.npmmirror.com/has-value@1.0.0
-      isobject: registry.npmmirror.com/isobject@3.0.1
-      set-value: registry.npmmirror.com/set-value@2.0.1
-      to-object-path: registry.npmmirror.com/to-object-path@0.3.0
-      union-value: registry.npmmirror.com/union-value@1.0.1
-      unset-value: registry.npmmirror.com/unset-value@1.0.0
-    dev: false
 
   registry.npmmirror.com/cacheable-lookup@2.0.1:
     resolution: {integrity: sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz}
@@ -3042,7 +1579,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@types/keyv': registry.npmmirror.com/@types/keyv@3.1.4
-      keyv: registry.npmmirror.com/keyv@4.5.2
+      keyv: 4.5.2
     dev: true
 
   registry.npmmirror.com/cacheable-request@6.1.0:
@@ -3052,9 +1589,9 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       clone-response: registry.npmmirror.com/clone-response@1.0.3
-      get-stream: registry.npmmirror.com/get-stream@5.2.0
+      get-stream: 5.2.0
       http-cache-semantics: registry.npmmirror.com/http-cache-semantics@4.1.1
-      keyv: registry.npmmirror.com/keyv@3.1.0
+      keyv: 3.1.0
       lowercase-keys: registry.npmmirror.com/lowercase-keys@2.0.0
       normalize-url: registry.npmmirror.com/normalize-url@4.5.1
       responselike: registry.npmmirror.com/responselike@1.0.2
@@ -3067,135 +1604,19 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       clone-response: registry.npmmirror.com/clone-response@1.0.3
-      get-stream: registry.npmmirror.com/get-stream@5.2.0
+      get-stream: 5.2.0
       http-cache-semantics: registry.npmmirror.com/http-cache-semantics@4.1.1
-      keyv: registry.npmmirror.com/keyv@4.5.2
+      keyv: 4.5.2
       lowercase-keys: registry.npmmirror.com/lowercase-keys@2.0.0
       normalize-url: registry.npmmirror.com/normalize-url@6.1.0
       responselike: registry.npmmirror.com/responselike@2.0.1
     dev: true
-
-  registry.npmmirror.com/call-bind@1.0.2:
-    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/call-bind/-/call-bind-1.0.2.tgz}
-    name: call-bind
-    version: 1.0.2
-    dependencies:
-      function-bind: registry.npmmirror.com/function-bind@1.1.1
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-    dev: false
 
   registry.npmmirror.com/call-me-maybe@1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz}
     name: call-me-maybe
     version: 1.0.2
     dev: false
-
-  registry.npmmirror.com/caller-callsite@2.0.0:
-    resolution: {integrity: sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/caller-callsite/-/caller-callsite-2.0.0.tgz}
-    name: caller-callsite
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      callsites: registry.npmmirror.com/callsites@2.0.0
-    dev: false
-
-  registry.npmmirror.com/caller-path@2.0.0:
-    resolution: {integrity: sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/caller-path/-/caller-path-2.0.0.tgz}
-    name: caller-path
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      caller-callsite: registry.npmmirror.com/caller-callsite@2.0.0
-    dev: false
-
-  registry.npmmirror.com/callsites@2.0.0:
-    resolution: {integrity: sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/callsites/-/callsites-2.0.0.tgz}
-    name: callsites
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz}
-    name: callsites
-    version: 3.1.0
-    engines: {node: '>=6'}
-
-  registry.npmmirror.com/camelcase-keys@4.2.0:
-    resolution: {integrity: sha512-Ej37YKYbFUI8QiYlvj9YHb6/Z60dZyPJW0Cs8sFilMbd2lP0bw3ylAq9yJkK4lcTA2dID5fG8LjmJYbO7kWb7Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz}
-    name: camelcase-keys
-    version: 4.2.0
-    engines: {node: '>=4'}
-    dependencies:
-      camelcase: registry.npmmirror.com/camelcase@4.1.0
-      map-obj: registry.npmmirror.com/map-obj@2.0.0
-      quick-lru: registry.npmmirror.com/quick-lru@1.1.0
-    dev: false
-
-  registry.npmmirror.com/camelcase-keys@6.2.2:
-    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz}
-    name: camelcase-keys
-    version: 6.2.2
-    engines: {node: '>=8'}
-    dependencies:
-      camelcase: registry.npmmirror.com/camelcase@5.3.1
-      map-obj: registry.npmmirror.com/map-obj@4.3.0
-      quick-lru: registry.npmmirror.com/quick-lru@4.0.1
-
-  registry.npmmirror.com/camelcase@4.1.0:
-    resolution: {integrity: sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/camelcase/-/camelcase-4.1.0.tgz}
-    name: camelcase
-    version: 4.1.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/camelcase@5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/camelcase/-/camelcase-5.3.1.tgz}
-    name: camelcase
-    version: 5.3.1
-    engines: {node: '>=6'}
-
-  registry.npmmirror.com/camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/camelcase/-/camelcase-6.3.0.tgz}
-    name: camelcase
-    version: 6.3.0
-    engines: {node: '>=10'}
-    dev: true
-
-  registry.npmmirror.com/caniuse-lite@1.0.30001514:
-    resolution: {integrity: sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz}
-    name: caniuse-lite
-    version: 1.0.30001514
-    dev: false
-
-  registry.npmmirror.com/ccount@1.1.0:
-    resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ccount/-/ccount-1.1.0.tgz}
-    name: ccount
-    version: 1.1.0
-    dev: false
-
-  registry.npmmirror.com/chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chalk/-/chalk-1.1.3.tgz}
-    name: chalk
-    version: 1.1.3
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@2.2.1
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
-      has-ansi: registry.npmmirror.com/has-ansi@2.0.0
-      strip-ansi: registry.npmmirror.com/strip-ansi@3.0.1
-      supports-color: registry.npmmirror.com/supports-color@2.0.0
-    dev: true
-
-  registry.npmmirror.com/chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chalk/-/chalk-2.4.2.tgz}
-    name: chalk
-    version: 2.4.2
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@3.2.1
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
-      supports-color: registry.npmmirror.com/supports-color@5.5.0
 
   registry.npmmirror.com/chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz}
@@ -3206,61 +1627,11 @@ packages:
       ansi-styles: registry.npmmirror.com/ansi-styles@4.3.0
       supports-color: registry.npmmirror.com/supports-color@7.2.0
 
-  registry.npmmirror.com/character-entities-html4@1.1.4:
-    resolution: {integrity: sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/character-entities-html4/-/character-entities-html4-1.1.4.tgz}
-    name: character-entities-html4
-    version: 1.1.4
-    dev: false
-
-  registry.npmmirror.com/character-entities-legacy@1.1.4:
-    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz}
-    name: character-entities-legacy
-    version: 1.1.4
-    dev: false
-
-  registry.npmmirror.com/character-entities@1.2.4:
-    resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/character-entities/-/character-entities-1.2.4.tgz}
-    name: character-entities
-    version: 1.2.4
-    dev: false
-
-  registry.npmmirror.com/character-reference-invalid@1.1.4:
-    resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz}
-    name: character-reference-invalid
-    version: 1.1.4
-    dev: false
-
   registry.npmmirror.com/chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/chardet/-/chardet-0.7.0.tgz}
     name: chardet
     version: 0.7.0
     dev: true
-
-  registry.npmmirror.com/ci-info@2.0.0:
-    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ci-info/-/ci-info-2.0.0.tgz}
-    name: ci-info
-    version: 2.0.0
-
-  registry.npmmirror.com/class-utils@0.3.6:
-    resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/class-utils/-/class-utils-0.3.6.tgz}
-    name: class-utils
-    version: 0.3.6
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-union: registry.npmmirror.com/arr-union@3.1.0
-      define-property: registry.npmmirror.com/define-property@0.2.5
-      isobject: registry.npmmirror.com/isobject@3.0.1
-      static-extend: registry.npmmirror.com/static-extend@0.1.2
-    dev: false
-
-  registry.npmmirror.com/clean-regexp@1.0.0:
-    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/clean-regexp/-/clean-regexp-1.0.0.tgz}
-    name: clean-regexp
-    version: 1.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
-    dev: false
 
   registry.npmmirror.com/clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/clean-stack/-/clean-stack-2.2.0.tgz}
@@ -3300,8 +1671,8 @@ packages:
     version: 0.2.1
     engines: {node: '>=0.10.0'}
     dependencies:
-      slice-ansi: registry.npmmirror.com/slice-ansi@0.0.4
-      string-width: registry.npmmirror.com/string-width@1.0.2
+      slice-ansi: 0.0.4
+      string-width: 1.0.2
     dev: true
 
   registry.npmmirror.com/cli-width@2.2.1:
@@ -3338,25 +1709,6 @@ packages:
       wrap-ansi: registry.npmmirror.com/wrap-ansi@7.0.0
     dev: false
 
-  registry.npmmirror.com/clone-regexp@1.0.1:
-    resolution: {integrity: sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/clone-regexp/-/clone-regexp-1.0.1.tgz}
-    name: clone-regexp
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-regexp: registry.npmmirror.com/is-regexp@1.0.0
-      is-supported-regexp-flag: registry.npmmirror.com/is-supported-regexp-flag@1.0.1
-    dev: false
-
-  registry.npmmirror.com/clone-regexp@2.2.0:
-    resolution: {integrity: sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/clone-regexp/-/clone-regexp-2.2.0.tgz}
-    name: clone-regexp
-    version: 2.2.0
-    engines: {node: '>=6'}
-    dependencies:
-      is-regexp: registry.npmmirror.com/is-regexp@2.1.0
-    dev: false
-
   registry.npmmirror.com/clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/clone-response/-/clone-response-1.0.3.tgz}
     name: clone-response
@@ -3372,29 +1724,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  registry.npmmirror.com/collapse-white-space@1.0.6:
-    resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz}
-    name: collapse-white-space
-    version: 1.0.6
-    dev: false
-
-  registry.npmmirror.com/collection-visit@1.0.0:
-    resolution: {integrity: sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/collection-visit/-/collection-visit-1.0.0.tgz}
-    name: collection-visit
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      map-visit: registry.npmmirror.com/map-visit@1.0.0
-      object-visit: registry.npmmirror.com/object-visit@1.0.1
-    dev: false
-
-  registry.npmmirror.com/color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/color-convert/-/color-convert-1.9.3.tgz}
-    name: color-convert
-    version: 1.9.3
-    dependencies:
-      color-name: registry.npmmirror.com/color-name@1.1.3
-
   registry.npmmirror.com/color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz}
     name: color-convert
@@ -3402,11 +1731,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: registry.npmmirror.com/color-name@1.1.4
-
-  registry.npmmirror.com/color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/color-name/-/color-name-1.1.3.tgz}
-    name: color-name
-    version: 1.1.3
 
   registry.npmmirror.com/color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz}
@@ -3427,17 +1751,6 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
-  registry.npmmirror.com/component-emitter@1.3.0:
-    resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/component-emitter/-/component-emitter-1.3.0.tgz}
-    name: component-emitter
-    version: 1.3.0
-    dev: false
-
-  registry.npmmirror.com/concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz}
-    name: concat-map
-    version: 0.0.1
-
   registry.npmmirror.com/configstore@5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/configstore/-/configstore-5.0.1.tgz}
     name: configstore
@@ -3448,61 +1761,9 @@ packages:
       graceful-fs: registry.npmmirror.com/graceful-fs@4.2.11
       make-dir: registry.npmmirror.com/make-dir@3.1.0
       unique-string: registry.npmmirror.com/unique-string@2.0.0
-      write-file-atomic: registry.npmmirror.com/write-file-atomic@3.0.3
+      write-file-atomic: 3.0.3
       xdg-basedir: registry.npmmirror.com/xdg-basedir@4.0.0
     dev: true
-
-  registry.npmmirror.com/confusing-browser-globals@1.0.11:
-    resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz}
-    name: confusing-browser-globals
-    version: 1.0.11
-    dev: false
-
-  registry.npmmirror.com/convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/convert-source-map/-/convert-source-map-1.9.0.tgz}
-    name: convert-source-map
-    version: 1.9.0
-    dev: false
-
-  registry.npmmirror.com/copy-descriptor@0.1.1:
-    resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz}
-    name: copy-descriptor
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/core-js-compat@3.31.1:
-    resolution: {integrity: sha512-wIDWd2s5/5aJSdpOJHfSibxNODxoGoWOBHt8JSPB41NOE94M7kuTPZCYLOlTtuoXTsBPKobpJ6T+y0SSy5L9SA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/core-js-compat/-/core-js-compat-3.31.1.tgz}
-    name: core-js-compat
-    version: 3.31.1
-    dependencies:
-      browserslist: registry.npmmirror.com/browserslist@4.21.9
-    dev: false
-
-  registry.npmmirror.com/core-js@3.31.1:
-    resolution: {integrity: sha512-2sKLtfq1eFST7l7v62zaqXacPc7uG8ZAya8ogijLhTtaKNcpzpB4TMoTw2Si+8GYKRwFPMMtUT0263QFWFfqyQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/core-js/-/core-js-3.31.1.tgz}
-    name: core-js
-    version: 3.31.1
-    requiresBuild: true
-    dev: false
-
-  registry.npmmirror.com/core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/core-util-is/-/core-util-is-1.0.3.tgz}
-    name: core-util-is
-    version: 1.0.3
-    dev: false
-
-  registry.npmmirror.com/cosmiconfig@5.2.1:
-    resolution: {integrity: sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz}
-    name: cosmiconfig
-    version: 5.2.1
-    engines: {node: '>=4'}
-    dependencies:
-      import-fresh: registry.npmmirror.com/import-fresh@2.0.0
-      is-directory: registry.npmmirror.com/is-directory@0.3.1
-      js-yaml: registry.npmmirror.com/js-yaml@3.14.1
-      parse-json: registry.npmmirror.com/parse-json@4.0.0
-    dev: false
 
   registry.npmmirror.com/cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz}
@@ -3510,21 +1771,12 @@ packages:
     version: 7.1.0
     engines: {node: '>=10'}
     dependencies:
-      '@types/parse-json': registry.npmmirror.com/@types/parse-json@4.0.0
-      import-fresh: registry.npmmirror.com/import-fresh@3.3.0
-      parse-json: registry.npmmirror.com/parse-json@5.2.0
-      path-type: registry.npmmirror.com/path-type@4.0.0
-      yaml: registry.npmmirror.com/yaml@1.10.2
-
-  registry.npmmirror.com/cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.3.tgz}
-    name: cross-spawn
-    version: 7.0.3
-    engines: {node: '>= 8'}
-    dependencies:
-      path-key: registry.npmmirror.com/path-key@3.1.1
-      shebang-command: registry.npmmirror.com/shebang-command@2.0.0
-      which: registry.npmmirror.com/which@2.0.2
+      '@types/parse-json': 4.0.0
+      import-fresh: 3.3.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+    dev: true
 
   registry.npmmirror.com/crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz}
@@ -3533,44 +1785,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/css-rule-stream@1.1.0:
-    resolution: {integrity: sha512-qiio/Zkr8I19jh/XuzEkK8OKDQRTrEYaRyIHy4Bwh/tPUe0w8GcQs7r6x24Yc9lT+FbnZFYULxEIXCmaymguUQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/css-rule-stream/-/css-rule-stream-1.1.0.tgz}
-    name: css-rule-stream
-    version: 1.1.0
-    hasBin: true
-    dependencies:
-      css-tokenize: registry.npmmirror.com/css-tokenize@1.0.1
-      duplexer2: registry.npmmirror.com/duplexer2@0.0.2
-      ldjson-stream: registry.npmmirror.com/ldjson-stream@1.2.1
-      through2: registry.npmmirror.com/through2@0.6.5
-    dev: false
-
-  registry.npmmirror.com/css-tokenize@1.0.1:
-    resolution: {integrity: sha512-gLmmbJdwH9HLY4bcA17lnZ8GgPwEXRbvxBJGHnkiB6gLhRpTzjkjtMIvz7YORGW/Ptv2oMk8b5g+u7mRD6Dd7A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/css-tokenize/-/css-tokenize-1.0.1.tgz}
-    name: css-tokenize
-    version: 1.0.1
-    dependencies:
-      inherits: registry.npmmirror.com/inherits@2.0.4
-      readable-stream: registry.npmmirror.com/readable-stream@1.1.14
-    dev: false
-
-  registry.npmmirror.com/cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/cssesc/-/cssesc-3.0.0.tgz}
-    name: cssesc
-    version: 3.0.0
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/currently-unhandled@0.4.1:
-    resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz}
-    name: currently-unhandled
-    version: 0.4.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-find-index: registry.npmmirror.com/array-find-index@1.0.2
-    dev: false
-
   registry.npmmirror.com/d@1.0.1:
     resolution: {integrity: sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/d/-/d-1.0.1.tgz}
     name: d
@@ -3578,12 +1792,6 @@ packages:
     dependencies:
       es5-ext: registry.npmmirror.com/es5-ext@0.10.62
       type: registry.npmmirror.com/type@1.2.0
-    dev: false
-
-  registry.npmmirror.com/damerau-levenshtein@1.0.8:
-    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz}
-    name: damerau-levenshtein
-    version: 1.0.8
     dev: false
 
   registry.npmmirror.com/date-fns@1.30.1:
@@ -3596,68 +1804,6 @@ packages:
     resolution: {integrity: sha512-/2fdLN987N8Ki7Id8BUN2nhuiRyxTLumQnSQf9CNncFCyqFsSKb9TNhzRYcC8K8eJSJOKvbvkImo/MKKhNi4iw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dayjs/-/dayjs-1.10.3.tgz}
     name: dayjs
     version: 1.10.3
-    dev: false
-
-  registry.npmmirror.com/debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/debug/-/debug-2.6.9.tgz}
-    name: debug
-    version: 2.6.9
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: registry.npmmirror.com/ms@2.0.0
-    dev: false
-
-  registry.npmmirror.com/debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/debug/-/debug-3.2.7.tgz}
-    name: debug
-    version: 3.2.7
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: registry.npmmirror.com/ms@2.1.3
-    dev: false
-
-  registry.npmmirror.com/debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/debug/-/debug-4.3.4.tgz}
-    name: debug
-    version: 4.3.4
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: registry.npmmirror.com/ms@2.1.2
-    dev: false
-
-  registry.npmmirror.com/decamelize-keys@1.1.1:
-    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/decamelize-keys/-/decamelize-keys-1.1.1.tgz}
-    name: decamelize-keys
-    version: 1.1.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      decamelize: registry.npmmirror.com/decamelize@1.2.0
-      map-obj: registry.npmmirror.com/map-obj@1.0.1
-
-  registry.npmmirror.com/decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/decamelize/-/decamelize-1.2.0.tgz}
-    name: decamelize
-    version: 1.2.0
-    engines: {node: '>=0.10.0'}
-
-  registry.npmmirror.com/decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz}
-    name: decode-uri-component
-    version: 0.2.2
-    engines: {node: '>=0.10'}
     dev: false
 
   registry.npmmirror.com/decompress-response@3.3.0:
@@ -3685,12 +1831,6 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: true
 
-  registry.npmmirror.com/deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz}
-    name: deep-is
-    version: 0.1.4
-    dev: false
-
   registry.npmmirror.com/defer-to-connect@1.1.3:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz}
     name: defer-to-connect
@@ -3704,158 +1844,21 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  registry.npmmirror.com/define-properties@1.2.0:
-    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/define-properties/-/define-properties-1.2.0.tgz}
-    name: define-properties
-    version: 1.2.0
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-property-descriptors: registry.npmmirror.com/has-property-descriptors@1.0.0
-      object-keys: registry.npmmirror.com/object-keys@1.1.1
-    dev: false
-
-  registry.npmmirror.com/define-property@0.2.5:
-    resolution: {integrity: sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/define-property/-/define-property-0.2.5.tgz}
-    name: define-property
-    version: 0.2.5
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-descriptor: registry.npmmirror.com/is-descriptor@0.1.6
-    dev: false
-
-  registry.npmmirror.com/define-property@1.0.0:
-    resolution: {integrity: sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/define-property/-/define-property-1.0.0.tgz}
-    name: define-property
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-descriptor: registry.npmmirror.com/is-descriptor@1.0.2
-    dev: false
-
-  registry.npmmirror.com/define-property@2.0.2:
-    resolution: {integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/define-property/-/define-property-2.0.2.tgz}
-    name: define-property
-    version: 2.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-descriptor: registry.npmmirror.com/is-descriptor@1.0.2
-      isobject: registry.npmmirror.com/isobject@3.0.1
-    dev: false
-
   registry.npmmirror.com/del@6.1.1:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/del/-/del-6.1.1.tgz}
     name: del
     version: 6.1.1
     engines: {node: '>=10'}
     dependencies:
-      globby: registry.npmmirror.com/globby@11.1.0
+      globby: 11.1.0
       graceful-fs: registry.npmmirror.com/graceful-fs@4.2.11
-      is-glob: registry.npmmirror.com/is-glob@4.0.3
+      is-glob: 4.0.3
       is-path-cwd: registry.npmmirror.com/is-path-cwd@2.2.0
       is-path-inside: registry.npmmirror.com/is-path-inside@3.0.3
       p-map: registry.npmmirror.com/p-map@4.0.0
-      rimraf: registry.npmmirror.com/rimraf@3.0.2
-      slash: registry.npmmirror.com/slash@3.0.0
+      rimraf: 3.0.2
+      slash: 3.0.0
     dev: true
-
-  registry.npmmirror.com/dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dequal/-/dequal-2.0.3.tgz}
-    name: dequal
-    version: 2.0.3
-    engines: {node: '>=6'}
-    dev: false
-
-  registry.npmmirror.com/dir-glob@2.2.2:
-    resolution: {integrity: sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dir-glob/-/dir-glob-2.2.2.tgz}
-    name: dir-glob
-    version: 2.2.2
-    engines: {node: '>=4'}
-    dependencies:
-      path-type: registry.npmmirror.com/path-type@3.0.0
-    dev: false
-
-  registry.npmmirror.com/dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dir-glob/-/dir-glob-3.0.1.tgz}
-    name: dir-glob
-    version: 3.0.1
-    engines: {node: '>=8'}
-    dependencies:
-      path-type: registry.npmmirror.com/path-type@4.0.0
-
-  registry.npmmirror.com/doctrine@2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/doctrine/-/doctrine-2.1.0.tgz}
-    name: doctrine
-    version: 2.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      esutils: registry.npmmirror.com/esutils@2.0.3
-    dev: false
-
-  registry.npmmirror.com/doctrine@3.0.0:
-    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/doctrine/-/doctrine-3.0.0.tgz}
-    name: doctrine
-    version: 3.0.0
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      esutils: registry.npmmirror.com/esutils@2.0.3
-    dev: false
-
-  registry.npmmirror.com/doiuse@4.4.1:
-    resolution: {integrity: sha512-TUpr1/YNg20IB09tZmwGCTsTQoxj8jUld/hUZprZMj8vj0VpAJySXEWCr8WMvqvgzk0/kG/FxeSMGKode4UjPg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/doiuse/-/doiuse-4.4.1.tgz}
-    name: doiuse
-    version: 4.4.1
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      browserslist: registry.npmmirror.com/browserslist@4.21.9
-      caniuse-lite: registry.npmmirror.com/caniuse-lite@1.0.30001514
-      css-rule-stream: registry.npmmirror.com/css-rule-stream@1.1.0
-      duplexer2: registry.npmmirror.com/duplexer2@0.0.2
-      ldjson-stream: registry.npmmirror.com/ldjson-stream@1.2.1
-      multimatch: registry.npmmirror.com/multimatch@5.0.0
-      postcss: registry.npmmirror.com/postcss@8.4.25
-      source-map: registry.npmmirror.com/source-map@0.7.4
-      through2: registry.npmmirror.com/through2@4.0.2
-      yargs: registry.npmmirror.com/yargs@16.2.0
-    dev: false
-
-  registry.npmmirror.com/dom-serializer@0.2.2:
-    resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dom-serializer/-/dom-serializer-0.2.2.tgz}
-    name: dom-serializer
-    version: 0.2.2
-    dependencies:
-      domelementtype: registry.npmmirror.com/domelementtype@2.3.0
-      entities: registry.npmmirror.com/entities@2.2.0
-    dev: false
-
-  registry.npmmirror.com/domelementtype@1.3.1:
-    resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/domelementtype/-/domelementtype-1.3.1.tgz}
-    name: domelementtype
-    version: 1.3.1
-    dev: false
-
-  registry.npmmirror.com/domelementtype@2.3.0:
-    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/domelementtype/-/domelementtype-2.3.0.tgz}
-    name: domelementtype
-    version: 2.3.0
-    dev: false
-
-  registry.npmmirror.com/domhandler@2.4.2:
-    resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/domhandler/-/domhandler-2.4.2.tgz}
-    name: domhandler
-    version: 2.4.2
-    dependencies:
-      domelementtype: registry.npmmirror.com/domelementtype@1.3.1
-    dev: false
-
-  registry.npmmirror.com/domutils@1.7.0:
-    resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/domutils/-/domutils-1.7.0.tgz}
-    name: domutils
-    version: 1.7.0
-    dependencies:
-      dom-serializer: registry.npmmirror.com/dom-serializer@0.2.2
-      domelementtype: registry.npmmirror.com/domelementtype@1.3.1
-    dev: false
 
   registry.npmmirror.com/dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dot-prop/-/dot-prop-5.3.0.tgz}
@@ -3864,6 +1867,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-obj: registry.npmmirror.com/is-obj@2.0.0
+    dev: true
 
   registry.npmmirror.com/dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dot-prop/-/dot-prop-6.0.1.tgz}
@@ -3874,25 +1878,11 @@ packages:
       is-obj: registry.npmmirror.com/is-obj@2.0.0
     dev: true
 
-  registry.npmmirror.com/duplexer2@0.0.2:
-    resolution: {integrity: sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/duplexer2/-/duplexer2-0.0.2.tgz}
-    name: duplexer2
-    version: 0.0.2
-    dependencies:
-      readable-stream: registry.npmmirror.com/readable-stream@1.1.14
-    dev: false
-
   registry.npmmirror.com/duplexer3@0.1.5:
     resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/duplexer3/-/duplexer3-0.1.5.tgz}
     name: duplexer3
     version: 0.1.5
     dev: true
-
-  registry.npmmirror.com/electron-to-chromium@1.4.454:
-    resolution: {integrity: sha512-pmf1rbAStw8UEQ0sr2cdJtWl48ZMuPD9Sto8HVQOq9vx9j2WgDEN6lYoaqFvqEHYOmGA9oRGn7LqWI9ta0YugQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.4.454.tgz}
-    name: electron-to-chromium
-    version: 1.4.454
-    dev: false
 
   registry.npmmirror.com/elegant-spinner@1.0.1:
     resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz}
@@ -3901,130 +1891,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  registry.npmmirror.com/emoji-regex@7.0.3:
-    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/emoji-regex/-/emoji-regex-7.0.3.tgz}
-    name: emoji-regex
-    version: 7.0.3
-    dev: false
-
   registry.npmmirror.com/emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz}
     name: emoji-regex
     version: 8.0.0
-
-  registry.npmmirror.com/emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/emoji-regex/-/emoji-regex-9.2.2.tgz}
-    name: emoji-regex
-    version: 9.2.2
-    dev: false
-
-  registry.npmmirror.com/end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/end-of-stream/-/end-of-stream-1.4.4.tgz}
-    name: end-of-stream
-    version: 1.4.4
-    dependencies:
-      once: registry.npmmirror.com/once@1.4.0
-    dev: true
-
-  registry.npmmirror.com/enquirer@2.3.6:
-    resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/enquirer/-/enquirer-2.3.6.tgz}
-    name: enquirer
-    version: 2.3.6
-    engines: {node: '>=8.6'}
-    dependencies:
-      ansi-colors: registry.npmmirror.com/ansi-colors@4.1.3
-    dev: false
-
-  registry.npmmirror.com/entities@1.1.2:
-    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/entities/-/entities-1.1.2.tgz}
-    name: entities
-    version: 1.1.2
-    dev: false
-
-  registry.npmmirror.com/entities@2.2.0:
-    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/entities/-/entities-2.2.0.tgz}
-    name: entities
-    version: 2.2.0
-    dev: false
-
-  registry.npmmirror.com/error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/error-ex/-/error-ex-1.3.2.tgz}
-    name: error-ex
-    version: 1.3.2
-    dependencies:
-      is-arrayish: registry.npmmirror.com/is-arrayish@0.2.1
-
-  registry.npmmirror.com/es-abstract@1.21.2:
-    resolution: {integrity: sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es-abstract/-/es-abstract-1.21.2.tgz}
-    name: es-abstract
-    version: 1.21.2
-    engines: {node: '>= 0.4'}
-    dependencies:
-      array-buffer-byte-length: registry.npmmirror.com/array-buffer-byte-length@1.0.0
-      available-typed-arrays: registry.npmmirror.com/available-typed-arrays@1.0.5
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      es-set-tostringtag: registry.npmmirror.com/es-set-tostringtag@2.0.1
-      es-to-primitive: registry.npmmirror.com/es-to-primitive@1.2.1
-      function.prototype.name: registry.npmmirror.com/function.prototype.name@1.1.5
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-      get-symbol-description: registry.npmmirror.com/get-symbol-description@1.0.0
-      globalthis: registry.npmmirror.com/globalthis@1.0.3
-      gopd: registry.npmmirror.com/gopd@1.0.1
-      has: registry.npmmirror.com/has@1.0.3
-      has-property-descriptors: registry.npmmirror.com/has-property-descriptors@1.0.0
-      has-proto: registry.npmmirror.com/has-proto@1.0.1
-      has-symbols: registry.npmmirror.com/has-symbols@1.0.3
-      internal-slot: registry.npmmirror.com/internal-slot@1.0.5
-      is-array-buffer: registry.npmmirror.com/is-array-buffer@3.0.2
-      is-callable: registry.npmmirror.com/is-callable@1.2.7
-      is-negative-zero: registry.npmmirror.com/is-negative-zero@2.0.2
-      is-regex: registry.npmmirror.com/is-regex@1.1.4
-      is-shared-array-buffer: registry.npmmirror.com/is-shared-array-buffer@1.0.2
-      is-string: registry.npmmirror.com/is-string@1.0.7
-      is-typed-array: registry.npmmirror.com/is-typed-array@1.1.10
-      is-weakref: registry.npmmirror.com/is-weakref@1.0.2
-      object-inspect: registry.npmmirror.com/object-inspect@1.12.3
-      object-keys: registry.npmmirror.com/object-keys@1.1.1
-      object.assign: registry.npmmirror.com/object.assign@4.1.4
-      regexp.prototype.flags: registry.npmmirror.com/regexp.prototype.flags@1.5.0
-      safe-regex-test: registry.npmmirror.com/safe-regex-test@1.0.0
-      string.prototype.trim: registry.npmmirror.com/string.prototype.trim@1.2.7
-      string.prototype.trimend: registry.npmmirror.com/string.prototype.trimend@1.0.6
-      string.prototype.trimstart: registry.npmmirror.com/string.prototype.trimstart@1.0.6
-      typed-array-length: registry.npmmirror.com/typed-array-length@1.0.4
-      unbox-primitive: registry.npmmirror.com/unbox-primitive@1.0.2
-      which-typed-array: registry.npmmirror.com/which-typed-array@1.1.9
-    dev: false
-
-  registry.npmmirror.com/es-set-tostringtag@2.0.1:
-    resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz}
-    name: es-set-tostringtag
-    version: 2.0.1
-    engines: {node: '>= 0.4'}
-    dependencies:
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-      has: registry.npmmirror.com/has@1.0.3
-      has-tostringtag: registry.npmmirror.com/has-tostringtag@1.0.0
-    dev: false
-
-  registry.npmmirror.com/es-shim-unscopables@1.0.0:
-    resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz}
-    name: es-shim-unscopables
-    version: 1.0.0
-    dependencies:
-      has: registry.npmmirror.com/has@1.0.3
-    dev: false
-
-  registry.npmmirror.com/es-to-primitive@1.2.1:
-    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz}
-    name: es-to-primitive
-    version: 1.2.1
-    engines: {node: '>= 0.4'}
-    dependencies:
-      is-callable: registry.npmmirror.com/is-callable@1.2.7
-      is-date-object: registry.npmmirror.com/is-date-object@1.0.5
-      is-symbol: registry.npmmirror.com/is-symbol@1.0.4
-    dev: false
 
   registry.npmmirror.com/es5-ext@0.10.62:
     resolution: {integrity: sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.62.tgz}
@@ -4095,519 +1965,12 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  registry.npmmirror.com/escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz}
-    name: escape-string-regexp
-    version: 1.0.5
-    engines: {node: '>=0.8.0'}
-
   registry.npmmirror.com/escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz}
     name: escape-string-regexp
     version: 4.0.0
     engines: {node: '>=10'}
-
-  registry.npmmirror.com/eslint-ast-utils@1.1.0:
-    resolution: {integrity: sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz}
-    name: eslint-ast-utils
-    version: 1.1.0
-    engines: {node: '>=4'}
-    dependencies:
-      lodash.get: registry.npmmirror.com/lodash.get@4.4.2
-      lodash.zip: registry.npmmirror.com/lodash.zip@4.2.0
-    dev: false
-
-  registry.npmmirror.com/eslint-config-airbnb-base@14.2.1(eslint-plugin-import@2.27.5)(eslint@7.32.0):
-    resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz}
-    id: registry.npmmirror.com/eslint-config-airbnb-base/14.2.1
-    name: eslint-config-airbnb-base
-    version: 14.2.1
-    engines: {node: '>= 6'}
-    peerDependencies:
-      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-      eslint-plugin-import: ^2.22.1
-    dependencies:
-      confusing-browser-globals: registry.npmmirror.com/confusing-browser-globals@1.0.11
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-plugin-import: registry.npmmirror.com/eslint-plugin-import@2.27.5(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)
-      object.assign: registry.npmmirror.com/object.assign@4.1.4
-      object.entries: registry.npmmirror.com/object.entries@1.1.6
-    dev: false
-
-  registry.npmmirror.com/eslint-config-prettier@6.15.0(eslint@7.32.0):
-    resolution: {integrity: sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz}
-    id: registry.npmmirror.com/eslint-config-prettier/6.15.0
-    name: eslint-config-prettier
-    version: 6.15.0
-    hasBin: true
-    peerDependencies:
-      eslint: '>=3.14.1'
-    dependencies:
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      get-stdin: registry.npmmirror.com/get-stdin@6.0.0
-    dev: false
-
-  registry.npmmirror.com/eslint-formatter-pretty@4.1.0:
-    resolution: {integrity: sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz}
-    name: eslint-formatter-pretty
-    version: 4.1.0
-    engines: {node: '>=10'}
-    dependencies:
-      '@types/eslint': registry.npmmirror.com/@types/eslint@7.29.0
-      ansi-escapes: registry.npmmirror.com/ansi-escapes@4.3.2
-      chalk: registry.npmmirror.com/chalk@4.1.2
-      eslint-rule-docs: registry.npmmirror.com/eslint-rule-docs@1.1.235
-      log-symbols: registry.npmmirror.com/log-symbols@4.1.0
-      plur: registry.npmmirror.com/plur@4.0.0
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      supports-hyperlinks: registry.npmmirror.com/supports-hyperlinks@2.3.0
-    dev: false
-
-  registry.npmmirror.com/eslint-import-resolver-node@0.3.7:
-    resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz}
-    name: eslint-import-resolver-node
-    version: 0.3.7
-    dependencies:
-      debug: registry.npmmirror.com/debug@3.2.7
-      is-core-module: registry.npmmirror.com/is-core-module@2.12.1
-      resolve: registry.npmmirror.com/resolve@1.22.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/eslint-module-utils@2.8.0(@typescript-eslint/parser@4.33.0)(eslint-import-resolver-node@0.3.7)(eslint@7.32.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz}
-    id: registry.npmmirror.com/eslint-module-utils/2.8.0
-    name: eslint-module-utils
-    version: 2.8.0
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': registry.npmmirror.com/@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.1.3)
-      debug: registry.npmmirror.com/debug@3.2.7
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-import-resolver-node: registry.npmmirror.com/eslint-import-resolver-node@0.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-babel@5.3.1(eslint@7.32.0):
-    resolution: {integrity: sha512-VsQEr6NH3dj664+EyxJwO4FCYm/00JhYb3Sk3ft8o+fpKuIfQ9TaW6uVUfvwMXHcf/lsnRIoyFPsLMyiWCSL/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz}
-    id: registry.npmmirror.com/eslint-plugin-babel/5.3.1
-    name: eslint-plugin-babel
-    version: 5.3.1
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: '>=4.0.0'
-    dependencies:
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-rule-composer: registry.npmmirror.com/eslint-rule-composer@0.3.0
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-compat@3.13.0(eslint@7.32.0):
-    resolution: {integrity: sha512-cv8IYMuTXm7PIjMVDN2y4k/KVnKZmoNGHNq27/9dLstOLydKblieIv+oe2BN2WthuXnFNhaNvv3N1Bvl4dbIGA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-compat/-/eslint-plugin-compat-3.13.0.tgz}
-    id: registry.npmmirror.com/eslint-plugin-compat/3.13.0
-    name: eslint-plugin-compat
-    version: 3.13.0
-    engines: {node: '>=9.x'}
-    peerDependencies:
-      eslint: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-    dependencies:
-      '@mdn/browser-compat-data': registry.npmmirror.com/@mdn/browser-compat-data@3.3.14
-      ast-metadata-inferer: registry.npmmirror.com/ast-metadata-inferer@0.7.0
-      browserslist: registry.npmmirror.com/browserslist@4.21.9
-      caniuse-lite: registry.npmmirror.com/caniuse-lite@1.0.30001514
-      core-js: registry.npmmirror.com/core-js@3.31.1
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      find-up: registry.npmmirror.com/find-up@5.0.0
-      lodash.memoize: registry.npmmirror.com/lodash.memoize@4.1.2
-      semver: registry.npmmirror.com/semver@7.3.5
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-eslint-comments@3.2.0(eslint@7.32.0):
-    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz}
-    id: registry.npmmirror.com/eslint-plugin-eslint-comments/3.2.0
-    name: eslint-plugin-eslint-comments
-    version: 3.2.0
-    engines: {node: '>=6.5.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-    dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      ignore: registry.npmmirror.com/ignore@5.2.4
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-import@2.27.5(@typescript-eslint/parser@4.33.0)(eslint@7.32.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz}
-    id: registry.npmmirror.com/eslint-plugin-import/2.27.5
-    name: eslint-plugin-import
-    version: 2.27.5
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': registry.npmmirror.com/@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.1.3)
-      array-includes: registry.npmmirror.com/array-includes@3.1.6
-      array.prototype.flat: registry.npmmirror.com/array.prototype.flat@1.3.1
-      array.prototype.flatmap: registry.npmmirror.com/array.prototype.flatmap@1.3.1
-      debug: registry.npmmirror.com/debug@3.2.7
-      doctrine: registry.npmmirror.com/doctrine@2.1.0
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-import-resolver-node: registry.npmmirror.com/eslint-import-resolver-node@0.3.7
-      eslint-module-utils: registry.npmmirror.com/eslint-module-utils@2.8.0(@typescript-eslint/parser@4.33.0)(eslint-import-resolver-node@0.3.7)(eslint@7.32.0)
-      has: registry.npmmirror.com/has@1.0.3
-      is-core-module: registry.npmmirror.com/is-core-module@2.12.1
-      is-glob: registry.npmmirror.com/is-glob@4.0.3
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-      object.values: registry.npmmirror.com/object.values@1.1.6
-      resolve: registry.npmmirror.com/resolve@1.22.2
-      semver: registry.npmmirror.com/semver@6.3.0
-      tsconfig-paths: registry.npmmirror.com/tsconfig-paths@3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@4.33.0)(eslint@7.32.0)(typescript@4.1.3):
-    resolution: {integrity: sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz}
-    id: registry.npmmirror.com/eslint-plugin-jest/24.7.0
-    name: eslint-plugin-jest
-    version: 24.7.0
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': '>= 4'
-      eslint: '>=5'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': registry.npmmirror.com/@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@4.1.3)
-      '@typescript-eslint/experimental-utils': registry.npmmirror.com/@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@4.1.3)
-      eslint: registry.npmmirror.com/eslint@7.32.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-jsx-a11y@6.7.1(eslint@7.32.0):
-    resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz}
-    id: registry.npmmirror.com/eslint-plugin-jsx-a11y/6.7.1
-    name: eslint-plugin-jsx-a11y
-    version: 6.7.1
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      '@babel/runtime': registry.npmmirror.com/@babel/runtime@7.22.6
-      aria-query: registry.npmmirror.com/aria-query@5.3.0
-      array-includes: registry.npmmirror.com/array-includes@3.1.6
-      array.prototype.flatmap: registry.npmmirror.com/array.prototype.flatmap@1.3.1
-      ast-types-flow: registry.npmmirror.com/ast-types-flow@0.0.7
-      axe-core: registry.npmmirror.com/axe-core@4.7.2
-      axobject-query: registry.npmmirror.com/axobject-query@3.2.1
-      damerau-levenshtein: registry.npmmirror.com/damerau-levenshtein@1.0.8
-      emoji-regex: registry.npmmirror.com/emoji-regex@9.2.2
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      has: registry.npmmirror.com/has@1.0.3
-      jsx-ast-utils: registry.npmmirror.com/jsx-ast-utils@3.3.4
-      language-tags: registry.npmmirror.com/language-tags@1.0.5
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-      object.entries: registry.npmmirror.com/object.entries@1.1.6
-      object.fromentries: registry.npmmirror.com/object.fromentries@2.0.6
-      semver: registry.npmmirror.com/semver@6.3.0
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-markdown@1.0.2:
-    resolution: {integrity: sha512-BfvXKsO0K+zvdarNc801jsE/NTLmig4oKhZ1U3aSUgTf2dB/US5+CrfGxMsCK2Ki1vS1R3HPok+uYpufFndhzw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.2.tgz}
-    name: eslint-plugin-markdown
-    version: 1.0.2
-    engines: {node: ^6.14.0 || ^8.10.0 || >=9.10.0}
-    dependencies:
-      object-assign: registry.npmmirror.com/object-assign@4.1.1
-      remark-parse: registry.npmmirror.com/remark-parse@5.0.0
-      unified: registry.npmmirror.com/unified@6.2.0
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-promise@4.3.1:
-    resolution: {integrity: sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz}
-    name: eslint-plugin-promise
-    version: 4.3.1
-    engines: {node: '>=6'}
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-react-hooks@4.6.0(eslint@7.32.0):
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz}
-    id: registry.npmmirror.com/eslint-plugin-react-hooks/4.6.0
-    name: eslint-plugin-react-hooks
-    version: 4.6.0
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: registry.npmmirror.com/eslint@7.32.0
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-react@7.32.2(eslint@7.32.0):
-    resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz}
-    id: registry.npmmirror.com/eslint-plugin-react/7.32.2
-    name: eslint-plugin-react
-    version: 7.32.2
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: registry.npmmirror.com/array-includes@3.1.6
-      array.prototype.flatmap: registry.npmmirror.com/array.prototype.flatmap@1.3.1
-      array.prototype.tosorted: registry.npmmirror.com/array.prototype.tosorted@1.1.1
-      doctrine: registry.npmmirror.com/doctrine@2.1.0
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      estraverse: registry.npmmirror.com/estraverse@5.3.0
-      jsx-ast-utils: registry.npmmirror.com/jsx-ast-utils@3.3.4
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-      object.entries: registry.npmmirror.com/object.entries@1.1.6
-      object.fromentries: registry.npmmirror.com/object.fromentries@2.0.6
-      object.hasown: registry.npmmirror.com/object.hasown@1.1.2
-      object.values: registry.npmmirror.com/object.values@1.1.6
-      prop-types: registry.npmmirror.com/prop-types@15.8.1
-      resolve: registry.npmmirror.com/resolve@2.0.0-next.4
-      semver: registry.npmmirror.com/semver@6.3.0
-      string.prototype.matchall: registry.npmmirror.com/string.prototype.matchall@4.0.8
-    dev: false
-
-  registry.npmmirror.com/eslint-plugin-unicorn@20.1.0(eslint@7.32.0):
-    resolution: {integrity: sha512-XQxLBJT/gnwyRR6cfYsIK1AdekQchAt5tmcsnldevGjgR2xoZsRUa5/i6e0seNHy2RoT57CkTnbVHwHF8No8LA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-20.1.0.tgz}
-    id: registry.npmmirror.com/eslint-plugin-unicorn/20.1.0
-    name: eslint-plugin-unicorn
-    version: 20.1.0
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      ci-info: registry.npmmirror.com/ci-info@2.0.0
-      clean-regexp: registry.npmmirror.com/clean-regexp@1.0.0
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-ast-utils: registry.npmmirror.com/eslint-ast-utils@1.1.0
-      eslint-template-visitor: registry.npmmirror.com/eslint-template-visitor@2.3.2(eslint@7.32.0)
-      eslint-utils: registry.npmmirror.com/eslint-utils@2.1.0
-      import-modules: registry.npmmirror.com/import-modules@2.1.0
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      pluralize: registry.npmmirror.com/pluralize@8.0.0
-      read-pkg-up: registry.npmmirror.com/read-pkg-up@7.0.1
-      regexp-tree: registry.npmmirror.com/regexp-tree@0.1.27
-      reserved-words: registry.npmmirror.com/reserved-words@0.1.2
-      safe-regex: registry.npmmirror.com/safe-regex@2.1.1
-      semver: registry.npmmirror.com/semver@7.5.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/eslint-rule-composer@0.3.0:
-    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz}
-    name: eslint-rule-composer
-    version: 0.3.0
-    engines: {node: '>=4.0.0'}
-    dev: false
-
-  registry.npmmirror.com/eslint-rule-docs@1.1.235:
-    resolution: {integrity: sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz}
-    name: eslint-rule-docs
-    version: 1.1.235
-    dev: false
-
-  registry.npmmirror.com/eslint-scope@5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-scope/-/eslint-scope-5.1.1.tgz}
-    name: eslint-scope
-    version: 5.1.1
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      esrecurse: registry.npmmirror.com/esrecurse@4.3.0
-      estraverse: registry.npmmirror.com/estraverse@4.3.0
-    dev: false
-
-  registry.npmmirror.com/eslint-template-visitor@2.3.2(eslint@7.32.0):
-    resolution: {integrity: sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz}
-    id: registry.npmmirror.com/eslint-template-visitor/2.3.2
-    name: eslint-template-visitor
-    version: 2.3.2
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      '@babel/eslint-parser': registry.npmmirror.com/@babel/eslint-parser@7.22.7(@babel/core@7.22.8)(eslint@7.32.0)
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys@2.1.0
-      esquery: registry.npmmirror.com/esquery@1.5.0
-      multimap: registry.npmmirror.com/multimap@1.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/eslint-utils@2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-utils/-/eslint-utils-2.1.0.tgz}
-    name: eslint-utils
-    version: 2.1.0
-    engines: {node: '>=6'}
-    dependencies:
-      eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys@1.3.0
-    dev: false
-
-  registry.npmmirror.com/eslint-utils@3.0.0(eslint@7.32.0):
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-utils/-/eslint-utils-3.0.0.tgz}
-    id: registry.npmmirror.com/eslint-utils/3.0.0
-    name: eslint-utils
-    version: 3.0.0
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: registry.npmmirror.com/eslint@7.32.0
-      eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys@2.1.0
-    dev: false
-
-  registry.npmmirror.com/eslint-visitor-keys@1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz}
-    name: eslint-visitor-keys
-    version: 1.3.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/eslint-visitor-keys@2.1.0:
-    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz}
-    name: eslint-visitor-keys
-    version: 2.1.0
-    engines: {node: '>=10'}
-    dev: false
-
-  registry.npmmirror.com/eslint@7.32.0:
-    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/eslint/-/eslint-7.32.0.tgz}
-    name: eslint
-    version: 7.32.0
-    engines: {node: ^10.12.0 || >=12.0.0}
-    hasBin: true
-    dependencies:
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.12.11
-      '@eslint/eslintrc': registry.npmmirror.com/@eslint/eslintrc@0.4.3
-      '@humanwhocodes/config-array': registry.npmmirror.com/@humanwhocodes/config-array@0.5.0
-      ajv: registry.npmmirror.com/ajv@6.12.6
-      chalk: registry.npmmirror.com/chalk@4.1.2
-      cross-spawn: registry.npmmirror.com/cross-spawn@7.0.3
-      debug: registry.npmmirror.com/debug@4.3.4
-      doctrine: registry.npmmirror.com/doctrine@3.0.0
-      enquirer: registry.npmmirror.com/enquirer@2.3.6
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@4.0.0
-      eslint-scope: registry.npmmirror.com/eslint-scope@5.1.1
-      eslint-utils: registry.npmmirror.com/eslint-utils@2.1.0
-      eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys@2.1.0
-      espree: registry.npmmirror.com/espree@7.3.1
-      esquery: registry.npmmirror.com/esquery@1.5.0
-      esutils: registry.npmmirror.com/esutils@2.0.3
-      fast-deep-equal: registry.npmmirror.com/fast-deep-equal@3.1.3
-      file-entry-cache: registry.npmmirror.com/file-entry-cache@6.0.1
-      functional-red-black-tree: registry.npmmirror.com/functional-red-black-tree@1.0.1
-      glob-parent: registry.npmmirror.com/glob-parent@5.1.2
-      globals: registry.npmmirror.com/globals@13.20.0
-      ignore: registry.npmmirror.com/ignore@4.0.6
-      import-fresh: registry.npmmirror.com/import-fresh@3.3.0
-      imurmurhash: registry.npmmirror.com/imurmurhash@0.1.4
-      is-glob: registry.npmmirror.com/is-glob@4.0.3
-      js-yaml: registry.npmmirror.com/js-yaml@3.14.1
-      json-stable-stringify-without-jsonify: registry.npmmirror.com/json-stable-stringify-without-jsonify@1.0.1
-      levn: registry.npmmirror.com/levn@0.4.1
-      lodash.merge: registry.npmmirror.com/lodash.merge@4.6.2
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-      natural-compare: registry.npmmirror.com/natural-compare@1.4.0
-      optionator: registry.npmmirror.com/optionator@0.9.3
-      progress: registry.npmmirror.com/progress@2.0.3
-      regexpp: registry.npmmirror.com/regexpp@3.2.0
-      semver: registry.npmmirror.com/semver@7.5.4
-      strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
-      strip-json-comments: registry.npmmirror.com/strip-json-comments@3.1.1
-      table: registry.npmmirror.com/table@6.8.1
-      text-table: registry.npmmirror.com/text-table@0.2.0
-      v8-compile-cache: registry.npmmirror.com/v8-compile-cache@2.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/espree@7.3.1:
-    resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/espree/-/espree-7.3.1.tgz}
-    name: espree
-    version: 7.3.1
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      acorn: registry.npmmirror.com/acorn@7.4.1
-      acorn-jsx: registry.npmmirror.com/acorn-jsx@5.3.2(acorn@7.4.1)
-      eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys@1.3.0
-    dev: false
-
-  registry.npmmirror.com/esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/esprima/-/esprima-4.0.1.tgz}
-    name: esprima
-    version: 4.0.1
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/esquery@1.5.0:
-    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/esquery/-/esquery-1.5.0.tgz}
-    name: esquery
-    version: 1.5.0
-    engines: {node: '>=0.10'}
-    dependencies:
-      estraverse: registry.npmmirror.com/estraverse@5.3.0
-    dev: false
-
-  registry.npmmirror.com/esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/esrecurse/-/esrecurse-4.3.0.tgz}
-    name: esrecurse
-    version: 4.3.0
-    engines: {node: '>=4.0'}
-    dependencies:
-      estraverse: registry.npmmirror.com/estraverse@5.3.0
-    dev: false
-
-  registry.npmmirror.com/estraverse@4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/estraverse/-/estraverse-4.3.0.tgz}
-    name: estraverse
-    version: 4.3.0
-    engines: {node: '>=4.0'}
-    dev: false
-
-  registry.npmmirror.com/estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz}
-    name: estraverse
-    version: 5.3.0
-    engines: {node: '>=4.0'}
-    dev: false
-
-  registry.npmmirror.com/esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz}
-    name: esutils
-    version: 2.0.3
-    engines: {node: '>=0.10.0'}
-    dev: false
+    dev: true
 
   registry.npmmirror.com/event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/event-emitter/-/event-emitter-0.3.5.tgz}
@@ -4624,51 +1987,16 @@ packages:
     version: 5.1.1
     engines: {node: '>=10'}
     dependencies:
-      cross-spawn: registry.npmmirror.com/cross-spawn@7.0.3
-      get-stream: registry.npmmirror.com/get-stream@6.0.1
-      human-signals: registry.npmmirror.com/human-signals@2.1.0
-      is-stream: registry.npmmirror.com/is-stream@2.0.1
-      merge-stream: registry.npmmirror.com/merge-stream@2.0.0
-      npm-run-path: registry.npmmirror.com/npm-run-path@4.0.1
-      onetime: registry.npmmirror.com/onetime@5.1.2
-      signal-exit: registry.npmmirror.com/signal-exit@3.0.7
-      strip-final-newline: registry.npmmirror.com/strip-final-newline@2.0.0
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
     dev: true
-
-  registry.npmmirror.com/execall@1.0.0:
-    resolution: {integrity: sha512-/J0Q8CvOvlAdpvhfkD/WnTQ4H1eU0exze2nFGPj/RSC7jpQ0NkKe2r28T5eMkhEEs+fzepMZNy1kVRKNlC04nQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/execall/-/execall-1.0.0.tgz}
-    name: execall
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      clone-regexp: registry.npmmirror.com/clone-regexp@1.0.1
-    dev: false
-
-  registry.npmmirror.com/execall@2.0.0:
-    resolution: {integrity: sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/execall/-/execall-2.0.0.tgz}
-    name: execall
-    version: 2.0.0
-    engines: {node: '>=8'}
-    dependencies:
-      clone-regexp: registry.npmmirror.com/clone-regexp@2.2.0
-    dev: false
-
-  registry.npmmirror.com/expand-brackets@2.1.4:
-    resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/expand-brackets/-/expand-brackets-2.1.4.tgz}
-    name: expand-brackets
-    version: 2.1.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      debug: registry.npmmirror.com/debug@2.6.9
-      define-property: registry.npmmirror.com/define-property@0.2.5
-      extend-shallow: registry.npmmirror.com/extend-shallow@2.0.1
-      posix-character-classes: registry.npmmirror.com/posix-character-classes@0.1.1
-      regex-not: registry.npmmirror.com/regex-not@1.0.2
-      snapdragon: registry.npmmirror.com/snapdragon@0.8.2
-      to-regex: registry.npmmirror.com/to-regex@3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   registry.npmmirror.com/ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ext/-/ext-1.7.0.tgz}
@@ -4676,31 +2004,6 @@ packages:
     version: 1.7.0
     dependencies:
       type: registry.npmmirror.com/type@2.7.2
-    dev: false
-
-  registry.npmmirror.com/extend-shallow@2.0.1:
-    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/extend-shallow/-/extend-shallow-2.0.1.tgz}
-    name: extend-shallow
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extendable: registry.npmmirror.com/is-extendable@0.1.1
-    dev: false
-
-  registry.npmmirror.com/extend-shallow@3.0.2:
-    resolution: {integrity: sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/extend-shallow/-/extend-shallow-3.0.2.tgz}
-    name: extend-shallow
-    version: 3.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      assign-symbols: registry.npmmirror.com/assign-symbols@1.0.0
-      is-extendable: registry.npmmirror.com/is-extendable@1.0.1
-    dev: false
-
-  registry.npmmirror.com/extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz}
-    name: extend
-    version: 3.0.2
     dev: false
 
   registry.npmmirror.com/external-editor@3.1.0:
@@ -4714,89 +2017,11 @@ packages:
       tmp: registry.npmmirror.com/tmp@0.0.33
     dev: true
 
-  registry.npmmirror.com/extglob@2.0.4:
-    resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/extglob/-/extglob-2.0.4.tgz}
-    name: extglob
-    version: 2.0.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-unique: registry.npmmirror.com/array-unique@0.3.2
-      define-property: registry.npmmirror.com/define-property@1.0.0
-      expand-brackets: registry.npmmirror.com/expand-brackets@2.1.4
-      extend-shallow: registry.npmmirror.com/extend-shallow@2.0.1
-      fragment-cache: registry.npmmirror.com/fragment-cache@0.2.1
-      regex-not: registry.npmmirror.com/regex-not@1.0.2
-      snapdragon: registry.npmmirror.com/snapdragon@0.8.2
-      to-regex: registry.npmmirror.com/to-regex@3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz}
-    name: fast-deep-equal
-    version: 3.1.3
-    dev: false
-
-  registry.npmmirror.com/fast-glob@2.2.7:
-    resolution: {integrity: sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fast-glob/-/fast-glob-2.2.7.tgz}
-    name: fast-glob
-    version: 2.2.7
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      '@mrmlnc/readdir-enhanced': registry.npmmirror.com/@mrmlnc/readdir-enhanced@2.2.1
-      '@nodelib/fs.stat': registry.npmmirror.com/@nodelib/fs.stat@1.1.3
-      glob-parent: registry.npmmirror.com/glob-parent@3.1.0
-      is-glob: registry.npmmirror.com/is-glob@4.0.3
-      merge2: registry.npmmirror.com/merge2@1.4.1
-      micromatch: registry.npmmirror.com/micromatch@3.1.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/fast-glob@3.3.0:
-    resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fast-glob/-/fast-glob-3.3.0.tgz}
-    name: fast-glob
-    version: 3.3.0
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': registry.npmmirror.com/@nodelib/fs.stat@2.0.5
-      '@nodelib/fs.walk': registry.npmmirror.com/@nodelib/fs.walk@1.2.8
-      glob-parent: registry.npmmirror.com/glob-parent@5.1.2
-      merge2: registry.npmmirror.com/merge2@1.4.1
-      micromatch: registry.npmmirror.com/micromatch@4.0.5
-
-  registry.npmmirror.com/fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz}
-    name: fast-json-stable-stringify
-    version: 2.1.0
-    dev: false
-
-  registry.npmmirror.com/fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz}
-    name: fast-levenshtein
-    version: 2.0.6
-    dev: false
-
   registry.npmmirror.com/fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz}
     name: fast-safe-stringify
     version: 2.1.1
     dev: false
-
-  registry.npmmirror.com/fastest-levenshtein@1.0.16:
-    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz}
-    name: fastest-levenshtein
-    version: 1.0.16
-    engines: {node: '>= 4.9.1'}
-    dev: false
-
-  registry.npmmirror.com/fastq@1.15.0:
-    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fastq/-/fastq-1.15.0.tgz}
-    name: fastq
-    version: 1.15.0
-    dependencies:
-      reusify: registry.npmmirror.com/reusify@1.0.4
 
   registry.npmmirror.com/figures@1.7.0:
     resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/figures/-/figures-1.7.0.tgz}
@@ -4804,8 +2029,8 @@ packages:
     version: 1.7.0
     engines: {node: '>=0.10.0'}
     dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
-      object-assign: registry.npmmirror.com/object-assign@4.1.1
+      escape-string-regexp: 1.0.5
+      object-assign: 4.1.1
     dev: true
 
   registry.npmmirror.com/figures@2.0.0:
@@ -4814,7 +2039,7 @@ packages:
     version: 2.0.0
     engines: {node: '>=4'}
     dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
+      escape-string-regexp: 1.0.5
     dev: true
 
   registry.npmmirror.com/figures@3.2.0:
@@ -4823,170 +2048,24 @@ packages:
     version: 3.2.0
     engines: {node: '>=8'}
     dependencies:
-      escape-string-regexp: registry.npmmirror.com/escape-string-regexp@1.0.5
+      escape-string-regexp: 1.0.5
     dev: true
-
-  registry.npmmirror.com/file-entry-cache@4.0.0:
-    resolution: {integrity: sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-4.0.0.tgz}
-    name: file-entry-cache
-    version: 4.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      flat-cache: registry.npmmirror.com/flat-cache@2.0.1
-    dev: false
-
-  registry.npmmirror.com/file-entry-cache@6.0.1:
-    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz}
-    name: file-entry-cache
-    version: 6.0.1
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      flat-cache: registry.npmmirror.com/flat-cache@3.0.4
-    dev: false
-
-  registry.npmmirror.com/fill-range@4.0.0:
-    resolution: {integrity: sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fill-range/-/fill-range-4.0.0.tgz}
-    name: fill-range
-    version: 4.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: registry.npmmirror.com/extend-shallow@2.0.1
-      is-number: registry.npmmirror.com/is-number@3.0.0
-      repeat-string: registry.npmmirror.com/repeat-string@1.6.1
-      to-regex-range: registry.npmmirror.com/to-regex-range@2.1.1
-    dev: false
 
   registry.npmmirror.com/fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fill-range/-/fill-range-7.0.1.tgz}
     name: fill-range
     version: 7.0.1
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       to-regex-range: registry.npmmirror.com/to-regex-range@5.0.1
-
-  registry.npmmirror.com/find-up@2.1.0:
-    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/find-up/-/find-up-2.1.0.tgz}
-    name: find-up
-    version: 2.1.0
-    engines: {node: '>=4'}
-    dependencies:
-      locate-path: registry.npmmirror.com/locate-path@2.0.0
     dev: false
-
-  registry.npmmirror.com/find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/find-up/-/find-up-4.1.0.tgz}
-    name: find-up
-    version: 4.1.0
-    engines: {node: '>=8'}
-    dependencies:
-      locate-path: registry.npmmirror.com/locate-path@5.0.0
-      path-exists: registry.npmmirror.com/path-exists@4.0.0
-
-  registry.npmmirror.com/find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz}
-    name: find-up
-    version: 5.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      locate-path: registry.npmmirror.com/locate-path@6.0.0
-      path-exists: registry.npmmirror.com/path-exists@4.0.0
-
-  registry.npmmirror.com/flat-cache@2.0.1:
-    resolution: {integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/flat-cache/-/flat-cache-2.0.1.tgz}
-    name: flat-cache
-    version: 2.0.1
-    engines: {node: '>=4'}
-    dependencies:
-      flatted: registry.npmmirror.com/flatted@2.0.2
-      rimraf: registry.npmmirror.com/rimraf@2.6.3
-      write: registry.npmmirror.com/write@1.0.3
-    dev: false
-
-  registry.npmmirror.com/flat-cache@3.0.4:
-    resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/flat-cache/-/flat-cache-3.0.4.tgz}
-    name: flat-cache
-    version: 3.0.4
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      flatted: registry.npmmirror.com/flatted@3.2.7
-      rimraf: registry.npmmirror.com/rimraf@3.0.2
-    dev: false
-
-  registry.npmmirror.com/flatted@2.0.2:
-    resolution: {integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/flatted/-/flatted-2.0.2.tgz}
-    name: flatted
-    version: 2.0.2
-    dev: false
-
-  registry.npmmirror.com/flatted@3.2.7:
-    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/flatted/-/flatted-3.2.7.tgz}
-    name: flatted
-    version: 3.2.7
-    dev: false
-
-  registry.npmmirror.com/for-each@0.3.3:
-    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/for-each/-/for-each-0.3.3.tgz}
-    name: for-each
-    version: 0.3.3
-    dependencies:
-      is-callable: registry.npmmirror.com/is-callable@1.2.7
-    dev: false
-
-  registry.npmmirror.com/for-in@1.0.2:
-    resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/for-in/-/for-in-1.0.2.tgz}
-    name: for-in
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/fragment-cache@0.2.1:
-    resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fragment-cache/-/fragment-cache-0.2.1.tgz}
-    name: fragment-cache
-    version: 0.2.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      map-cache: registry.npmmirror.com/map-cache@0.2.2
-    dev: false
+    optional: true
 
   registry.npmmirror.com/fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz}
     name: fs.realpath
     version: 1.0.0
-
-  registry.npmmirror.com/function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/function-bind/-/function-bind-1.1.1.tgz}
-    name: function-bind
-    version: 1.1.1
-
-  registry.npmmirror.com/function.prototype.name@1.1.5:
-    resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz}
-    name: function.prototype.name
-    version: 1.1.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-      functions-have-names: registry.npmmirror.com/functions-have-names@1.2.3
-    dev: false
-
-  registry.npmmirror.com/functional-red-black-tree@1.0.1:
-    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz}
-    name: functional-red-black-tree
-    version: 1.0.1
-    dev: false
-
-  registry.npmmirror.com/functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/functions-have-names/-/functions-have-names-1.2.3.tgz}
-    name: functions-have-names
-    version: 1.2.3
-    dev: false
-
-  registry.npmmirror.com/gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/gensync/-/gensync-1.0.0-beta.2.tgz}
-    name: gensync
-    version: 1.0.0-beta.2
-    engines: {node: '>=6.9.0'}
     dev: false
 
   registry.npmmirror.com/get-caller-file@2.0.5:
@@ -4996,101 +2075,22 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: false
 
-  registry.npmmirror.com/get-intrinsic@1.2.1:
-    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz}
-    name: get-intrinsic
-    version: 1.2.1
-    dependencies:
-      function-bind: registry.npmmirror.com/function-bind@1.1.1
-      has: registry.npmmirror.com/has@1.0.3
-      has-proto: registry.npmmirror.com/has-proto@1.0.1
-      has-symbols: registry.npmmirror.com/has-symbols@1.0.3
-    dev: false
-
-  registry.npmmirror.com/get-stdin@6.0.0:
-    resolution: {integrity: sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-stdin/-/get-stdin-6.0.0.tgz}
-    name: get-stdin
-    version: 6.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/get-stdin@8.0.0:
-    resolution: {integrity: sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-stdin/-/get-stdin-8.0.0.tgz}
-    name: get-stdin
-    version: 8.0.0
-    engines: {node: '>=10'}
-    dev: false
-
-  registry.npmmirror.com/get-stream@4.1.0:
-    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-stream/-/get-stream-4.1.0.tgz}
-    name: get-stream
-    version: 4.1.0
-    engines: {node: '>=6'}
-    dependencies:
-      pump: registry.npmmirror.com/pump@3.0.0
-    dev: true
-
-  registry.npmmirror.com/get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-stream/-/get-stream-5.2.0.tgz}
-    name: get-stream
-    version: 5.2.0
-    engines: {node: '>=8'}
-    dependencies:
-      pump: registry.npmmirror.com/pump@3.0.0
-    dev: true
-
-  registry.npmmirror.com/get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-stream/-/get-stream-6.0.1.tgz}
-    name: get-stream
-    version: 6.0.1
-    engines: {node: '>=10'}
-    dev: true
-
-  registry.npmmirror.com/get-symbol-description@1.0.0:
-    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz}
-    name: get-symbol-description
-    version: 1.0.0
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-    dev: false
-
-  registry.npmmirror.com/get-value@2.0.6:
-    resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/get-value/-/get-value-2.0.6.tgz}
-    name: get-value
-    version: 2.0.6
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   registry.npmmirror.com/github-url-from-git@1.5.0:
     resolution: {integrity: sha512-WWOec4aRI7YAykQ9+BHmzjyNlkfJFG8QLXnDTsLz/kZefq7qkzdfo4p6fkYYMIq1aj+gZcQs/1HQhQh3DPPxlQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz}
     name: github-url-from-git
     version: 1.5.0
     dev: true
 
-  registry.npmmirror.com/glob-parent@3.1.0:
-    resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/glob-parent/-/glob-parent-3.1.0.tgz}
-    name: glob-parent
-    version: 3.1.0
-    dependencies:
-      is-glob: registry.npmmirror.com/is-glob@3.1.0
-      path-dirname: registry.npmmirror.com/path-dirname@1.0.2
-    dev: false
-
   registry.npmmirror.com/glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz}
     name: glob-parent
     version: 5.1.2
     engines: {node: '>= 6'}
+    requiresBuild: true
     dependencies:
       is-glob: registry.npmmirror.com/is-glob@4.0.3
-
-  registry.npmmirror.com/glob-to-regexp@0.3.0:
-    resolution: {integrity: sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz}
-    name: glob-to-regexp
-    version: 0.3.0
     dev: false
+    optional: true
 
   registry.npmmirror.com/glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/glob/-/glob-7.1.6.tgz}
@@ -5103,6 +2103,7 @@ packages:
       minimatch: registry.npmmirror.com/minimatch@3.1.2
       once: registry.npmmirror.com/once@1.4.0
       path-is-absolute: registry.npmmirror.com/path-is-absolute@1.0.1
+    dev: false
 
   registry.npmmirror.com/global-dirs@2.1.0:
     resolution: {integrity: sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/global-dirs/-/global-dirs-2.1.0.tgz}
@@ -5110,7 +2111,7 @@ packages:
     version: 2.1.0
     engines: {node: '>=8'}
     dependencies:
-      ini: registry.npmmirror.com/ini@1.3.7
+      ini: 1.3.7
     dev: true
 
   registry.npmmirror.com/global-dirs@3.0.1:
@@ -5119,108 +2120,8 @@ packages:
     version: 3.0.1
     engines: {node: '>=10'}
     dependencies:
-      ini: registry.npmmirror.com/ini@2.0.0
+      ini: 2.0.0
     dev: true
-
-  registry.npmmirror.com/global-modules@2.0.0:
-    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/global-modules/-/global-modules-2.0.0.tgz}
-    name: global-modules
-    version: 2.0.0
-    engines: {node: '>=6'}
-    dependencies:
-      global-prefix: registry.npmmirror.com/global-prefix@3.0.0
-    dev: false
-
-  registry.npmmirror.com/global-prefix@3.0.0:
-    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/global-prefix/-/global-prefix-3.0.0.tgz}
-    name: global-prefix
-    version: 3.0.0
-    engines: {node: '>=6'}
-    dependencies:
-      ini: registry.npmmirror.com/ini@1.3.8
-      kind-of: registry.npmmirror.com/kind-of@6.0.3
-      which: registry.npmmirror.com/which@1.3.1
-    dev: false
-
-  registry.npmmirror.com/globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/globals/-/globals-11.12.0.tgz}
-    name: globals
-    version: 11.12.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/globals@13.20.0:
-    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/globals/-/globals-13.20.0.tgz}
-    name: globals
-    version: 13.20.0
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: registry.npmmirror.com/type-fest@0.20.2
-    dev: false
-
-  registry.npmmirror.com/globalthis@1.0.3:
-    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/globalthis/-/globalthis-1.0.3.tgz}
-    name: globalthis
-    version: 1.0.3
-    engines: {node: '>= 0.4'}
-    dependencies:
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-    dev: false
-
-  registry.npmmirror.com/globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/globby/-/globby-11.1.0.tgz}
-    name: globby
-    version: 11.1.0
-    engines: {node: '>=10'}
-    dependencies:
-      array-union: registry.npmmirror.com/array-union@2.1.0
-      dir-glob: registry.npmmirror.com/dir-glob@3.0.1
-      fast-glob: registry.npmmirror.com/fast-glob@3.3.0
-      ignore: registry.npmmirror.com/ignore@5.2.4
-      merge2: registry.npmmirror.com/merge2@1.4.1
-      slash: registry.npmmirror.com/slash@3.0.0
-
-  registry.npmmirror.com/globby@9.2.0:
-    resolution: {integrity: sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/globby/-/globby-9.2.0.tgz}
-    name: globby
-    version: 9.2.0
-    engines: {node: '>=6'}
-    dependencies:
-      '@types/glob': registry.npmmirror.com/@types/glob@7.2.0
-      array-union: registry.npmmirror.com/array-union@1.0.2
-      dir-glob: registry.npmmirror.com/dir-glob@2.2.2
-      fast-glob: registry.npmmirror.com/fast-glob@2.2.7
-      glob: registry.npmmirror.com/glob@7.1.6
-      ignore: registry.npmmirror.com/ignore@4.0.6
-      pify: registry.npmmirror.com/pify@4.0.1
-      slash: registry.npmmirror.com/slash@2.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/globjoin@0.1.4:
-    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/globjoin/-/globjoin-0.1.4.tgz}
-    name: globjoin
-    version: 0.1.4
-    dev: false
-
-  registry.npmmirror.com/gonzales-pe@4.3.0:
-    resolution: {integrity: sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/gonzales-pe/-/gonzales-pe-4.3.0.tgz}
-    name: gonzales-pe
-    version: 4.3.0
-    engines: {node: '>=0.6.0'}
-    hasBin: true
-    dependencies:
-      minimist: registry.npmmirror.com/minimist@1.2.8
-    dev: false
-
-  registry.npmmirror.com/gopd@1.0.1:
-    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/gopd/-/gopd-1.0.1.tgz}
-    name: gopd
-    version: 1.0.1
-    dependencies:
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-    dev: false
 
   registry.npmmirror.com/got@10.7.0:
     resolution: {integrity: sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/got/-/got-10.7.0.tgz}
@@ -5237,14 +2138,14 @@ packages:
       cacheable-request: registry.npmmirror.com/cacheable-request@7.0.4
       decompress-response: registry.npmmirror.com/decompress-response@5.0.0
       duplexer3: registry.npmmirror.com/duplexer3@0.1.5
-      get-stream: registry.npmmirror.com/get-stream@5.2.0
+      get-stream: 5.2.0
       lowercase-keys: registry.npmmirror.com/lowercase-keys@2.0.0
       mimic-response: registry.npmmirror.com/mimic-response@2.1.0
       p-cancelable: registry.npmmirror.com/p-cancelable@2.1.1
       p-event: registry.npmmirror.com/p-event@4.2.0
       responselike: registry.npmmirror.com/responselike@2.0.1
       to-readable-stream: registry.npmmirror.com/to-readable-stream@2.1.0
-      type-fest: registry.npmmirror.com/type-fest@0.10.0
+      type-fest: 0.10.0
     dev: true
 
   registry.npmmirror.com/got@9.6.0:
@@ -5260,7 +2161,7 @@ packages:
       cacheable-request: registry.npmmirror.com/cacheable-request@6.1.0
       decompress-response: registry.npmmirror.com/decompress-response@3.3.0
       duplexer3: registry.npmmirror.com/duplexer3@0.1.5
-      get-stream: registry.npmmirror.com/get-stream@4.1.0
+      get-stream: 4.1.0
       lowercase-keys: registry.npmmirror.com/lowercase-keys@1.0.1
       mimic-response: registry.npmmirror.com/mimic-response@1.0.1
       p-cancelable: registry.npmmirror.com/p-cancelable@1.1.0
@@ -5272,12 +2173,7 @@ packages:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz}
     name: graceful-fs
     version: 4.2.11
-
-  registry.npmmirror.com/hard-rejection@2.1.0:
-    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/hard-rejection/-/hard-rejection-2.1.0.tgz}
-    name: hard-rejection
-    version: 2.1.0
-    engines: {node: '>=6'}
+    dev: true
 
   registry.npmmirror.com/has-ansi@2.0.0:
     resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-ansi/-/has-ansi-2.0.0.tgz}
@@ -5285,96 +2181,14 @@ packages:
     version: 2.0.0
     engines: {node: '>=0.10.0'}
     dependencies:
-      ansi-regex: registry.npmmirror.com/ansi-regex@2.1.1
+      ansi-regex: 2.1.1
     dev: true
-
-  registry.npmmirror.com/has-bigints@1.0.2:
-    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-bigints/-/has-bigints-1.0.2.tgz}
-    name: has-bigints
-    version: 1.0.2
-    dev: false
-
-  registry.npmmirror.com/has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-flag/-/has-flag-3.0.0.tgz}
-    name: has-flag
-    version: 3.0.0
-    engines: {node: '>=4'}
 
   registry.npmmirror.com/has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz}
     name: has-flag
     version: 4.0.0
     engines: {node: '>=8'}
-
-  registry.npmmirror.com/has-property-descriptors@1.0.0:
-    resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz}
-    name: has-property-descriptors
-    version: 1.0.0
-    dependencies:
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-    dev: false
-
-  registry.npmmirror.com/has-proto@1.0.1:
-    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-proto/-/has-proto-1.0.1.tgz}
-    name: has-proto
-    version: 1.0.1
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  registry.npmmirror.com/has-symbols@1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-symbols/-/has-symbols-1.0.3.tgz}
-    name: has-symbols
-    version: 1.0.3
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  registry.npmmirror.com/has-tostringtag@1.0.0:
-    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz}
-    name: has-tostringtag
-    version: 1.0.0
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-symbols: registry.npmmirror.com/has-symbols@1.0.3
-    dev: false
-
-  registry.npmmirror.com/has-value@0.3.1:
-    resolution: {integrity: sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-value/-/has-value-0.3.1.tgz}
-    name: has-value
-    version: 0.3.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      get-value: registry.npmmirror.com/get-value@2.0.6
-      has-values: registry.npmmirror.com/has-values@0.1.4
-      isobject: registry.npmmirror.com/isobject@2.1.0
-    dev: false
-
-  registry.npmmirror.com/has-value@1.0.0:
-    resolution: {integrity: sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-value/-/has-value-1.0.0.tgz}
-    name: has-value
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      get-value: registry.npmmirror.com/get-value@2.0.6
-      has-values: registry.npmmirror.com/has-values@1.0.0
-      isobject: registry.npmmirror.com/isobject@3.0.1
-    dev: false
-
-  registry.npmmirror.com/has-values@0.1.4:
-    resolution: {integrity: sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-values/-/has-values-0.1.4.tgz}
-    name: has-values
-    version: 0.1.4
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/has-values@1.0.0:
-    resolution: {integrity: sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-values/-/has-values-1.0.0.tgz}
-    name: has-values
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-number: registry.npmmirror.com/is-number@3.0.0
-      kind-of: registry.npmmirror.com/kind-of@4.0.0
-    dev: false
 
   registry.npmmirror.com/has-yarn@2.1.0:
     resolution: {integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has-yarn/-/has-yarn-2.1.0.tgz}
@@ -5383,62 +2197,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/has@1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/has/-/has-1.0.3.tgz}
-    name: has
-    version: 1.0.3
-    engines: {node: '>= 0.4.0'}
-    dependencies:
-      function-bind: registry.npmmirror.com/function-bind@1.1.1
-
-  registry.npmmirror.com/hosted-git-info@2.8.9:
-    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz}
-    name: hosted-git-info
-    version: 2.8.9
-
   registry.npmmirror.com/hosted-git-info@3.0.8:
     resolution: {integrity: sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz}
     name: hosted-git-info
     version: 3.0.8
     engines: {node: '>=10'}
     dependencies:
-      lru-cache: registry.npmmirror.com/lru-cache@6.0.0
+      lru-cache: 6.0.0
     dev: true
-
-  registry.npmmirror.com/hosted-git-info@4.1.0:
-    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz}
-    name: hosted-git-info
-    version: 4.1.0
-    engines: {node: '>=10'}
-    dependencies:
-      lru-cache: registry.npmmirror.com/lru-cache@6.0.0
-
-  registry.npmmirror.com/html-tags@2.0.0:
-    resolution: {integrity: sha512-+Il6N8cCo2wB/Vd3gqy/8TZhTD3QvcVeQLCnZiGkGCH3JP28IgGAY41giccp2W4R3jfyJPAP318FQTa1yU7K7g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/html-tags/-/html-tags-2.0.0.tgz}
-    name: html-tags
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/html-tags@3.3.1:
-    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/html-tags/-/html-tags-3.3.1.tgz}
-    name: html-tags
-    version: 3.3.1
-    engines: {node: '>=8'}
-    dev: false
-
-  registry.npmmirror.com/htmlparser2@3.10.1:
-    resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/htmlparser2/-/htmlparser2-3.10.1.tgz}
-    name: htmlparser2
-    version: 3.10.1
-    dependencies:
-      domelementtype: registry.npmmirror.com/domelementtype@1.3.1
-      domhandler: registry.npmmirror.com/domhandler@2.4.2
-      domutils: registry.npmmirror.com/domutils@1.7.0
-      entities: registry.npmmirror.com/entities@1.1.2
-      inherits: registry.npmmirror.com/inherits@2.0.4
-      readable-stream: registry.npmmirror.com/readable-stream@3.6.2
-    dev: false
 
   registry.npmmirror.com/http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz}
@@ -5451,13 +2217,6 @@ packages:
     name: http2-client
     version: 1.3.5
     dev: false
-
-  registry.npmmirror.com/human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/human-signals/-/human-signals-2.1.0.tgz}
-    name: human-signals
-    version: 2.1.0
-    engines: {node: '>=10.17.0'}
-    dev: true
 
   registry.npmmirror.com/iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.4.24.tgz}
@@ -5473,61 +2232,8 @@ packages:
     name: ignore-walk
     version: 3.0.4
     dependencies:
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
+      minimatch: 3.1.2
     dev: true
-
-  registry.npmmirror.com/ignore@4.0.6:
-    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ignore/-/ignore-4.0.6.tgz}
-    name: ignore
-    version: 4.0.6
-    engines: {node: '>= 4'}
-    dev: false
-
-  registry.npmmirror.com/ignore@5.2.4:
-    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ignore/-/ignore-5.2.4.tgz}
-    name: ignore
-    version: 5.2.4
-    engines: {node: '>= 4'}
-
-  registry.npmmirror.com/import-fresh@2.0.0:
-    resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-fresh/-/import-fresh-2.0.0.tgz}
-    name: import-fresh
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      caller-path: registry.npmmirror.com/caller-path@2.0.0
-      resolve-from: registry.npmmirror.com/resolve-from@3.0.0
-    dev: false
-
-  registry.npmmirror.com/import-fresh@3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz}
-    name: import-fresh
-    version: 3.3.0
-    engines: {node: '>=6'}
-    dependencies:
-      parent-module: registry.npmmirror.com/parent-module@1.0.1
-      resolve-from: registry.npmmirror.com/resolve-from@4.0.0
-
-  registry.npmmirror.com/import-lazy@2.1.0:
-    resolution: {integrity: sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-lazy/-/import-lazy-2.1.0.tgz}
-    name: import-lazy
-    version: 2.1.0
-    engines: {node: '>=4'}
-    dev: true
-
-  registry.npmmirror.com/import-lazy@3.1.0:
-    resolution: {integrity: sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-lazy/-/import-lazy-3.1.0.tgz}
-    name: import-lazy
-    version: 3.1.0
-    engines: {node: '>=6'}
-    dev: false
-
-  registry.npmmirror.com/import-lazy@4.0.0:
-    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-lazy/-/import-lazy-4.0.0.tgz}
-    name: import-lazy
-    version: 4.0.0
-    engines: {node: '>=8'}
-    dev: false
 
   registry.npmmirror.com/import-local@3.1.0:
     resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-local/-/import-local-3.1.0.tgz}
@@ -5540,37 +2246,6 @@ packages:
       resolve-cwd: registry.npmmirror.com/resolve-cwd@3.0.0
     dev: true
 
-  registry.npmmirror.com/import-modules@2.1.0:
-    resolution: {integrity: sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/import-modules/-/import-modules-2.1.0.tgz}
-    name: import-modules
-    version: 2.1.0
-    engines: {node: '>=8'}
-    dev: false
-
-  registry.npmmirror.com/imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/imurmurhash/-/imurmurhash-0.1.4.tgz}
-    name: imurmurhash
-    version: 0.1.4
-    engines: {node: '>=0.8.19'}
-
-  registry.npmmirror.com/indent-string@3.2.0:
-    resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/indent-string/-/indent-string-3.2.0.tgz}
-    name: indent-string
-    version: 3.2.0
-    engines: {node: '>=4'}
-
-  registry.npmmirror.com/indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/indent-string/-/indent-string-4.0.0.tgz}
-    name: indent-string
-    version: 4.0.0
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/indexes-of@1.0.1:
-    resolution: {integrity: sha512-bup+4tap3Hympa+JBJUG7XuOsdNQ6fxt0MHyXMKuLBKn0OqsTfvUxkUrroEX1+B2VsSHvCjiIcZVxRtYa4nllA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/indexes-of/-/indexes-of-1.0.1.tgz}
-    name: indexes-of
-    version: 1.0.1
-    dev: false
-
   registry.npmmirror.com/inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz}
     name: inflight
@@ -5578,36 +2253,20 @@ packages:
     dependencies:
       once: registry.npmmirror.com/once@1.4.0
       wrappy: registry.npmmirror.com/wrappy@1.0.2
+    dev: false
 
   registry.npmmirror.com/inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz}
     name: inherits
     version: 2.0.4
-
-  registry.npmmirror.com/ini@1.3.7:
-    resolution: {integrity: sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ini/-/ini-1.3.7.tgz}
-    name: ini
-    version: 1.3.7
-    dev: true
-
-  registry.npmmirror.com/ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ini/-/ini-1.3.8.tgz}
-    name: ini
-    version: 1.3.8
-
-  registry.npmmirror.com/ini@2.0.0:
-    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ini/-/ini-2.0.0.tgz}
-    name: ini
-    version: 2.0.0
-    engines: {node: '>=10'}
-    dev: true
+    dev: false
 
   registry.npmmirror.com/inquirer-autosubmit-prompt@0.2.0:
     resolution: {integrity: sha512-mzNrusCk5L6kSzlN0Ioddn8yzrhYNLli+Sn2ZxMuLechMYAzakiFCIULxsxlQb5YKzthLGfrFACcWoAvM7p04Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz}
     name: inquirer-autosubmit-prompt
     version: 0.2.0
     dependencies:
-      chalk: registry.npmmirror.com/chalk@2.4.2
+      chalk: 2.4.2
       inquirer: registry.npmmirror.com/inquirer@6.5.2
       rxjs: registry.npmmirror.com/rxjs@6.6.7
     dev: true
@@ -5618,18 +2277,18 @@ packages:
     version: 6.5.2
     engines: {node: '>=6.0.0'}
     dependencies:
-      ansi-escapes: registry.npmmirror.com/ansi-escapes@3.2.0
-      chalk: registry.npmmirror.com/chalk@2.4.2
+      ansi-escapes: 3.2.0
+      chalk: 2.4.2
       cli-cursor: registry.npmmirror.com/cli-cursor@2.1.0
       cli-width: registry.npmmirror.com/cli-width@2.2.1
       external-editor: registry.npmmirror.com/external-editor@3.1.0
       figures: registry.npmmirror.com/figures@2.0.0
-      lodash: registry.npmmirror.com/lodash@4.17.21
+      lodash: 4.17.21
       mute-stream: registry.npmmirror.com/mute-stream@0.0.7
       run-async: registry.npmmirror.com/run-async@2.4.1
       rxjs: registry.npmmirror.com/rxjs@6.6.7
-      string-width: registry.npmmirror.com/string-width@2.1.1
-      strip-ansi: registry.npmmirror.com/strip-ansi@5.2.0
+      string-width: 2.1.1
+      strip-ansi: 5.2.0
       through: registry.npmmirror.com/through@2.3.8
     dev: true
 
@@ -5639,141 +2298,31 @@ packages:
     version: 7.3.3
     engines: {node: '>=8.0.0'}
     dependencies:
-      ansi-escapes: registry.npmmirror.com/ansi-escapes@4.3.2
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
       cli-cursor: registry.npmmirror.com/cli-cursor@3.1.0
       cli-width: registry.npmmirror.com/cli-width@3.0.0
       external-editor: registry.npmmirror.com/external-editor@3.1.0
       figures: registry.npmmirror.com/figures@3.2.0
-      lodash: registry.npmmirror.com/lodash@4.17.21
+      lodash: 4.17.21
       mute-stream: registry.npmmirror.com/mute-stream@0.0.8
       run-async: registry.npmmirror.com/run-async@2.4.1
       rxjs: registry.npmmirror.com/rxjs@6.6.7
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
       through: registry.npmmirror.com/through@2.3.8
     dev: true
-
-  registry.npmmirror.com/internal-slot@1.0.5:
-    resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/internal-slot/-/internal-slot-1.0.5.tgz}
-    name: internal-slot
-    version: 1.0.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-      has: registry.npmmirror.com/has@1.0.3
-      side-channel: registry.npmmirror.com/side-channel@1.0.4
-    dev: false
-
-  registry.npmmirror.com/irregular-plurals@3.5.0:
-    resolution: {integrity: sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/irregular-plurals/-/irregular-plurals-3.5.0.tgz}
-    name: irregular-plurals
-    version: 3.5.0
-    engines: {node: '>=8'}
-    dev: false
-
-  registry.npmmirror.com/is-accessor-descriptor@0.1.6:
-    resolution: {integrity: sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz}
-    name: is-accessor-descriptor
-    version: 0.1.6
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmmirror.com/kind-of@3.2.2
-    dev: false
-
-  registry.npmmirror.com/is-accessor-descriptor@1.0.0:
-    resolution: {integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz}
-    name: is-accessor-descriptor
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmmirror.com/kind-of@6.0.3
-    dev: false
-
-  registry.npmmirror.com/is-alphabetical@1.0.4:
-    resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz}
-    name: is-alphabetical
-    version: 1.0.4
-    dev: false
-
-  registry.npmmirror.com/is-alphanumeric@1.0.0:
-    resolution: {integrity: sha512-ZmRL7++ZkcMOfDuWZuMJyIVLr2keE1o/DeNWh1EmgqGhUcV+9BIVsx0BcSBOHTZqzjs4+dISzr2KAeBEWGgXeA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz}
-    name: is-alphanumeric
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/is-alphanumerical@1.0.4:
-    resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz}
-    name: is-alphanumerical
-    version: 1.0.4
-    dependencies:
-      is-alphabetical: registry.npmmirror.com/is-alphabetical@1.0.4
-      is-decimal: registry.npmmirror.com/is-decimal@1.0.4
-    dev: false
-
-  registry.npmmirror.com/is-array-buffer@3.0.2:
-    resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz}
-    name: is-array-buffer
-    version: 3.0.2
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-      is-typed-array: registry.npmmirror.com/is-typed-array@1.1.10
-    dev: false
-
-  registry.npmmirror.com/is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-arrayish/-/is-arrayish-0.2.1.tgz}
-    name: is-arrayish
-    version: 0.2.1
-
-  registry.npmmirror.com/is-bigint@1.0.4:
-    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-bigint/-/is-bigint-1.0.4.tgz}
-    name: is-bigint
-    version: 1.0.4
-    dependencies:
-      has-bigints: registry.npmmirror.com/has-bigints@1.0.2
-    dev: false
 
   registry.npmmirror.com/is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-binary-path/-/is-binary-path-2.1.0.tgz}
     name: is-binary-path
     version: 2.1.0
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       binary-extensions: registry.npmmirror.com/binary-extensions@2.2.0
     dev: false
     optional: true
-
-  registry.npmmirror.com/is-boolean-object@1.1.2:
-    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz}
-    name: is-boolean-object
-    version: 1.1.2
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      has-tostringtag: registry.npmmirror.com/has-tostringtag@1.0.0
-    dev: false
-
-  registry.npmmirror.com/is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-buffer/-/is-buffer-1.1.6.tgz}
-    name: is-buffer
-    version: 1.1.6
-    dev: false
-
-  registry.npmmirror.com/is-buffer@2.0.5:
-    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-buffer/-/is-buffer-2.0.5.tgz}
-    name: is-buffer
-    version: 2.0.5
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-callable/-/is-callable-1.2.7.tgz}
-    name: is-callable
-    version: 1.2.7
-    engines: {node: '>= 0.4'}
-    dev: false
 
   registry.npmmirror.com/is-ci@2.0.0:
     resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-ci/-/is-ci-2.0.0.tgz}
@@ -5781,77 +2330,8 @@ packages:
     version: 2.0.0
     hasBin: true
     dependencies:
-      ci-info: registry.npmmirror.com/ci-info@2.0.0
+      ci-info: 2.0.0
     dev: true
-
-  registry.npmmirror.com/is-core-module@2.12.1:
-    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-core-module/-/is-core-module-2.12.1.tgz}
-    name: is-core-module
-    version: 2.12.1
-    dependencies:
-      has: registry.npmmirror.com/has@1.0.3
-
-  registry.npmmirror.com/is-data-descriptor@0.1.4:
-    resolution: {integrity: sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz}
-    name: is-data-descriptor
-    version: 0.1.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmmirror.com/kind-of@3.2.2
-    dev: false
-
-  registry.npmmirror.com/is-data-descriptor@1.0.0:
-    resolution: {integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz}
-    name: is-data-descriptor
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmmirror.com/kind-of@6.0.3
-    dev: false
-
-  registry.npmmirror.com/is-date-object@1.0.5:
-    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-date-object/-/is-date-object-1.0.5.tgz}
-    name: is-date-object
-    version: 1.0.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: registry.npmmirror.com/has-tostringtag@1.0.0
-    dev: false
-
-  registry.npmmirror.com/is-decimal@1.0.4:
-    resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-decimal/-/is-decimal-1.0.4.tgz}
-    name: is-decimal
-    version: 1.0.4
-    dev: false
-
-  registry.npmmirror.com/is-descriptor@0.1.6:
-    resolution: {integrity: sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-descriptor/-/is-descriptor-0.1.6.tgz}
-    name: is-descriptor
-    version: 0.1.6
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-accessor-descriptor: registry.npmmirror.com/is-accessor-descriptor@0.1.6
-      is-data-descriptor: registry.npmmirror.com/is-data-descriptor@0.1.4
-      kind-of: registry.npmmirror.com/kind-of@5.1.0
-    dev: false
-
-  registry.npmmirror.com/is-descriptor@1.0.2:
-    resolution: {integrity: sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-descriptor/-/is-descriptor-1.0.2.tgz}
-    name: is-descriptor
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-accessor-descriptor: registry.npmmirror.com/is-accessor-descriptor@1.0.0
-      is-data-descriptor: registry.npmmirror.com/is-data-descriptor@1.0.0
-      kind-of: registry.npmmirror.com/kind-of@6.0.3
-    dev: false
-
-  registry.npmmirror.com/is-directory@0.3.1:
-    resolution: {integrity: sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-directory/-/is-directory-0.3.1.tgz}
-    name: is-directory
-    version: 0.3.1
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   registry.npmmirror.com/is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-docker/-/is-docker-2.2.1.tgz}
@@ -5861,42 +2341,14 @@ packages:
     hasBin: true
     dev: true
 
-  registry.npmmirror.com/is-extendable@0.1.1:
-    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-extendable/-/is-extendable-0.1.1.tgz}
-    name: is-extendable
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/is-extendable@1.0.1:
-    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-extendable/-/is-extendable-1.0.1.tgz}
-    name: is-extendable
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-plain-object: registry.npmmirror.com/is-plain-object@2.0.4
-    dev: false
-
   registry.npmmirror.com/is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz}
     name: is-extglob
     version: 2.1.1
     engines: {node: '>=0.10.0'}
-
-  registry.npmmirror.com/is-fullwidth-code-point@1.0.0:
-    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz}
-    name: is-fullwidth-code-point
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      number-is-nan: registry.npmmirror.com/number-is-nan@1.0.1
-    dev: true
-
-  registry.npmmirror.com/is-fullwidth-code-point@2.0.0:
-    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz}
-    name: is-fullwidth-code-point
-    version: 2.0.0
-    engines: {node: '>=4'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   registry.npmmirror.com/is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz}
@@ -5904,28 +2356,16 @@ packages:
     version: 3.0.0
     engines: {node: '>=8'}
 
-  registry.npmmirror.com/is-glob@3.1.0:
-    resolution: {integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-glob/-/is-glob-3.1.0.tgz}
-    name: is-glob
-    version: 3.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: registry.npmmirror.com/is-extglob@2.1.1
-    dev: false
-
   registry.npmmirror.com/is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz}
     name: is-glob
     version: 4.0.3
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       is-extglob: registry.npmmirror.com/is-extglob@2.1.1
-
-  registry.npmmirror.com/is-hexadecimal@1.0.4:
-    resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz}
-    name: is-hexadecimal
-    version: 1.0.4
     dev: false
+    optional: true
 
   registry.npmmirror.com/is-installed-globally@0.3.2:
     resolution: {integrity: sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz}
@@ -5954,13 +2394,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/is-negative-zero@2.0.2:
-    resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz}
-    name: is-negative-zero
-    version: 2.0.2
-    engines: {node: '>= 0.4'}
-    dev: false
-
   registry.npmmirror.com/is-npm@5.0.0:
     resolution: {integrity: sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-npm/-/is-npm-5.0.0.tgz}
     name: is-npm
@@ -5968,35 +2401,21 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  registry.npmmirror.com/is-number-object@1.0.7:
-    resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-number-object/-/is-number-object-1.0.7.tgz}
-    name: is-number-object
-    version: 1.0.7
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: registry.npmmirror.com/has-tostringtag@1.0.0
-    dev: false
-
-  registry.npmmirror.com/is-number@3.0.0:
-    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-number/-/is-number-3.0.0.tgz}
-    name: is-number
-    version: 3.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmmirror.com/kind-of@3.2.2
-    dev: false
-
   registry.npmmirror.com/is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz}
     name: is-number
     version: 7.0.0
     engines: {node: '>=0.12.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   registry.npmmirror.com/is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz}
     name: is-obj
     version: 2.0.0
     engines: {node: '>=8'}
+    dev: true
 
   registry.npmmirror.com/is-observable@1.1.0:
     resolution: {integrity: sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-observable/-/is-observable-1.1.0.tgz}
@@ -6021,56 +2440,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/is-plain-obj@1.1.0:
-    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz}
-    name: is-plain-obj
-    version: 1.1.0
-    engines: {node: '>=0.10.0'}
-
-  registry.npmmirror.com/is-plain-obj@2.1.0:
-    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz}
-    name: is-plain-obj
-    version: 2.1.0
-    engines: {node: '>=8'}
-    dev: false
-
-  registry.npmmirror.com/is-plain-object@2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-plain-object/-/is-plain-object-2.0.4.tgz}
-    name: is-plain-object
-    version: 2.0.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isobject: registry.npmmirror.com/isobject@3.0.1
-    dev: false
-
   registry.npmmirror.com/is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-promise/-/is-promise-2.2.2.tgz}
     name: is-promise
     version: 2.2.2
-
-  registry.npmmirror.com/is-regex@1.1.4:
-    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-regex/-/is-regex-1.1.4.tgz}
-    name: is-regex
-    version: 1.1.4
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      has-tostringtag: registry.npmmirror.com/has-tostringtag@1.0.0
-    dev: false
-
-  registry.npmmirror.com/is-regexp@1.0.0:
-    resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-regexp/-/is-regexp-1.0.0.tgz}
-    name: is-regexp
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/is-regexp@2.1.0:
-    resolution: {integrity: sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-regexp/-/is-regexp-2.1.0.tgz}
-    name: is-regexp
-    version: 2.1.0
-    engines: {node: '>=6'}
-    dev: false
 
   registry.npmmirror.com/is-scoped@2.1.0:
     resolution: {integrity: sha512-Cv4OpPTHAK9kHYzkzCrof3VJh7H/PrG2MBUMvvJebaaUMbqhm0YAtXnvh0I3Hnj2tMZWwrRROWLSgfJrKqWmlQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-scoped/-/is-scoped-2.1.0.tgz}
@@ -6081,110 +2454,12 @@ packages:
       scoped-regex: registry.npmmirror.com/scoped-regex@2.1.0
     dev: true
 
-  registry.npmmirror.com/is-shared-array-buffer@1.0.2:
-    resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz}
-    name: is-shared-array-buffer
-    version: 1.0.2
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-    dev: false
-
-  registry.npmmirror.com/is-stream@1.1.0:
-    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-stream/-/is-stream-1.1.0.tgz}
-    name: is-stream
-    version: 1.1.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmmirror.com/is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-stream/-/is-stream-2.0.1.tgz}
-    name: is-stream
-    version: 2.0.1
-    engines: {node: '>=8'}
-    dev: true
-
-  registry.npmmirror.com/is-string@1.0.7:
-    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-string/-/is-string-1.0.7.tgz}
-    name: is-string
-    version: 1.0.7
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: registry.npmmirror.com/has-tostringtag@1.0.0
-    dev: false
-
-  registry.npmmirror.com/is-supported-regexp-flag@1.0.1:
-    resolution: {integrity: sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz}
-    name: is-supported-regexp-flag
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/is-symbol@1.0.4:
-    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-symbol/-/is-symbol-1.0.4.tgz}
-    name: is-symbol
-    version: 1.0.4
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-symbols: registry.npmmirror.com/has-symbols@1.0.3
-    dev: false
-
-  registry.npmmirror.com/is-typed-array@1.1.10:
-    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-typed-array/-/is-typed-array-1.1.10.tgz}
-    name: is-typed-array
-    version: 1.1.10
-    engines: {node: '>= 0.4'}
-    dependencies:
-      available-typed-arrays: registry.npmmirror.com/available-typed-arrays@1.0.5
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      for-each: registry.npmmirror.com/for-each@0.3.3
-      gopd: registry.npmmirror.com/gopd@1.0.1
-      has-tostringtag: registry.npmmirror.com/has-tostringtag@1.0.0
-    dev: false
-
-  registry.npmmirror.com/is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-typedarray/-/is-typedarray-1.0.0.tgz}
-    name: is-typedarray
-    version: 1.0.0
-
-  registry.npmmirror.com/is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz}
-    name: is-unicode-supported
-    version: 0.1.0
-    engines: {node: '>=10'}
-
   registry.npmmirror.com/is-url-superb@4.0.0:
     resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-url-superb/-/is-url-superb-4.0.0.tgz}
     name: is-url-superb
     version: 4.0.0
     engines: {node: '>=10'}
     dev: true
-
-  registry.npmmirror.com/is-weakref@1.0.2:
-    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-weakref/-/is-weakref-1.0.2.tgz}
-    name: is-weakref
-    version: 1.0.2
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-    dev: false
-
-  registry.npmmirror.com/is-whitespace-character@1.0.4:
-    resolution: {integrity: sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz}
-    name: is-whitespace-character
-    version: 1.0.4
-    dev: false
-
-  registry.npmmirror.com/is-windows@1.0.2:
-    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-windows/-/is-windows-1.0.2.tgz}
-    name: is-windows
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/is-word-character@1.0.4:
-    resolution: {integrity: sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-word-character/-/is-word-character-1.0.4.tgz}
-    name: is-word-character
-    version: 1.0.4
-    dev: false
 
   registry.npmmirror.com/is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/is-wsl/-/is-wsl-2.2.0.tgz}
@@ -6201,218 +2476,12 @@ packages:
     version: 0.3.0
     dev: true
 
-  registry.npmmirror.com/isarray@0.0.1:
-    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/isarray/-/isarray-0.0.1.tgz}
-    name: isarray
-    version: 0.0.1
-    dev: false
-
-  registry.npmmirror.com/isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/isarray/-/isarray-1.0.0.tgz}
-    name: isarray
-    version: 1.0.0
-    dev: false
-
-  registry.npmmirror.com/isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz}
-    name: isexe
-    version: 2.0.0
-
-  registry.npmmirror.com/isobject@2.1.0:
-    resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/isobject/-/isobject-2.1.0.tgz}
-    name: isobject
-    version: 2.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isarray: registry.npmmirror.com/isarray@1.0.0
-    dev: false
-
-  registry.npmmirror.com/isobject@3.0.1:
-    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/isobject/-/isobject-3.0.1.tgz}
-    name: isobject
-    version: 3.0.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   registry.npmmirror.com/issue-regex@3.1.0:
     resolution: {integrity: sha512-0RHjbtw9QXeSYnIEY5Yrp2QZrdtz21xBDV9C/GIlY2POmgoS6a7qjkYS5siRKXScnuAj5/SPv1C3YForNCHTJA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/issue-regex/-/issue-regex-3.1.0.tgz}
     name: issue-regex
     version: 3.1.0
     engines: {node: '>=10'}
     dev: true
-
-  registry.npmmirror.com/js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz}
-    name: js-tokens
-    version: 4.0.0
-
-  registry.npmmirror.com/js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/js-yaml/-/js-yaml-3.14.1.tgz}
-    name: js-yaml
-    version: 3.14.1
-    hasBin: true
-    dependencies:
-      argparse: registry.npmmirror.com/argparse@1.0.10
-      esprima: registry.npmmirror.com/esprima@4.0.1
-    dev: false
-
-  registry.npmmirror.com/jsesc@0.5.0:
-    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/jsesc/-/jsesc-0.5.0.tgz}
-    name: jsesc
-    version: 0.5.0
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/jsesc@2.5.2:
-    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/jsesc/-/jsesc-2.5.2.tgz}
-    name: jsesc
-    version: 2.5.2
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/json-buffer@3.0.0:
-    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-buffer/-/json-buffer-3.0.0.tgz}
-    name: json-buffer
-    version: 3.0.0
-    dev: true
-
-  registry.npmmirror.com/json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-buffer/-/json-buffer-3.0.1.tgz}
-    name: json-buffer
-    version: 3.0.1
-    dev: true
-
-  registry.npmmirror.com/json-parse-better-errors@1.0.2:
-    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz}
-    name: json-parse-better-errors
-    version: 1.0.2
-    dev: false
-
-  registry.npmmirror.com/json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz}
-    name: json-parse-even-better-errors
-    version: 2.3.1
-
-  registry.npmmirror.com/json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz}
-    name: json-schema-traverse
-    version: 0.4.1
-    dev: false
-
-  registry.npmmirror.com/json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz}
-    name: json-schema-traverse
-    version: 1.0.0
-    dev: false
-
-  registry.npmmirror.com/json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz}
-    name: json-stable-stringify-without-jsonify
-    version: 1.0.1
-    dev: false
-
-  registry.npmmirror.com/json5@1.0.2:
-    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json5/-/json5-1.0.2.tgz}
-    name: json5
-    version: 1.0.2
-    hasBin: true
-    dependencies:
-      minimist: registry.npmmirror.com/minimist@1.2.8
-    dev: false
-
-  registry.npmmirror.com/json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/json5/-/json5-2.2.3.tgz}
-    name: json5
-    version: 2.2.3
-    engines: {node: '>=6'}
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/jsx-ast-utils@3.3.4:
-    resolution: {integrity: sha512-fX2TVdCViod6HwKEtSWGHs57oFhVfCMwieb9PuRDgjDPh5XeqJiHFFFJCHxU5cnTc3Bu/GRL+kPiFmw8XWOfKw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/jsx-ast-utils/-/jsx-ast-utils-3.3.4.tgz}
-    name: jsx-ast-utils
-    version: 3.3.4
-    engines: {node: '>=4.0'}
-    dependencies:
-      array-includes: registry.npmmirror.com/array-includes@3.1.6
-      array.prototype.flat: registry.npmmirror.com/array.prototype.flat@1.3.1
-      object.assign: registry.npmmirror.com/object.assign@4.1.4
-      object.values: registry.npmmirror.com/object.values@1.1.6
-    dev: false
-
-  registry.npmmirror.com/keyv@3.1.0:
-    resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/keyv/-/keyv-3.1.0.tgz}
-    name: keyv
-    version: 3.1.0
-    dependencies:
-      json-buffer: registry.npmmirror.com/json-buffer@3.0.0
-    dev: true
-
-  registry.npmmirror.com/keyv@4.5.2:
-    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/keyv/-/keyv-4.5.2.tgz}
-    name: keyv
-    version: 4.5.2
-    dependencies:
-      json-buffer: registry.npmmirror.com/json-buffer@3.0.1
-    dev: true
-
-  registry.npmmirror.com/kind-of@3.2.2:
-    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/kind-of/-/kind-of-3.2.2.tgz}
-    name: kind-of
-    version: 3.2.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-buffer: registry.npmmirror.com/is-buffer@1.1.6
-    dev: false
-
-  registry.npmmirror.com/kind-of@4.0.0:
-    resolution: {integrity: sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/kind-of/-/kind-of-4.0.0.tgz}
-    name: kind-of
-    version: 4.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-buffer: registry.npmmirror.com/is-buffer@1.1.6
-    dev: false
-
-  registry.npmmirror.com/kind-of@5.1.0:
-    resolution: {integrity: sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/kind-of/-/kind-of-5.1.0.tgz}
-    name: kind-of
-    version: 5.1.0
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/kind-of/-/kind-of-6.0.3.tgz}
-    name: kind-of
-    version: 6.0.3
-    engines: {node: '>=0.10.0'}
-
-  registry.npmmirror.com/known-css-properties@0.11.0:
-    resolution: {integrity: sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/known-css-properties/-/known-css-properties-0.11.0.tgz}
-    name: known-css-properties
-    version: 0.11.0
-    dev: false
-
-  registry.npmmirror.com/known-css-properties@0.21.0:
-    resolution: {integrity: sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/known-css-properties/-/known-css-properties-0.21.0.tgz}
-    name: known-css-properties
-    version: 0.21.0
-    dev: false
-
-  registry.npmmirror.com/language-subtag-registry@0.3.22:
-    resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz}
-    name: language-subtag-registry
-    version: 0.3.22
-    dev: false
-
-  registry.npmmirror.com/language-tags@1.0.5:
-    resolution: {integrity: sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/language-tags/-/language-tags-1.0.5.tgz}
-    name: language-tags
-    version: 1.0.5
-    dependencies:
-      language-subtag-registry: registry.npmmirror.com/language-subtag-registry@0.3.22
-    dev: false
 
   registry.npmmirror.com/latest-version@5.1.0:
     resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/latest-version/-/latest-version-5.1.0.tgz}
@@ -6422,37 +2491,6 @@ packages:
     dependencies:
       package-json: registry.npmmirror.com/package-json@6.5.0
     dev: true
-
-  registry.npmmirror.com/ldjson-stream@1.2.1:
-    resolution: {integrity: sha512-xw/nNEXafuPSLu8NjjG3+atVVw+8U1APZAQylmwQn19Hgw6rC7QjHvP6MupnHWCrzSm9m0xs5QWkCLuRvBPjgQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ldjson-stream/-/ldjson-stream-1.2.1.tgz}
-    name: ldjson-stream
-    version: 1.2.1
-    dependencies:
-      split2: registry.npmmirror.com/split2@0.2.1
-      through2: registry.npmmirror.com/through2@0.6.5
-    dev: false
-
-  registry.npmmirror.com/leven@2.1.0:
-    resolution: {integrity: sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/leven/-/leven-2.1.0.tgz}
-    name: leven
-    version: 2.1.0
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/levn/-/levn-0.4.1.tgz}
-    name: levn
-    version: 0.4.1
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      prelude-ls: registry.npmmirror.com/prelude-ls@1.2.1
-      type-check: registry.npmmirror.com/type-check@0.4.0
-    dev: false
-
-  registry.npmmirror.com/lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz}
-    name: lines-and-columns
-    version: 1.2.4
 
   registry.npmmirror.com/listr-input@0.2.1:
     resolution: {integrity: sha512-oa8iVG870qJq+OuuMK3DjGqFcwsK1SDu+kULp9kEq09TY231aideIZenr3lFOQdASpAr6asuyJBbX62/a3IIhg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/listr-input/-/listr-input-0.2.1.tgz}
@@ -6482,15 +2520,15 @@ packages:
     peerDependencies:
       listr: ^0.14.2
     dependencies:
-      chalk: registry.npmmirror.com/chalk@1.1.3
+      chalk: 1.1.3
       cli-truncate: registry.npmmirror.com/cli-truncate@0.2.1
       elegant-spinner: registry.npmmirror.com/elegant-spinner@1.0.1
       figures: registry.npmmirror.com/figures@1.7.0
-      indent-string: registry.npmmirror.com/indent-string@3.2.0
+      indent-string: 3.2.0
       listr: registry.npmmirror.com/listr@0.14.3
-      log-symbols: registry.npmmirror.com/log-symbols@1.0.2
+      log-symbols: 1.0.2
       log-update: registry.npmmirror.com/log-update@2.3.0
-      strip-ansi: registry.npmmirror.com/strip-ansi@3.0.1
+      strip-ansi: 3.0.1
     dev: true
 
   registry.npmmirror.com/listr-verbose-renderer@0.5.0:
@@ -6499,7 +2537,7 @@ packages:
     version: 0.5.0
     engines: {node: '>=4'}
     dependencies:
-      chalk: registry.npmmirror.com/chalk@2.4.2
+      chalk: 2.4.2
       cli-cursor: registry.npmmirror.com/cli-cursor@2.1.0
       date-fns: registry.npmmirror.com/date-fns@1.30.1
       figures: registry.npmmirror.com/figures@2.0.0
@@ -6514,7 +2552,7 @@ packages:
       '@samverschueren/stream-to-observable': registry.npmmirror.com/@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7)
       is-observable: registry.npmmirror.com/is-observable@1.1.0
       is-promise: registry.npmmirror.com/is-promise@2.2.2
-      is-stream: registry.npmmirror.com/is-stream@1.1.0
+      is-stream: 1.1.0
       listr-silent-renderer: registry.npmmirror.com/listr-silent-renderer@1.1.1
       listr-update-renderer: registry.npmmirror.com/listr-update-renderer@0.5.0(listr@0.14.3)
       listr-verbose-renderer: registry.npmmirror.com/listr-verbose-renderer@0.5.0
@@ -6525,55 +2563,14 @@ packages:
       - zenObservable
     dev: true
 
-  registry.npmmirror.com/load-json-file@4.0.0:
-    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/load-json-file/-/load-json-file-4.0.0.tgz}
-    name: load-json-file
-    version: 4.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      graceful-fs: registry.npmmirror.com/graceful-fs@4.2.11
-      parse-json: registry.npmmirror.com/parse-json@4.0.0
-      pify: registry.npmmirror.com/pify@3.0.0
-      strip-bom: registry.npmmirror.com/strip-bom@3.0.0
-    dev: false
-
-  registry.npmmirror.com/locate-path@2.0.0:
-    resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/locate-path/-/locate-path-2.0.0.tgz}
-    name: locate-path
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      p-locate: registry.npmmirror.com/p-locate@2.0.0
-      path-exists: registry.npmmirror.com/path-exists@3.0.0
-    dev: false
-
-  registry.npmmirror.com/locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/locate-path/-/locate-path-5.0.0.tgz}
-    name: locate-path
-    version: 5.0.0
-    engines: {node: '>=8'}
-    dependencies:
-      p-locate: registry.npmmirror.com/p-locate@4.1.0
-
   registry.npmmirror.com/locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz}
     name: locate-path
     version: 6.0.0
     engines: {node: '>=10'}
     dependencies:
-      p-locate: registry.npmmirror.com/p-locate@5.0.0
-
-  registry.npmmirror.com/lodash.debounce@4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz}
-    name: lodash.debounce
-    version: 4.0.8
-    dev: false
-
-  registry.npmmirror.com/lodash.get@4.4.2:
-    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.get/-/lodash.get-4.4.2.tgz}
-    name: lodash.get
-    version: 4.4.2
-    dev: false
+      p-locate: 5.0.0
+    dev: true
 
   registry.npmmirror.com/lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz}
@@ -6581,50 +2578,10 @@ packages:
     version: 4.5.0
     dev: true
 
-  registry.npmmirror.com/lodash.memoize@4.1.2:
-    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz}
-    name: lodash.memoize
-    version: 4.1.2
-    dev: false
-
-  registry.npmmirror.com/lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz}
-    name: lodash.merge
-    version: 4.6.2
-    dev: false
-
-  registry.npmmirror.com/lodash.truncate@4.4.2:
-    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz}
-    name: lodash.truncate
-    version: 4.4.2
-    dev: false
-
-  registry.npmmirror.com/lodash.zip@4.2.0:
-    resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash.zip/-/lodash.zip-4.2.0.tgz}
-    name: lodash.zip
-    version: 4.2.0
-
   registry.npmmirror.com/lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz}
     name: lodash
     version: 4.17.21
-
-  registry.npmmirror.com/log-symbols@1.0.2:
-    resolution: {integrity: sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/log-symbols/-/log-symbols-1.0.2.tgz}
-    name: log-symbols
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      chalk: registry.npmmirror.com/chalk@1.1.3
-    dev: true
-
-  registry.npmmirror.com/log-symbols@2.2.0:
-    resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/log-symbols/-/log-symbols-2.2.0.tgz}
-    name: log-symbols
-    version: 2.2.0
-    engines: {node: '>=4'}
-    dependencies:
-      chalk: registry.npmmirror.com/chalk@2.4.2
     dev: false
 
   registry.npmmirror.com/log-symbols@4.1.0:
@@ -6633,8 +2590,9 @@ packages:
     version: 4.1.0
     engines: {node: '>=10'}
     dependencies:
-      chalk: registry.npmmirror.com/chalk@4.1.2
-      is-unicode-supported: registry.npmmirror.com/is-unicode-supported@0.1.0
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+    dev: true
 
   registry.npmmirror.com/log-update@2.3.0:
     resolution: {integrity: sha512-vlP11XfFGyeNQlmEn9tJ66rEW1coA/79m5z6BCkudjbAGE83uhAcGYrBFwfs3AdLiLzGRusRPAbSPK9xZteCmg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/log-update/-/log-update-2.3.0.tgz}
@@ -6642,35 +2600,10 @@ packages:
     version: 2.3.0
     engines: {node: '>=4'}
     dependencies:
-      ansi-escapes: registry.npmmirror.com/ansi-escapes@3.2.0
+      ansi-escapes: 3.2.0
       cli-cursor: registry.npmmirror.com/cli-cursor@2.1.0
       wrap-ansi: registry.npmmirror.com/wrap-ansi@3.0.1
     dev: true
-
-  registry.npmmirror.com/longest-streak@2.0.4:
-    resolution: {integrity: sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/longest-streak/-/longest-streak-2.0.4.tgz}
-    name: longest-streak
-    version: 2.0.4
-    dev: false
-
-  registry.npmmirror.com/loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/loose-envify/-/loose-envify-1.4.0.tgz}
-    name: loose-envify
-    version: 1.4.0
-    hasBin: true
-    dependencies:
-      js-tokens: registry.npmmirror.com/js-tokens@4.0.0
-    dev: false
-
-  registry.npmmirror.com/loud-rejection@1.6.0:
-    resolution: {integrity: sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/loud-rejection/-/loud-rejection-1.6.0.tgz}
-    name: loud-rejection
-    version: 1.6.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      currently-unhandled: registry.npmmirror.com/currently-unhandled@0.4.1
-      signal-exit: registry.npmmirror.com/signal-exit@3.0.7
-    dev: false
 
   registry.npmmirror.com/lowercase-keys@1.0.1:
     resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz}
@@ -6686,22 +2619,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lru-cache/-/lru-cache-5.1.1.tgz}
-    name: lru-cache
-    version: 5.1.1
-    dependencies:
-      yallist: registry.npmmirror.com/yallist@3.1.1
-    dev: false
-
-  registry.npmmirror.com/lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lru-cache/-/lru-cache-6.0.0.tgz}
-    name: lru-cache
-    version: 6.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      yallist: registry.npmmirror.com/yallist@4.0.0
-
   registry.npmmirror.com/lru-queue@0.1.0:
     resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/lru-queue/-/lru-queue-0.1.0.tgz}
     name: lru-queue
@@ -6716,111 +2633,8 @@ packages:
     version: 3.1.0
     engines: {node: '>=8'}
     dependencies:
-      semver: registry.npmmirror.com/semver@6.3.0
+      semver: 6.3.0
     dev: true
-
-  registry.npmmirror.com/map-age-cleaner@0.1.3:
-    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz}
-    name: map-age-cleaner
-    version: 0.1.3
-    engines: {node: '>=6'}
-    dependencies:
-      p-defer: registry.npmmirror.com/p-defer@1.0.0
-    dev: true
-
-  registry.npmmirror.com/map-cache@0.2.2:
-    resolution: {integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/map-cache/-/map-cache-0.2.2.tgz}
-    name: map-cache
-    version: 0.2.2
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/map-obj@1.0.1:
-    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/map-obj/-/map-obj-1.0.1.tgz}
-    name: map-obj
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-
-  registry.npmmirror.com/map-obj@2.0.0:
-    resolution: {integrity: sha512-TzQSV2DiMYgoF5RycneKVUzIa9bQsj/B3tTgsE3dOGqlzHnGIDaC7XBE7grnA+8kZPnfqSGFe95VHc2oc0VFUQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/map-obj/-/map-obj-2.0.0.tgz}
-    name: map-obj
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/map-obj@4.3.0:
-    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/map-obj/-/map-obj-4.3.0.tgz}
-    name: map-obj
-    version: 4.3.0
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/map-visit@1.0.0:
-    resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/map-visit/-/map-visit-1.0.0.tgz}
-    name: map-visit
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      object-visit: registry.npmmirror.com/object-visit@1.0.1
-    dev: false
-
-  registry.npmmirror.com/markdown-escapes@1.0.4:
-    resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz}
-    name: markdown-escapes
-    version: 1.0.4
-    dev: false
-
-  registry.npmmirror.com/markdown-table@1.1.3:
-    resolution: {integrity: sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/markdown-table/-/markdown-table-1.1.3.tgz}
-    name: markdown-table
-    version: 1.1.3
-    dev: false
-
-  registry.npmmirror.com/mathml-tag-names@2.1.3:
-    resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz}
-    name: mathml-tag-names
-    version: 2.1.3
-    dev: false
-
-  registry.npmmirror.com/mdast-util-compact@1.0.4:
-    resolution: {integrity: sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz}
-    name: mdast-util-compact
-    version: 1.0.4
-    dependencies:
-      unist-util-visit: registry.npmmirror.com/unist-util-visit@1.4.1
-    dev: false
-
-  registry.npmmirror.com/mdast-util-from-markdown@0.8.5:
-    resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz}
-    name: mdast-util-from-markdown
-    version: 0.8.5
-    dependencies:
-      '@types/mdast': registry.npmmirror.com/@types/mdast@3.0.11
-      mdast-util-to-string: registry.npmmirror.com/mdast-util-to-string@2.0.0
-      micromark: registry.npmmirror.com/micromark@2.11.4
-      parse-entities: registry.npmmirror.com/parse-entities@2.0.0
-      unist-util-stringify-position: registry.npmmirror.com/unist-util-stringify-position@2.0.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/mdast-util-to-markdown@0.6.5:
-    resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz}
-    name: mdast-util-to-markdown
-    version: 0.6.5
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@2.0.6
-      longest-streak: registry.npmmirror.com/longest-streak@2.0.4
-      mdast-util-to-string: registry.npmmirror.com/mdast-util-to-string@2.0.0
-      parse-entities: registry.npmmirror.com/parse-entities@2.0.0
-      repeat-string: registry.npmmirror.com/repeat-string@1.6.1
-      zwitch: registry.npmmirror.com/zwitch@1.0.5
-    dev: false
-
-  registry.npmmirror.com/mdast-util-to-string@2.0.0:
-    resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz}
-    name: mdast-util-to-string
-    version: 2.0.0
-    dev: false
 
   registry.npmmirror.com/memoizee@0.4.15:
     resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/memoizee/-/memoizee-0.4.15.tgz}
@@ -6837,136 +2651,23 @@ packages:
       timers-ext: registry.npmmirror.com/timers-ext@0.1.7
     dev: false
 
-  registry.npmmirror.com/meow@5.0.0:
-    resolution: {integrity: sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/meow/-/meow-5.0.0.tgz}
-    name: meow
-    version: 5.0.0
-    engines: {node: '>=6'}
-    dependencies:
-      camelcase-keys: registry.npmmirror.com/camelcase-keys@4.2.0
-      decamelize-keys: registry.npmmirror.com/decamelize-keys@1.1.1
-      loud-rejection: registry.npmmirror.com/loud-rejection@1.6.0
-      minimist-options: registry.npmmirror.com/minimist-options@3.0.2
-      normalize-package-data: registry.npmmirror.com/normalize-package-data@2.5.0
-      read-pkg-up: registry.npmmirror.com/read-pkg-up@3.0.0
-      redent: registry.npmmirror.com/redent@2.0.0
-      trim-newlines: registry.npmmirror.com/trim-newlines@2.0.0
-      yargs-parser: registry.npmmirror.com/yargs-parser@10.1.0
-    dev: false
-
   registry.npmmirror.com/meow@8.1.2:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/meow/-/meow-8.1.2.tgz}
     name: meow
     version: 8.1.2
     engines: {node: '>=10'}
     dependencies:
-      '@types/minimist': registry.npmmirror.com/@types/minimist@1.2.2
-      camelcase-keys: registry.npmmirror.com/camelcase-keys@6.2.2
-      decamelize-keys: registry.npmmirror.com/decamelize-keys@1.1.1
-      hard-rejection: registry.npmmirror.com/hard-rejection@2.1.0
-      minimist-options: registry.npmmirror.com/minimist-options@4.1.0
-      normalize-package-data: registry.npmmirror.com/normalize-package-data@3.0.3
-      read-pkg-up: registry.npmmirror.com/read-pkg-up@7.0.1
-      redent: registry.npmmirror.com/redent@3.0.0
-      trim-newlines: registry.npmmirror.com/trim-newlines@3.0.1
-      type-fest: registry.npmmirror.com/type-fest@0.18.1
-      yargs-parser: registry.npmmirror.com/yargs-parser@20.2.9
-    dev: true
-
-  registry.npmmirror.com/meow@9.0.0:
-    resolution: {integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/meow/-/meow-9.0.0.tgz}
-    name: meow
-    version: 9.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      '@types/minimist': registry.npmmirror.com/@types/minimist@1.2.2
-      camelcase-keys: registry.npmmirror.com/camelcase-keys@6.2.2
-      decamelize: registry.npmmirror.com/decamelize@1.2.0
-      decamelize-keys: registry.npmmirror.com/decamelize-keys@1.1.1
-      hard-rejection: registry.npmmirror.com/hard-rejection@2.1.0
-      minimist-options: registry.npmmirror.com/minimist-options@4.1.0
-      normalize-package-data: registry.npmmirror.com/normalize-package-data@3.0.3
-      read-pkg-up: registry.npmmirror.com/read-pkg-up@7.0.1
-      redent: registry.npmmirror.com/redent@3.0.0
-      trim-newlines: registry.npmmirror.com/trim-newlines@3.0.1
-      type-fest: registry.npmmirror.com/type-fest@0.18.1
-      yargs-parser: registry.npmmirror.com/yargs-parser@20.2.9
-    dev: false
-
-  registry.npmmirror.com/merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/merge-stream/-/merge-stream-2.0.0.tgz}
-    name: merge-stream
-    version: 2.0.0
-    dev: true
-
-  registry.npmmirror.com/merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz}
-    name: merge2
-    version: 1.4.1
-    engines: {node: '>= 8'}
-
-  registry.npmmirror.com/micromark@2.11.4:
-    resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/micromark/-/micromark-2.11.4.tgz}
-    name: micromark
-    version: 2.11.4
-    dependencies:
-      debug: registry.npmmirror.com/debug@4.3.4
-      parse-entities: registry.npmmirror.com/parse-entities@2.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/micromatch@3.1.10:
-    resolution: {integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/micromatch/-/micromatch-3.1.10.tgz}
-    name: micromatch
-    version: 3.1.10
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-diff: registry.npmmirror.com/arr-diff@4.0.0
-      array-unique: registry.npmmirror.com/array-unique@0.3.2
-      braces: registry.npmmirror.com/braces@2.3.2
-      define-property: registry.npmmirror.com/define-property@2.0.2
-      extend-shallow: registry.npmmirror.com/extend-shallow@3.0.2
-      extglob: registry.npmmirror.com/extglob@2.0.4
-      fragment-cache: registry.npmmirror.com/fragment-cache@0.2.1
-      kind-of: registry.npmmirror.com/kind-of@6.0.3
-      nanomatch: registry.npmmirror.com/nanomatch@1.2.13
-      object.pick: registry.npmmirror.com/object.pick@1.3.0
-      regex-not: registry.npmmirror.com/regex-not@1.0.2
-      snapdragon: registry.npmmirror.com/snapdragon@0.8.2
-      to-regex: registry.npmmirror.com/to-regex@3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/micromatch/-/micromatch-4.0.5.tgz}
-    name: micromatch
-    version: 4.0.5
-    engines: {node: '>=8.6'}
-    dependencies:
-      braces: registry.npmmirror.com/braces@3.0.2
-      picomatch: registry.npmmirror.com/picomatch@2.3.1
-
-  registry.npmmirror.com/mimic-fn@1.2.0:
-    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mimic-fn/-/mimic-fn-1.2.0.tgz}
-    name: mimic-fn
-    version: 1.2.0
-    engines: {node: '>=4'}
-    dev: true
-
-  registry.npmmirror.com/mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mimic-fn/-/mimic-fn-2.1.0.tgz}
-    name: mimic-fn
-    version: 2.1.0
-    engines: {node: '>=6'}
-    dev: true
-
-  registry.npmmirror.com/mimic-fn@3.1.0:
-    resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mimic-fn/-/mimic-fn-3.1.0.tgz}
-    name: mimic-fn
-    version: 3.1.0
-    engines: {node: '>=8'}
+      '@types/minimist': 1.2.2
+      camelcase-keys: 6.2.2
+      decamelize-keys: 1.1.1
+      hard-rejection: 2.1.0
+      minimist-options: 4.1.0
+      normalize-package-data: 3.0.3
+      read-pkg-up: 7.0.1
+      redent: 3.0.0
+      trim-newlines: 3.0.1
+      type-fest: 0.18.1
+      yargs-parser: 20.2.9
     dev: true
 
   registry.npmmirror.com/mimic-response@1.0.1:
@@ -6983,62 +2684,12 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/min-indent@1.0.1:
-    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/min-indent/-/min-indent-1.0.1.tgz}
-    name: min-indent
-    version: 1.0.1
-    engines: {node: '>=4'}
-
   registry.npmmirror.com/minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz}
     name: minimatch
     version: 3.1.2
     dependencies:
-      brace-expansion: registry.npmmirror.com/brace-expansion@1.1.11
-
-  registry.npmmirror.com/minimist-options@3.0.2:
-    resolution: {integrity: sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/minimist-options/-/minimist-options-3.0.2.tgz}
-    name: minimist-options
-    version: 3.0.2
-    engines: {node: '>= 4'}
-    dependencies:
-      arrify: registry.npmmirror.com/arrify@1.0.1
-      is-plain-obj: registry.npmmirror.com/is-plain-obj@1.1.0
-    dev: false
-
-  registry.npmmirror.com/minimist-options@4.1.0:
-    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/minimist-options/-/minimist-options-4.1.0.tgz}
-    name: minimist-options
-    version: 4.1.0
-    engines: {node: '>= 6'}
-    dependencies:
-      arrify: registry.npmmirror.com/arrify@1.0.1
-      is-plain-obj: registry.npmmirror.com/is-plain-obj@1.1.0
-      kind-of: registry.npmmirror.com/kind-of@6.0.3
-
-  registry.npmmirror.com/minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/minimist/-/minimist-1.2.8.tgz}
-    name: minimist
-    version: 1.2.8
-
-  registry.npmmirror.com/mixin-deep@1.3.2:
-    resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mixin-deep/-/mixin-deep-1.3.2.tgz}
-    name: mixin-deep
-    version: 1.3.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      for-in: registry.npmmirror.com/for-in@1.0.2
-      is-extendable: registry.npmmirror.com/is-extendable@1.0.1
-    dev: false
-
-  registry.npmmirror.com/mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mkdirp/-/mkdirp-0.5.6.tgz}
-    name: mkdirp
-    version: 0.5.6
-    hasBin: true
-    dependencies:
-      minimist: registry.npmmirror.com/minimist@1.2.8
-    dev: false
+      brace-expansion: 1.1.11
 
   registry.npmmirror.com/mock.js@0.2.0:
     resolution: {integrity: sha512-DKI8Rh/h7Mma+fg+6aD0uUvwn0QXAjKG6q3s+lTaCboCQ/kvQMBN9IXRBzgEaz4aPiYoRnKU9jVsfZp0mHpWrQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mock.js/-/mock.js-0.2.0.tgz}
@@ -7055,43 +2706,6 @@ packages:
       commander: registry.npmmirror.com/commander@11.0.0
     dev: false
 
-  registry.npmmirror.com/ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ms/-/ms-2.0.0.tgz}
-    name: ms
-    version: 2.0.0
-    dev: false
-
-  registry.npmmirror.com/ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ms/-/ms-2.1.2.tgz}
-    name: ms
-    version: 2.1.2
-    dev: false
-
-  registry.npmmirror.com/ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz}
-    name: ms
-    version: 2.1.3
-    dev: false
-
-  registry.npmmirror.com/multimap@1.1.0:
-    resolution: {integrity: sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/multimap/-/multimap-1.1.0.tgz}
-    name: multimap
-    version: 1.1.0
-    dev: false
-
-  registry.npmmirror.com/multimatch@5.0.0:
-    resolution: {integrity: sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/multimatch/-/multimatch-5.0.0.tgz}
-    name: multimatch
-    version: 5.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      '@types/minimatch': registry.npmmirror.com/@types/minimatch@3.0.5
-      array-differ: registry.npmmirror.com/array-differ@3.0.0
-      array-union: registry.npmmirror.com/array-union@2.1.0
-      arrify: registry.npmmirror.com/arrify@2.0.1
-      minimatch: registry.npmmirror.com/minimatch@3.1.2
-    dev: false
-
   registry.npmmirror.com/mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.7.tgz}
     name: mute-stream
@@ -7104,48 +2718,13 @@ packages:
     version: 0.0.8
     dev: true
 
-  registry.npmmirror.com/nanoid@3.3.6:
-    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/nanoid/-/nanoid-3.3.6.tgz}
-    name: nanoid
-    version: 3.3.6
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/nanomatch@1.2.13:
-    resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/nanomatch/-/nanomatch-1.2.13.tgz}
-    name: nanomatch
-    version: 1.2.13
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-diff: registry.npmmirror.com/arr-diff@4.0.0
-      array-unique: registry.npmmirror.com/array-unique@0.3.2
-      define-property: registry.npmmirror.com/define-property@2.0.2
-      extend-shallow: registry.npmmirror.com/extend-shallow@3.0.2
-      fragment-cache: registry.npmmirror.com/fragment-cache@0.2.1
-      is-windows: registry.npmmirror.com/is-windows@1.0.2
-      kind-of: registry.npmmirror.com/kind-of@6.0.3
-      object.pick: registry.npmmirror.com/object.pick@1.3.0
-      regex-not: registry.npmmirror.com/regex-not@1.0.2
-      snapdragon: registry.npmmirror.com/snapdragon@0.8.2
-      to-regex: registry.npmmirror.com/to-regex@3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/natural-compare/-/natural-compare-1.4.0.tgz}
-    name: natural-compare
-    version: 1.4.0
-    dev: false
-
   registry.npmmirror.com/new-github-release-url@1.0.0:
     resolution: {integrity: sha512-dle7yf655IMjyFUqn6Nxkb18r4AOAkzRcgcZv6WZ0IqrOH4QCEZ8Sm6I7XX21zvHdBeeMeTkhR9qT2Z0EJDx6A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/new-github-release-url/-/new-github-release-url-1.0.0.tgz}
     name: new-github-release-url
     version: 1.0.0
     engines: {node: '>=10'}
     dependencies:
-      type-fest: registry.npmmirror.com/type-fest@0.4.1
+      type-fest: 0.4.1
     dev: true
 
   registry.npmmirror.com/next-tick@1.1.0:
@@ -7178,53 +2757,14 @@ packages:
       es6-promise: registry.npmmirror.com/es6-promise@3.3.1
     dev: false
 
-  registry.npmmirror.com/node-releases@2.0.13:
-    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/node-releases/-/node-releases-2.0.13.tgz}
-    name: node-releases
-    version: 2.0.13
-    dev: false
-
-  registry.npmmirror.com/normalize-package-data@2.5.0:
-    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz}
-    name: normalize-package-data
-    version: 2.5.0
-    dependencies:
-      hosted-git-info: registry.npmmirror.com/hosted-git-info@2.8.9
-      resolve: registry.npmmirror.com/resolve@1.22.2
-      semver: registry.npmmirror.com/semver@5.7.1
-      validate-npm-package-license: registry.npmmirror.com/validate-npm-package-license@3.0.4
-
-  registry.npmmirror.com/normalize-package-data@3.0.3:
-    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz}
-    name: normalize-package-data
-    version: 3.0.3
-    engines: {node: '>=10'}
-    dependencies:
-      hosted-git-info: registry.npmmirror.com/hosted-git-info@4.1.0
-      is-core-module: registry.npmmirror.com/is-core-module@2.12.1
-      semver: registry.npmmirror.com/semver@7.5.4
-      validate-npm-package-license: registry.npmmirror.com/validate-npm-package-license@3.0.4
-
   registry.npmmirror.com/normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz}
     name: normalize-path
     version: 3.0.0
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dev: false
     optional: true
-
-  registry.npmmirror.com/normalize-range@0.1.2:
-    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-range/-/normalize-range-0.1.2.tgz}
-    name: normalize-range
-    version: 0.1.2
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/normalize-selector@0.2.0:
-    resolution: {integrity: sha512-dxvWdI8gw6eAvk9BlPffgEoGfM7AdijoCwOEJge3e3ulT2XLgmU7KvvxprOaCu05Q1uGRHmOhHe1r6emZoKyFw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-selector/-/normalize-selector-0.2.0.tgz}
-    name: normalize-selector
-    version: 0.2.0
-    dev: false
 
   registry.npmmirror.com/normalize-url@4.5.1:
     resolution: {integrity: sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/normalize-url/-/normalize-url-4.5.1.tgz}
@@ -7300,28 +2840,13 @@ packages:
       got: registry.npmmirror.com/got@10.7.0
       is-scoped: registry.npmmirror.com/is-scoped@2.1.0
       is-url-superb: registry.npmmirror.com/is-url-superb@4.0.0
-      lodash.zip: registry.npmmirror.com/lodash.zip@4.2.0
+      lodash.zip: 4.2.0
       org-regex: registry.npmmirror.com/org-regex@1.0.0
       p-map: registry.npmmirror.com/p-map@3.0.0
       registry-auth-token: registry.npmmirror.com/registry-auth-token@4.2.2
       registry-url: registry.npmmirror.com/registry-url@5.1.0
       validate-npm-package-name: registry.npmmirror.com/validate-npm-package-name@3.0.0
     dev: true
-
-  registry.npmmirror.com/npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/npm-run-path/-/npm-run-path-4.0.1.tgz}
-    name: npm-run-path
-    version: 4.0.1
-    engines: {node: '>=8'}
-    dependencies:
-      path-key: registry.npmmirror.com/path-key@3.1.1
-    dev: true
-
-  registry.npmmirror.com/num2fraction@1.2.2:
-    resolution: {integrity: sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/num2fraction/-/num2fraction-1.2.2.tgz}
-    name: num2fraction
-    version: 1.2.2
-    dev: false
 
   registry.npmmirror.com/number-is-nan@1.0.1:
     resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/number-is-nan/-/number-is-nan-1.0.1.tgz}
@@ -7396,123 +2921,13 @@ packages:
       yaml: registry.npmmirror.com/yaml@1.10.2
     dev: false
 
-  registry.npmmirror.com/object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz}
-    name: object-assign
-    version: 4.1.1
-    engines: {node: '>=0.10.0'}
-
-  registry.npmmirror.com/object-copy@0.1.0:
-    resolution: {integrity: sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object-copy/-/object-copy-0.1.0.tgz}
-    name: object-copy
-    version: 0.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      copy-descriptor: registry.npmmirror.com/copy-descriptor@0.1.1
-      define-property: registry.npmmirror.com/define-property@0.2.5
-      kind-of: registry.npmmirror.com/kind-of@3.2.2
-    dev: false
-
-  registry.npmmirror.com/object-inspect@1.12.3:
-    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object-inspect/-/object-inspect-1.12.3.tgz}
-    name: object-inspect
-    version: 1.12.3
-    dev: false
-
-  registry.npmmirror.com/object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object-keys/-/object-keys-1.1.1.tgz}
-    name: object-keys
-    version: 1.1.1
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  registry.npmmirror.com/object-visit@1.0.1:
-    resolution: {integrity: sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object-visit/-/object-visit-1.0.1.tgz}
-    name: object-visit
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isobject: registry.npmmirror.com/isobject@3.0.1
-    dev: false
-
-  registry.npmmirror.com/object.assign@4.1.4:
-    resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object.assign/-/object.assign-4.1.4.tgz}
-    name: object.assign
-    version: 4.1.4
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      has-symbols: registry.npmmirror.com/has-symbols@1.0.3
-      object-keys: registry.npmmirror.com/object-keys@1.1.1
-    dev: false
-
-  registry.npmmirror.com/object.entries@1.1.6:
-    resolution: {integrity: sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object.entries/-/object.entries-1.1.6.tgz}
-    name: object.entries
-    version: 1.1.6
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-    dev: false
-
-  registry.npmmirror.com/object.fromentries@2.0.6:
-    resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object.fromentries/-/object.fromentries-2.0.6.tgz}
-    name: object.fromentries
-    version: 2.0.6
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-    dev: false
-
-  registry.npmmirror.com/object.hasown@1.1.2:
-    resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object.hasown/-/object.hasown-1.1.2.tgz}
-    name: object.hasown
-    version: 1.1.2
-    dependencies:
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-    dev: false
-
-  registry.npmmirror.com/object.pick@1.3.0:
-    resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object.pick/-/object.pick-1.3.0.tgz}
-    name: object.pick
-    version: 1.3.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isobject: registry.npmmirror.com/isobject@3.0.1
-    dev: false
-
-  registry.npmmirror.com/object.values@1.1.6:
-    resolution: {integrity: sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/object.values/-/object.values-1.1.6.tgz}
-    name: object.values
-    version: 1.1.6
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-    dev: false
-
   registry.npmmirror.com/once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/once/-/once-1.4.0.tgz}
     name: once
     version: 1.4.0
     dependencies:
       wrappy: registry.npmmirror.com/wrappy@1.0.2
-
-  registry.npmmirror.com/onetime@2.0.1:
-    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/onetime/-/onetime-2.0.1.tgz}
-    name: onetime
-    version: 2.0.1
-    engines: {node: '>=4'}
-    dependencies:
-      mimic-fn: registry.npmmirror.com/mimic-fn@1.2.0
-    dev: true
+    dev: false
 
   registry.npmmirror.com/onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/onetime/-/onetime-5.1.2.tgz}
@@ -7520,7 +2935,7 @@ packages:
     version: 5.1.2
     engines: {node: '>=6'}
     dependencies:
-      mimic-fn: registry.npmmirror.com/mimic-fn@2.1.0
+      mimic-fn: 2.1.0
     dev: true
 
   registry.npmmirror.com/open@7.4.2:
@@ -7539,20 +2954,6 @@ packages:
     version: 2.0.1
     dependencies:
       yaml: registry.npmmirror.com/yaml@1.10.2
-    dev: false
-
-  registry.npmmirror.com/optionator@0.9.3:
-    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/optionator/-/optionator-0.9.3.tgz}
-    name: optionator
-    version: 0.9.3
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      '@aashutoshrathi/word-wrap': registry.npmmirror.com/@aashutoshrathi/word-wrap@1.2.6
-      deep-is: registry.npmmirror.com/deep-is@0.1.4
-      fast-levenshtein: registry.npmmirror.com/fast-levenshtein@2.0.6
-      levn: registry.npmmirror.com/levn@0.4.1
-      prelude-ls: registry.npmmirror.com/prelude-ls@1.2.1
-      type-check: registry.npmmirror.com/type-check@0.4.0
     dev: false
 
   registry.npmmirror.com/org-regex@1.0.0:
@@ -7576,10 +2977,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@sindresorhus/is': registry.npmmirror.com/@sindresorhus/is@4.6.0
-      callsites: registry.npmmirror.com/callsites@3.1.0
+      callsites: 3.1.0
       dot-prop: registry.npmmirror.com/dot-prop@6.0.1
       lodash.isequal: registry.npmmirror.com/lodash.isequal@4.5.0
-      type-fest: registry.npmmirror.com/type-fest@0.20.2
+      type-fest: 0.20.2
       vali-date: registry.npmmirror.com/vali-date@1.0.0
     dev: true
 
@@ -7595,13 +2996,6 @@ packages:
     name: p-cancelable
     version: 2.1.1
     engines: {node: '>=8'}
-    dev: true
-
-  registry.npmmirror.com/p-defer@1.0.0:
-    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-defer/-/p-defer-1.0.0.tgz}
-    name: p-defer
-    version: 1.0.0
-    engines: {node: '>=4'}
     dev: true
 
   registry.npmmirror.com/p-event@4.2.0:
@@ -7620,55 +3014,14 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  registry.npmmirror.com/p-limit@1.3.0:
-    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-limit/-/p-limit-1.3.0.tgz}
-    name: p-limit
-    version: 1.3.0
-    engines: {node: '>=4'}
-    dependencies:
-      p-try: registry.npmmirror.com/p-try@1.0.0
-    dev: false
-
   registry.npmmirror.com/p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-limit/-/p-limit-2.3.0.tgz}
     name: p-limit
     version: 2.3.0
     engines: {node: '>=6'}
     dependencies:
-      p-try: registry.npmmirror.com/p-try@2.2.0
-
-  registry.npmmirror.com/p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz}
-    name: p-limit
-    version: 3.1.0
-    engines: {node: '>=10'}
-    dependencies:
-      yocto-queue: registry.npmmirror.com/yocto-queue@0.1.0
-
-  registry.npmmirror.com/p-locate@2.0.0:
-    resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-locate/-/p-locate-2.0.0.tgz}
-    name: p-locate
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      p-limit: registry.npmmirror.com/p-limit@1.3.0
-    dev: false
-
-  registry.npmmirror.com/p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-locate/-/p-locate-4.1.0.tgz}
-    name: p-locate
-    version: 4.1.0
-    engines: {node: '>=8'}
-    dependencies:
-      p-limit: registry.npmmirror.com/p-limit@2.3.0
-
-  registry.npmmirror.com/p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-locate/-/p-locate-5.0.0.tgz}
-    name: p-locate
-    version: 5.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      p-limit: registry.npmmirror.com/p-limit@3.1.0
+      p-try: 2.2.0
+    dev: true
 
   registry.npmmirror.com/p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-map/-/p-map-2.1.0.tgz}
@@ -7701,8 +3054,8 @@ packages:
     version: 4.0.4
     engines: {node: '>=10'}
     dependencies:
-      map-age-cleaner: registry.npmmirror.com/map-age-cleaner@0.1.3
-      mimic-fn: registry.npmmirror.com/mimic-fn@3.1.0
+      map-age-cleaner: 0.1.3
+      mimic-fn: 3.1.0
       p-settle: registry.npmmirror.com/p-settle@4.1.1
     dev: true
 
@@ -7739,19 +3092,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  registry.npmmirror.com/p-try@1.0.0:
-    resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-try/-/p-try-1.0.0.tgz}
-    name: p-try
-    version: 1.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/p-try/-/p-try-2.2.0.tgz}
-    name: p-try
-    version: 2.2.0
-    engines: {node: '>=6'}
-
   registry.npmmirror.com/package-json@6.5.0:
     resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/package-json/-/package-json-6.5.0.tgz}
     name: package-json
@@ -7761,132 +3101,21 @@ packages:
       got: registry.npmmirror.com/got@9.6.0
       registry-auth-token: registry.npmmirror.com/registry-auth-token@4.2.2
       registry-url: registry.npmmirror.com/registry-url@5.1.0
-      semver: registry.npmmirror.com/semver@6.3.0
+      semver: 6.3.0
     dev: true
-
-  registry.npmmirror.com/parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz}
-    name: parent-module
-    version: 1.0.1
-    engines: {node: '>=6'}
-    dependencies:
-      callsites: registry.npmmirror.com/callsites@3.1.0
-
-  registry.npmmirror.com/parse-entities@1.2.2:
-    resolution: {integrity: sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parse-entities/-/parse-entities-1.2.2.tgz}
-    name: parse-entities
-    version: 1.2.2
-    dependencies:
-      character-entities: registry.npmmirror.com/character-entities@1.2.4
-      character-entities-legacy: registry.npmmirror.com/character-entities-legacy@1.1.4
-      character-reference-invalid: registry.npmmirror.com/character-reference-invalid@1.1.4
-      is-alphanumerical: registry.npmmirror.com/is-alphanumerical@1.0.4
-      is-decimal: registry.npmmirror.com/is-decimal@1.0.4
-      is-hexadecimal: registry.npmmirror.com/is-hexadecimal@1.0.4
-    dev: false
-
-  registry.npmmirror.com/parse-entities@2.0.0:
-    resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parse-entities/-/parse-entities-2.0.0.tgz}
-    name: parse-entities
-    version: 2.0.0
-    dependencies:
-      character-entities: registry.npmmirror.com/character-entities@1.2.4
-      character-entities-legacy: registry.npmmirror.com/character-entities-legacy@1.1.4
-      character-reference-invalid: registry.npmmirror.com/character-reference-invalid@1.1.4
-      is-alphanumerical: registry.npmmirror.com/is-alphanumerical@1.0.4
-      is-decimal: registry.npmmirror.com/is-decimal@1.0.4
-      is-hexadecimal: registry.npmmirror.com/is-hexadecimal@1.0.4
-    dev: false
-
-  registry.npmmirror.com/parse-json@4.0.0:
-    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parse-json/-/parse-json-4.0.0.tgz}
-    name: parse-json
-    version: 4.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      error-ex: registry.npmmirror.com/error-ex@1.3.2
-      json-parse-better-errors: registry.npmmirror.com/json-parse-better-errors@1.0.2
-    dev: false
-
-  registry.npmmirror.com/parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/parse-json/-/parse-json-5.2.0.tgz}
-    name: parse-json
-    version: 5.2.0
-    engines: {node: '>=8'}
-    dependencies:
-      '@babel/code-frame': registry.npmmirror.com/@babel/code-frame@7.22.5
-      error-ex: registry.npmmirror.com/error-ex@1.3.2
-      json-parse-even-better-errors: registry.npmmirror.com/json-parse-even-better-errors@2.3.1
-      lines-and-columns: registry.npmmirror.com/lines-and-columns@1.2.4
-
-  registry.npmmirror.com/pascalcase@0.1.1:
-    resolution: {integrity: sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pascalcase/-/pascalcase-0.1.1.tgz}
-    name: pascalcase
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/path-dirname@1.0.2:
-    resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-dirname/-/path-dirname-1.0.2.tgz}
-    name: path-dirname
-    version: 1.0.2
-    dev: false
-
-  registry.npmmirror.com/path-exists@3.0.0:
-    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-exists/-/path-exists-3.0.0.tgz}
-    name: path-exists
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dev: false
 
   registry.npmmirror.com/path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz}
     name: path-exists
     version: 4.0.0
     engines: {node: '>=8'}
+    dev: true
 
   registry.npmmirror.com/path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz}
     name: path-is-absolute
     version: 1.0.1
     engines: {node: '>=0.10.0'}
-
-  registry.npmmirror.com/path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz}
-    name: path-key
-    version: 3.1.1
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-parse/-/path-parse-1.0.7.tgz}
-    name: path-parse
-    version: 1.0.7
-
-  registry.npmmirror.com/path-type@3.0.0:
-    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-type/-/path-type-3.0.0.tgz}
-    name: path-type
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      pify: registry.npmmirror.com/pify@3.0.0
-    dev: false
-
-  registry.npmmirror.com/path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/path-type/-/path-type-4.0.0.tgz}
-    name: path-type
-    version: 4.0.0
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/picocolors@0.2.1:
-    resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/picocolors/-/picocolors-0.2.1.tgz}
-    name: picocolors
-    version: 0.2.1
-    dev: false
-
-  registry.npmmirror.com/picocolors@1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/picocolors/-/picocolors-1.0.0.tgz}
-    name: picocolors
-    version: 1.0.0
     dev: false
 
   registry.npmmirror.com/picomatch@2.3.1:
@@ -7894,20 +3123,9 @@ packages:
     name: picomatch
     version: 2.3.1
     engines: {node: '>=8.6'}
-
-  registry.npmmirror.com/pify@3.0.0:
-    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pify/-/pify-3.0.0.tgz}
-    name: pify
-    version: 3.0.0
-    engines: {node: '>=4'}
+    requiresBuild: true
     dev: false
-
-  registry.npmmirror.com/pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pify/-/pify-4.0.1.tgz}
-    name: pify
-    version: 4.0.1
-    engines: {node: '>=6'}
-    dev: false
+    optional: true
 
   registry.npmmirror.com/pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pkg-dir/-/pkg-dir-4.2.0.tgz}
@@ -7915,7 +3133,7 @@ packages:
     version: 4.2.0
     engines: {node: '>=8'}
     dependencies:
-      find-up: registry.npmmirror.com/find-up@4.1.0
+      find-up: 4.1.0
     dev: true
 
   registry.npmmirror.com/pkg-dir@5.0.0:
@@ -7924,258 +3142,8 @@ packages:
     version: 5.0.0
     engines: {node: '>=10'}
     dependencies:
-      find-up: registry.npmmirror.com/find-up@5.0.0
+      find-up: 5.0.0
     dev: true
-
-  registry.npmmirror.com/plur@4.0.0:
-    resolution: {integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/plur/-/plur-4.0.0.tgz}
-    name: plur
-    version: 4.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      irregular-plurals: registry.npmmirror.com/irregular-plurals@3.5.0
-    dev: false
-
-  registry.npmmirror.com/pluralize@8.0.0:
-    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pluralize/-/pluralize-8.0.0.tgz}
-    name: pluralize
-    version: 8.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/posix-character-classes@0.1.1:
-    resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz}
-    name: posix-character-classes
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
-    resolution: {integrity: sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-html/-/postcss-html-0.36.0.tgz}
-    id: registry.npmmirror.com/postcss-html/0.36.0
-    name: postcss-html
-    version: 0.36.0
-    peerDependencies:
-      postcss: '>=5.0.0'
-      postcss-syntax: '>=0.36.0'
-    dependencies:
-      htmlparser2: registry.npmmirror.com/htmlparser2@3.10.1
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
-    dev: false
-
-  registry.npmmirror.com/postcss-jsx@0.36.4(postcss-syntax@0.36.2)(postcss@7.0.39):
-    resolution: {integrity: sha512-jwO/7qWUvYuWYnpOb0+4bIIgJt7003pgU3P6nETBLaOyBXuTD55ho21xnals5nBrlpTIFodyd3/jBi6UO3dHvA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-jsx/-/postcss-jsx-0.36.4.tgz}
-    id: registry.npmmirror.com/postcss-jsx/0.36.4
-    name: postcss-jsx
-    version: 0.36.4
-    peerDependencies:
-      postcss: '>=5.0.0'
-      postcss-syntax: '>=0.36.0'
-    dependencies:
-      '@babel/core': registry.npmmirror.com/@babel/core@7.22.8
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/postcss-less@3.1.4:
-    resolution: {integrity: sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-less/-/postcss-less-3.1.4.tgz}
-    name: postcss-less
-    version: 3.1.4
-    engines: {node: '>=6.14.4'}
-    dependencies:
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/postcss-markdown@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
-    resolution: {integrity: sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-markdown/-/postcss-markdown-0.36.0.tgz}
-    id: registry.npmmirror.com/postcss-markdown/0.36.0
-    name: postcss-markdown
-    version: 0.36.0
-    peerDependencies:
-      postcss: '>=5.0.0'
-      postcss-syntax: '>=0.36.0'
-    dependencies:
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
-      remark: registry.npmmirror.com/remark@10.0.1
-      unist-util-find-all-after: registry.npmmirror.com/unist-util-find-all-after@1.0.5
-    dev: false
-
-  registry.npmmirror.com/postcss-media-query-parser@0.2.3:
-    resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz}
-    name: postcss-media-query-parser
-    version: 0.2.3
-    dev: false
-
-  registry.npmmirror.com/postcss-reporter@6.0.1:
-    resolution: {integrity: sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-reporter/-/postcss-reporter-6.0.1.tgz}
-    name: postcss-reporter
-    version: 6.0.1
-    engines: {node: '>=6'}
-    dependencies:
-      chalk: registry.npmmirror.com/chalk@2.4.2
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      log-symbols: registry.npmmirror.com/log-symbols@2.2.0
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/postcss-resolve-nested-selector@0.1.1:
-    resolution: {integrity: sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz}
-    name: postcss-resolve-nested-selector
-    version: 0.1.1
-    dev: false
-
-  registry.npmmirror.com/postcss-safe-parser@4.0.2:
-    resolution: {integrity: sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz}
-    name: postcss-safe-parser
-    version: 4.0.2
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/postcss-sass@0.3.5:
-    resolution: {integrity: sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-sass/-/postcss-sass-0.3.5.tgz}
-    name: postcss-sass
-    version: 0.3.5
-    dependencies:
-      gonzales-pe: registry.npmmirror.com/gonzales-pe@4.3.0
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/postcss-sass@0.4.4:
-    resolution: {integrity: sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-sass/-/postcss-sass-0.4.4.tgz}
-    name: postcss-sass
-    version: 0.4.4
-    dependencies:
-      gonzales-pe: registry.npmmirror.com/gonzales-pe@4.3.0
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/postcss-scss@2.1.1:
-    resolution: {integrity: sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-scss/-/postcss-scss-2.1.1.tgz}
-    name: postcss-scss
-    version: 2.1.1
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/postcss-selector-parser@3.1.2:
-    resolution: {integrity: sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz}
-    name: postcss-selector-parser
-    version: 3.1.2
-    engines: {node: '>=8'}
-    dependencies:
-      dot-prop: registry.npmmirror.com/dot-prop@5.3.0
-      indexes-of: registry.npmmirror.com/indexes-of@1.0.1
-      uniq: registry.npmmirror.com/uniq@1.0.1
-    dev: false
-
-  registry.npmmirror.com/postcss-selector-parser@6.0.13:
-    resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz}
-    name: postcss-selector-parser
-    version: 6.0.13
-    engines: {node: '>=4'}
-    dependencies:
-      cssesc: registry.npmmirror.com/cssesc@3.0.0
-      util-deprecate: registry.npmmirror.com/util-deprecate@1.0.2
-    dev: false
-
-  registry.npmmirror.com/postcss-sorting@4.1.0:
-    resolution: {integrity: sha512-r4T2oQd1giURJdHQ/RMb72dKZCuLOdWx2B/XhXN1Y1ZdnwXsKH896Qz6vD4tFy9xSjpKNYhlZoJmWyhH/7JUQw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-sorting/-/postcss-sorting-4.1.0.tgz}
-    name: postcss-sorting
-    version: 4.1.0
-    engines: {node: '>=6.14.3'}
-    dependencies:
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/postcss-sorting@5.0.1:
-    resolution: {integrity: sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-sorting/-/postcss-sorting-5.0.1.tgz}
-    name: postcss-sorting
-    version: 5.0.1
-    engines: {node: '>=8.7.0'}
-    dependencies:
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39):
-    resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-syntax/-/postcss-syntax-0.36.2.tgz}
-    id: registry.npmmirror.com/postcss-syntax/0.36.2
-    name: postcss-syntax
-    version: 0.36.2
-    peerDependencies:
-      postcss: '>=5.0.0'
-      postcss-html: '*'
-      postcss-jsx: '*'
-      postcss-less: '*'
-      postcss-markdown: '*'
-      postcss-scss: '*'
-    peerDependenciesMeta:
-      postcss-html:
-        optional: true
-      postcss-jsx:
-        optional: true
-      postcss-less:
-        optional: true
-      postcss-markdown:
-        optional: true
-      postcss-scss:
-        optional: true
-    dependencies:
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-html: registry.npmmirror.com/postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
-      postcss-jsx: registry.npmmirror.com/postcss-jsx@0.36.4(postcss-syntax@0.36.2)(postcss@7.0.39)
-      postcss-less: registry.npmmirror.com/postcss-less@3.1.4
-      postcss-markdown: registry.npmmirror.com/postcss-markdown@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
-      postcss-scss: registry.npmmirror.com/postcss-scss@2.1.1
-    dev: false
-
-  registry.npmmirror.com/postcss-value-parser@3.3.1:
-    resolution: {integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz}
-    name: postcss-value-parser
-    version: 3.3.1
-    dev: false
-
-  registry.npmmirror.com/postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz}
-    name: postcss-value-parser
-    version: 4.2.0
-    dev: false
-
-  registry.npmmirror.com/postcss@7.0.39:
-    resolution: {integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss/-/postcss-7.0.39.tgz}
-    name: postcss
-    version: 7.0.39
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      picocolors: registry.npmmirror.com/picocolors@0.2.1
-      source-map: registry.npmmirror.com/source-map@0.6.1
-    dev: false
-
-  registry.npmmirror.com/postcss@8.4.25:
-    resolution: {integrity: sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/postcss/-/postcss-8.4.25.tgz}
-    name: postcss
-    version: 8.4.25
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: registry.npmmirror.com/nanoid@3.3.6
-      picocolors: registry.npmmirror.com/picocolors@1.0.0
-      source-map-js: registry.npmmirror.com/source-map-js@1.0.2
-    dev: false
-
-  registry.npmmirror.com/prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prelude-ls/-/prelude-ls-1.2.1.tgz}
-    name: prelude-ls
-    version: 1.2.1
-    engines: {node: '>= 0.8.0'}
-    dev: false
 
   registry.npmmirror.com/prepend-http@2.0.0:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prepend-http/-/prepend-http-2.0.0.tgz}
@@ -8184,58 +3152,12 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  registry.npmmirror.com/prettier-plugin-style-order@0.2.2(prettier@2.2.1):
-    resolution: {integrity: sha512-4rASdHONhHLNX0arKqEvjGOEAbkSZE3+GQPSaS8mf3en/spjeN0le5fV1yKltWwQeM4UPn7CkKzeD97a4Az/6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prettier-plugin-style-order/-/prettier-plugin-style-order-0.2.2.tgz}
-    id: registry.npmmirror.com/prettier-plugin-style-order/0.2.2
-    name: prettier-plugin-style-order
-    version: 0.2.2
-    peerDependencies:
-      prettier: '>= 1.13'
-    dependencies:
-      postcss-sorting: registry.npmmirror.com/postcss-sorting@5.0.1
-      prettier: registry.npmmirror.com/prettier@2.2.1
-      resolve-cwd: registry.npmmirror.com/resolve-cwd@3.0.0
-    dev: false
-
   registry.npmmirror.com/prettier@2.2.1:
     resolution: {integrity: sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prettier/-/prettier-2.2.1.tgz}
     name: prettier
     version: 2.2.1
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: false
-
-  registry.npmmirror.com/progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/progress/-/progress-2.0.3.tgz}
-    name: progress
-    version: 2.0.3
-    engines: {node: '>=0.4.0'}
-    dev: false
-
-  registry.npmmirror.com/prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/prop-types/-/prop-types-15.8.1.tgz}
-    name: prop-types
-    version: 15.8.1
-    dependencies:
-      loose-envify: registry.npmmirror.com/loose-envify@1.4.0
-      object-assign: registry.npmmirror.com/object-assign@4.1.1
-      react-is: registry.npmmirror.com/react-is@16.13.1
-    dev: false
-
-  registry.npmmirror.com/pump@3.0.0:
-    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/pump/-/pump-3.0.0.tgz}
-    name: pump
-    version: 3.0.0
-    dependencies:
-      end-of-stream: registry.npmmirror.com/end-of-stream@1.4.4
-      once: registry.npmmirror.com/once@1.4.0
-    dev: true
-
-  registry.npmmirror.com/punycode@2.3.0:
-    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/punycode/-/punycode-2.3.0.tgz}
-    name: punycode
-    version: 2.3.0
-    engines: {node: '>=6'}
     dev: false
 
   registry.npmmirror.com/pupa@2.1.1:
@@ -8247,24 +3169,6 @@ packages:
       escape-goat: registry.npmmirror.com/escape-goat@2.1.1
     dev: true
 
-  registry.npmmirror.com/queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz}
-    name: queue-microtask
-    version: 1.2.3
-
-  registry.npmmirror.com/quick-lru@1.1.0:
-    resolution: {integrity: sha512-tRS7sTgyxMXtLum8L65daJnHUhfDUgboRdcWW2bR9vBfrj2+O5HSMbQOJfJJjIVSPFqbBCF37FpwWXGitDc5tA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/quick-lru/-/quick-lru-1.1.0.tgz}
-    name: quick-lru
-    version: 1.1.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/quick-lru@4.0.1:
-    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/quick-lru/-/quick-lru-4.0.1.tgz}
-    name: quick-lru
-    version: 4.0.1
-    engines: {node: '>=8'}
-
   registry.npmmirror.com/rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rc/-/rc-1.2.8.tgz}
     name: rc
@@ -8272,26 +3176,10 @@ packages:
     hasBin: true
     dependencies:
       deep-extend: registry.npmmirror.com/deep-extend@0.6.0
-      ini: registry.npmmirror.com/ini@1.3.8
-      minimist: registry.npmmirror.com/minimist@1.2.8
-      strip-json-comments: registry.npmmirror.com/strip-json-comments@2.0.1
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
     dev: true
-
-  registry.npmmirror.com/react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/react-is/-/react-is-16.13.1.tgz}
-    name: react-is
-    version: 16.13.1
-    dev: false
-
-  registry.npmmirror.com/read-pkg-up@3.0.0:
-    resolution: {integrity: sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz}
-    name: read-pkg-up
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      find-up: registry.npmmirror.com/find-up@2.1.0
-      read-pkg: registry.npmmirror.com/read-pkg@3.0.0
-    dev: false
 
   registry.npmmirror.com/read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz}
@@ -8299,176 +3187,26 @@ packages:
     version: 7.0.1
     engines: {node: '>=8'}
     dependencies:
-      find-up: registry.npmmirror.com/find-up@4.1.0
-      read-pkg: registry.npmmirror.com/read-pkg@5.2.0
-      type-fest: registry.npmmirror.com/type-fest@0.8.1
-
-  registry.npmmirror.com/read-pkg@3.0.0:
-    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/read-pkg/-/read-pkg-3.0.0.tgz}
-    name: read-pkg
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      load-json-file: registry.npmmirror.com/load-json-file@4.0.0
-      normalize-package-data: registry.npmmirror.com/normalize-package-data@2.5.0
-      path-type: registry.npmmirror.com/path-type@3.0.0
-    dev: false
-
-  registry.npmmirror.com/read-pkg@5.2.0:
-    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/read-pkg/-/read-pkg-5.2.0.tgz}
-    name: read-pkg
-    version: 5.2.0
-    engines: {node: '>=8'}
-    dependencies:
-      '@types/normalize-package-data': registry.npmmirror.com/@types/normalize-package-data@2.4.1
-      normalize-package-data: registry.npmmirror.com/normalize-package-data@2.5.0
-      parse-json: registry.npmmirror.com/parse-json@5.2.0
-      type-fest: registry.npmmirror.com/type-fest@0.6.0
-
-  registry.npmmirror.com/readable-stream@1.0.34:
-    resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/readable-stream/-/readable-stream-1.0.34.tgz}
-    name: readable-stream
-    version: 1.0.34
-    dependencies:
-      core-util-is: registry.npmmirror.com/core-util-is@1.0.3
-      inherits: registry.npmmirror.com/inherits@2.0.4
-      isarray: registry.npmmirror.com/isarray@0.0.1
-      string_decoder: registry.npmmirror.com/string_decoder@0.10.31
-    dev: false
-
-  registry.npmmirror.com/readable-stream@1.1.14:
-    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/readable-stream/-/readable-stream-1.1.14.tgz}
-    name: readable-stream
-    version: 1.1.14
-    dependencies:
-      core-util-is: registry.npmmirror.com/core-util-is@1.0.3
-      inherits: registry.npmmirror.com/inherits@2.0.4
-      isarray: registry.npmmirror.com/isarray@0.0.1
-      string_decoder: registry.npmmirror.com/string_decoder@0.10.31
-    dev: false
-
-  registry.npmmirror.com/readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/readable-stream/-/readable-stream-3.6.2.tgz}
-    name: readable-stream
-    version: 3.6.2
-    engines: {node: '>= 6'}
-    dependencies:
-      inherits: registry.npmmirror.com/inherits@2.0.4
-      string_decoder: registry.npmmirror.com/string_decoder@1.3.0
-      util-deprecate: registry.npmmirror.com/util-deprecate@1.0.2
-    dev: false
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+    dev: true
 
   registry.npmmirror.com/readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz}
     name: readdirp
     version: 3.6.0
     engines: {node: '>=8.10.0'}
+    requiresBuild: true
     dependencies:
       picomatch: registry.npmmirror.com/picomatch@2.3.1
     dev: false
     optional: true
 
-  registry.npmmirror.com/redent@2.0.0:
-    resolution: {integrity: sha512-XNwrTx77JQCEMXTeb8movBKuK75MgH0RZkujNuDKCezemx/voapl9i2gCSi8WWm8+ox5ycJi1gxF22fR7c0Ciw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/redent/-/redent-2.0.0.tgz}
-    name: redent
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      indent-string: registry.npmmirror.com/indent-string@3.2.0
-      strip-indent: registry.npmmirror.com/strip-indent@2.0.0
-    dev: false
-
-  registry.npmmirror.com/redent@3.0.0:
-    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/redent/-/redent-3.0.0.tgz}
-    name: redent
-    version: 3.0.0
-    engines: {node: '>=8'}
-    dependencies:
-      indent-string: registry.npmmirror.com/indent-string@4.0.0
-      strip-indent: registry.npmmirror.com/strip-indent@3.0.0
-
   registry.npmmirror.com/reftools@1.1.9:
     resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/reftools/-/reftools-1.1.9.tgz}
     name: reftools
     version: 1.1.9
-    dev: false
-
-  registry.npmmirror.com/regenerate-unicode-properties@10.1.0:
-    resolution: {integrity: sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz}
-    name: regenerate-unicode-properties
-    version: 10.1.0
-    engines: {node: '>=4'}
-    dependencies:
-      regenerate: registry.npmmirror.com/regenerate@1.4.2
-    dev: false
-
-  registry.npmmirror.com/regenerate@1.4.2:
-    resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regenerate/-/regenerate-1.4.2.tgz}
-    name: regenerate
-    version: 1.4.2
-    dev: false
-
-  registry.npmmirror.com/regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz}
-    name: regenerator-runtime
-    version: 0.13.11
-    dev: false
-
-  registry.npmmirror.com/regenerator-transform@0.15.1:
-    resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regenerator-transform/-/regenerator-transform-0.15.1.tgz}
-    name: regenerator-transform
-    version: 0.15.1
-    dependencies:
-      '@babel/runtime': registry.npmmirror.com/@babel/runtime@7.22.6
-    dev: false
-
-  registry.npmmirror.com/regex-not@1.0.2:
-    resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regex-not/-/regex-not-1.0.2.tgz}
-    name: regex-not
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: registry.npmmirror.com/extend-shallow@3.0.2
-      safe-regex: registry.npmmirror.com/safe-regex@1.1.0
-    dev: false
-
-  registry.npmmirror.com/regexp-tree@0.1.27:
-    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regexp-tree/-/regexp-tree-0.1.27.tgz}
-    name: regexp-tree
-    version: 0.1.27
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/regexp.prototype.flags@1.5.0:
-    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz}
-    name: regexp.prototype.flags
-    version: 1.5.0
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      functions-have-names: registry.npmmirror.com/functions-have-names@1.2.3
-    dev: false
-
-  registry.npmmirror.com/regexpp@3.2.0:
-    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regexpp/-/regexpp-3.2.0.tgz}
-    name: regexpp
-    version: 3.2.0
-    engines: {node: '>=8'}
-    dev: false
-
-  registry.npmmirror.com/regexpu-core@5.3.2:
-    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regexpu-core/-/regexpu-core-5.3.2.tgz}
-    name: regexpu-core
-    version: 5.3.2
-    engines: {node: '>=4'}
-    dependencies:
-      '@babel/regjsgen': registry.npmmirror.com/@babel/regjsgen@0.8.0
-      regenerate: registry.npmmirror.com/regenerate@1.4.2
-      regenerate-unicode-properties: registry.npmmirror.com/regenerate-unicode-properties@10.1.0
-      regjsparser: registry.npmmirror.com/regjsparser@0.9.1
-      unicode-match-property-ecmascript: registry.npmmirror.com/unicode-match-property-ecmascript@2.0.0
-      unicode-match-property-value-ecmascript: registry.npmmirror.com/unicode-match-property-value-ecmascript@2.1.0
     dev: false
 
   registry.npmmirror.com/registry-auth-token@4.2.2:
@@ -8489,152 +3227,10 @@ packages:
       rc: registry.npmmirror.com/rc@1.2.8
     dev: true
 
-  registry.npmmirror.com/regjsparser@0.9.1:
-    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/regjsparser/-/regjsparser-0.9.1.tgz}
-    name: regjsparser
-    version: 0.9.1
-    hasBin: true
-    dependencies:
-      jsesc: registry.npmmirror.com/jsesc@0.5.0
-    dev: false
-
-  registry.npmmirror.com/remark-parse@5.0.0:
-    resolution: {integrity: sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/remark-parse/-/remark-parse-5.0.0.tgz}
-    name: remark-parse
-    version: 5.0.0
-    dependencies:
-      collapse-white-space: registry.npmmirror.com/collapse-white-space@1.0.6
-      is-alphabetical: registry.npmmirror.com/is-alphabetical@1.0.4
-      is-decimal: registry.npmmirror.com/is-decimal@1.0.4
-      is-whitespace-character: registry.npmmirror.com/is-whitespace-character@1.0.4
-      is-word-character: registry.npmmirror.com/is-word-character@1.0.4
-      markdown-escapes: registry.npmmirror.com/markdown-escapes@1.0.4
-      parse-entities: registry.npmmirror.com/parse-entities@1.2.2
-      repeat-string: registry.npmmirror.com/repeat-string@1.6.1
-      state-toggle: registry.npmmirror.com/state-toggle@1.0.3
-      trim: registry.npmmirror.com/trim@0.0.1
-      trim-trailing-lines: registry.npmmirror.com/trim-trailing-lines@1.1.4
-      unherit: registry.npmmirror.com/unherit@1.1.3
-      unist-util-remove-position: registry.npmmirror.com/unist-util-remove-position@1.1.4
-      vfile-location: registry.npmmirror.com/vfile-location@2.0.6
-      xtend: registry.npmmirror.com/xtend@4.0.2
-    dev: false
-
-  registry.npmmirror.com/remark-parse@6.0.3:
-    resolution: {integrity: sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/remark-parse/-/remark-parse-6.0.3.tgz}
-    name: remark-parse
-    version: 6.0.3
-    dependencies:
-      collapse-white-space: registry.npmmirror.com/collapse-white-space@1.0.6
-      is-alphabetical: registry.npmmirror.com/is-alphabetical@1.0.4
-      is-decimal: registry.npmmirror.com/is-decimal@1.0.4
-      is-whitespace-character: registry.npmmirror.com/is-whitespace-character@1.0.4
-      is-word-character: registry.npmmirror.com/is-word-character@1.0.4
-      markdown-escapes: registry.npmmirror.com/markdown-escapes@1.0.4
-      parse-entities: registry.npmmirror.com/parse-entities@1.2.2
-      repeat-string: registry.npmmirror.com/repeat-string@1.6.1
-      state-toggle: registry.npmmirror.com/state-toggle@1.0.3
-      trim: registry.npmmirror.com/trim@0.0.1
-      trim-trailing-lines: registry.npmmirror.com/trim-trailing-lines@1.1.4
-      unherit: registry.npmmirror.com/unherit@1.1.3
-      unist-util-remove-position: registry.npmmirror.com/unist-util-remove-position@1.1.4
-      vfile-location: registry.npmmirror.com/vfile-location@2.0.6
-      xtend: registry.npmmirror.com/xtend@4.0.2
-    dev: false
-
-  registry.npmmirror.com/remark-parse@9.0.0:
-    resolution: {integrity: sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/remark-parse/-/remark-parse-9.0.0.tgz}
-    name: remark-parse
-    version: 9.0.0
-    dependencies:
-      mdast-util-from-markdown: registry.npmmirror.com/mdast-util-from-markdown@0.8.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/remark-stringify@6.0.4:
-    resolution: {integrity: sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/remark-stringify/-/remark-stringify-6.0.4.tgz}
-    name: remark-stringify
-    version: 6.0.4
-    dependencies:
-      ccount: registry.npmmirror.com/ccount@1.1.0
-      is-alphanumeric: registry.npmmirror.com/is-alphanumeric@1.0.0
-      is-decimal: registry.npmmirror.com/is-decimal@1.0.4
-      is-whitespace-character: registry.npmmirror.com/is-whitespace-character@1.0.4
-      longest-streak: registry.npmmirror.com/longest-streak@2.0.4
-      markdown-escapes: registry.npmmirror.com/markdown-escapes@1.0.4
-      markdown-table: registry.npmmirror.com/markdown-table@1.1.3
-      mdast-util-compact: registry.npmmirror.com/mdast-util-compact@1.0.4
-      parse-entities: registry.npmmirror.com/parse-entities@1.2.2
-      repeat-string: registry.npmmirror.com/repeat-string@1.6.1
-      state-toggle: registry.npmmirror.com/state-toggle@1.0.3
-      stringify-entities: registry.npmmirror.com/stringify-entities@1.3.2
-      unherit: registry.npmmirror.com/unherit@1.1.3
-      xtend: registry.npmmirror.com/xtend@4.0.2
-    dev: false
-
-  registry.npmmirror.com/remark-stringify@9.0.1:
-    resolution: {integrity: sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/remark-stringify/-/remark-stringify-9.0.1.tgz}
-    name: remark-stringify
-    version: 9.0.1
-    dependencies:
-      mdast-util-to-markdown: registry.npmmirror.com/mdast-util-to-markdown@0.6.5
-    dev: false
-
-  registry.npmmirror.com/remark@10.0.1:
-    resolution: {integrity: sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/remark/-/remark-10.0.1.tgz}
-    name: remark
-    version: 10.0.1
-    dependencies:
-      remark-parse: registry.npmmirror.com/remark-parse@6.0.3
-      remark-stringify: registry.npmmirror.com/remark-stringify@6.0.4
-      unified: registry.npmmirror.com/unified@7.1.0
-    dev: false
-
-  registry.npmmirror.com/remark@13.0.0:
-    resolution: {integrity: sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/remark/-/remark-13.0.0.tgz}
-    name: remark
-    version: 13.0.0
-    dependencies:
-      remark-parse: registry.npmmirror.com/remark-parse@9.0.0
-      remark-stringify: registry.npmmirror.com/remark-stringify@9.0.1
-      unified: registry.npmmirror.com/unified@9.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/repeat-element@1.1.4:
-    resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/repeat-element/-/repeat-element-1.1.4.tgz}
-    name: repeat-element
-    version: 1.1.4
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/repeat-string@1.6.1:
-    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/repeat-string/-/repeat-string-1.6.1.tgz}
-    name: repeat-string
-    version: 1.6.1
-    engines: {node: '>=0.10'}
-    dev: false
-
-  registry.npmmirror.com/replace-ext@1.0.0:
-    resolution: {integrity: sha512-vuNYXC7gG7IeVNBC1xUllqCcZKRbJoSPOBhnTEcAIiKCsbuef6zO3F0Rve3isPMMoNoQRWjQwbAgAjHUHniyEA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/replace-ext/-/replace-ext-1.0.0.tgz}
-    name: replace-ext
-    version: 1.0.0
-    engines: {node: '>= 0.10'}
-    dev: false
-
   registry.npmmirror.com/require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz}
     name: require-directory
     version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz}
-    name: require-from-string
-    version: 2.0.2
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -8650,54 +3246,8 @@ packages:
     version: 3.0.0
     engines: {node: '>=8'}
     dependencies:
-      resolve-from: registry.npmmirror.com/resolve-from@5.0.0
-
-  registry.npmmirror.com/resolve-from@3.0.0:
-    resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-from/-/resolve-from-3.0.0.tgz}
-    name: resolve-from
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz}
-    name: resolve-from
-    version: 4.0.0
-    engines: {node: '>=4'}
-
-  registry.npmmirror.com/resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-from/-/resolve-from-5.0.0.tgz}
-    name: resolve-from
-    version: 5.0.0
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/resolve-url@0.2.1:
-    resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve-url/-/resolve-url-0.2.1.tgz}
-    name: resolve-url
-    version: 0.2.1
-    deprecated: https://github.com/lydell/resolve-url#deprecated
-    dev: false
-
-  registry.npmmirror.com/resolve@1.22.2:
-    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve/-/resolve-1.22.2.tgz}
-    name: resolve
-    version: 1.22.2
-    hasBin: true
-    dependencies:
-      is-core-module: registry.npmmirror.com/is-core-module@2.12.1
-      path-parse: registry.npmmirror.com/path-parse@1.0.7
-      supports-preserve-symlinks-flag: registry.npmmirror.com/supports-preserve-symlinks-flag@1.0.0
-
-  registry.npmmirror.com/resolve@2.0.0-next.4:
-    resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/resolve/-/resolve-2.0.0-next.4.tgz}
-    name: resolve
-    version: 2.0.0-next.4
-    hasBin: true
-    dependencies:
-      is-core-module: registry.npmmirror.com/is-core-module@2.12.1
-      path-parse: registry.npmmirror.com/path-parse@1.0.7
-      supports-preserve-symlinks-flag: registry.npmmirror.com/supports-preserve-symlinks-flag@1.0.0
-    dev: false
+      resolve-from: 5.0.0
+    dev: true
 
   registry.npmmirror.com/responselike@1.0.2:
     resolution: {integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/responselike/-/responselike-1.0.2.tgz}
@@ -8721,8 +3271,8 @@ packages:
     version: 2.0.0
     engines: {node: '>=4'}
     dependencies:
-      onetime: registry.npmmirror.com/onetime@2.0.1
-      signal-exit: registry.npmmirror.com/signal-exit@3.0.7
+      onetime: 2.0.1
+      signal-exit: 3.0.7
     dev: true
 
   registry.npmmirror.com/restore-cursor@3.1.0:
@@ -8731,31 +3281,9 @@ packages:
     version: 3.1.0
     engines: {node: '>=8'}
     dependencies:
-      onetime: registry.npmmirror.com/onetime@5.1.2
-      signal-exit: registry.npmmirror.com/signal-exit@3.0.7
+      onetime: 5.1.2
+      signal-exit: 3.0.7
     dev: true
-
-  registry.npmmirror.com/ret@0.1.15:
-    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/ret/-/ret-0.1.15.tgz}
-    name: ret
-    version: 0.1.15
-    engines: {node: '>=0.12'}
-    dev: false
-
-  registry.npmmirror.com/reusify@1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/reusify/-/reusify-1.0.4.tgz}
-    name: reusify
-    version: 1.0.4
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  registry.npmmirror.com/rimraf@2.6.3:
-    resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rimraf/-/rimraf-2.6.3.tgz}
-    name: rimraf
-    version: 2.6.3
-    hasBin: true
-    dependencies:
-      glob: registry.npmmirror.com/glob@7.1.6
-    dev: false
 
   registry.npmmirror.com/rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz}
@@ -8764,6 +3292,7 @@ packages:
     hasBin: true
     dependencies:
       glob: registry.npmmirror.com/glob@7.1.6
+    dev: false
 
   registry.npmmirror.com/run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/run-async/-/run-async-2.4.1.tgz}
@@ -8771,13 +3300,6 @@ packages:
     version: 2.4.1
     engines: {node: '>=0.12.0'}
     dev: true
-
-  registry.npmmirror.com/run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz}
-    name: run-parallel
-    version: 1.2.0
-    dependencies:
-      queue-microtask: registry.npmmirror.com/queue-microtask@1.2.3
 
   registry.npmmirror.com/rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz}
@@ -8787,38 +3309,6 @@ packages:
     dependencies:
       tslib: registry.npmmirror.com/tslib@1.14.1
     dev: true
-
-  registry.npmmirror.com/safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz}
-    name: safe-buffer
-    version: 5.2.1
-    dev: false
-
-  registry.npmmirror.com/safe-regex-test@1.0.0:
-    resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz}
-    name: safe-regex-test
-    version: 1.0.0
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-      is-regex: registry.npmmirror.com/is-regex@1.1.4
-    dev: false
-
-  registry.npmmirror.com/safe-regex@1.1.0:
-    resolution: {integrity: sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/safe-regex/-/safe-regex-1.1.0.tgz}
-    name: safe-regex
-    version: 1.1.0
-    dependencies:
-      ret: registry.npmmirror.com/ret@0.1.15
-    dev: false
-
-  registry.npmmirror.com/safe-regex@2.1.1:
-    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/safe-regex/-/safe-regex-2.1.1.tgz}
-    name: safe-regex
-    version: 2.1.1
-    dependencies:
-      regexp-tree: registry.npmmirror.com/regexp-tree@0.1.27
-    dev: false
 
   registry.npmmirror.com/safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz}
@@ -8839,30 +3329,8 @@ packages:
     version: 3.1.1
     engines: {node: '>=8'}
     dependencies:
-      semver: registry.npmmirror.com/semver@6.3.0
+      semver: 6.3.0
     dev: true
-
-  registry.npmmirror.com/semver@5.7.1:
-    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/semver/-/semver-5.7.1.tgz}
-    name: semver
-    version: 5.7.1
-    hasBin: true
-
-  registry.npmmirror.com/semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/semver/-/semver-6.3.0.tgz}
-    name: semver
-    version: 6.3.0
-    hasBin: true
-
-  registry.npmmirror.com/semver@7.3.5:
-    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/semver/-/semver-7.3.5.tgz}
-    name: semver
-    version: 7.3.5
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: registry.npmmirror.com/lru-cache@6.0.0
-    dev: false
 
   registry.npmmirror.com/semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/semver/-/semver-7.5.4.tgz}
@@ -8871,33 +3339,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      lru-cache: registry.npmmirror.com/lru-cache@6.0.0
-
-  registry.npmmirror.com/set-value@2.0.1:
-    resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/set-value/-/set-value-2.0.1.tgz}
-    name: set-value
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: registry.npmmirror.com/extend-shallow@2.0.1
-      is-extendable: registry.npmmirror.com/is-extendable@0.1.1
-      is-plain-object: registry.npmmirror.com/is-plain-object@2.0.4
-      split-string: registry.npmmirror.com/split-string@3.1.0
-    dev: false
-
-  registry.npmmirror.com/shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz}
-    name: shebang-command
-    version: 2.0.0
-    engines: {node: '>=8'}
-    dependencies:
-      shebang-regex: registry.npmmirror.com/shebang-regex@3.0.0
-
-  registry.npmmirror.com/shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz}
-    name: shebang-regex
-    version: 3.0.0
-    engines: {node: '>=8'}
+      lru-cache: 6.0.0
+    dev: true
 
   registry.npmmirror.com/should-equal@2.0.0:
     resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/should-equal/-/should-equal-2.0.0.tgz}
@@ -8949,199 +3392,6 @@ packages:
       should-util: registry.npmmirror.com/should-util@1.0.1
     dev: false
 
-  registry.npmmirror.com/side-channel@1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/side-channel/-/side-channel-1.0.4.tgz}
-    name: side-channel
-    version: 1.0.4
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-      object-inspect: registry.npmmirror.com/object-inspect@1.12.3
-    dev: false
-
-  registry.npmmirror.com/signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/signal-exit/-/signal-exit-3.0.7.tgz}
-    name: signal-exit
-    version: 3.0.7
-
-  registry.npmmirror.com/slash@2.0.0:
-    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/slash/-/slash-2.0.0.tgz}
-    name: slash
-    version: 2.0.0
-    engines: {node: '>=6'}
-    dev: false
-
-  registry.npmmirror.com/slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/slash/-/slash-3.0.0.tgz}
-    name: slash
-    version: 3.0.0
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/slice-ansi@0.0.4:
-    resolution: {integrity: sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/slice-ansi/-/slice-ansi-0.0.4.tgz}
-    name: slice-ansi
-    version: 0.0.4
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmmirror.com/slice-ansi@2.1.0:
-    resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/slice-ansi/-/slice-ansi-2.1.0.tgz}
-    name: slice-ansi
-    version: 2.1.0
-    engines: {node: '>=6'}
-    dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@3.2.1
-      astral-regex: registry.npmmirror.com/astral-regex@1.0.0
-      is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@2.0.0
-    dev: false
-
-  registry.npmmirror.com/slice-ansi@4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/slice-ansi/-/slice-ansi-4.0.0.tgz}
-    name: slice-ansi
-    version: 4.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: registry.npmmirror.com/ansi-styles@4.3.0
-      astral-regex: registry.npmmirror.com/astral-regex@2.0.0
-      is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@3.0.0
-    dev: false
-
-  registry.npmmirror.com/snapdragon-node@2.1.1:
-    resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz}
-    name: snapdragon-node
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      define-property: registry.npmmirror.com/define-property@1.0.0
-      isobject: registry.npmmirror.com/isobject@3.0.1
-      snapdragon-util: registry.npmmirror.com/snapdragon-util@3.0.1
-    dev: false
-
-  registry.npmmirror.com/snapdragon-util@3.0.1:
-    resolution: {integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz}
-    name: snapdragon-util
-    version: 3.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmmirror.com/kind-of@3.2.2
-    dev: false
-
-  registry.npmmirror.com/snapdragon@0.8.2:
-    resolution: {integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/snapdragon/-/snapdragon-0.8.2.tgz}
-    name: snapdragon
-    version: 0.8.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      base: registry.npmmirror.com/base@0.11.2
-      debug: registry.npmmirror.com/debug@2.6.9
-      define-property: registry.npmmirror.com/define-property@0.2.5
-      extend-shallow: registry.npmmirror.com/extend-shallow@2.0.1
-      map-cache: registry.npmmirror.com/map-cache@0.2.2
-      source-map: registry.npmmirror.com/source-map@0.5.7
-      source-map-resolve: registry.npmmirror.com/source-map-resolve@0.5.3
-      use: registry.npmmirror.com/use@3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/source-map-js/-/source-map-js-1.0.2.tgz}
-    name: source-map-js
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/source-map-resolve@0.5.3:
-    resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz}
-    name: source-map-resolve
-    version: 0.5.3
-    deprecated: See https://github.com/lydell/source-map-resolve#deprecated
-    dependencies:
-      atob: registry.npmmirror.com/atob@2.1.2
-      decode-uri-component: registry.npmmirror.com/decode-uri-component@0.2.2
-      resolve-url: registry.npmmirror.com/resolve-url@0.2.1
-      source-map-url: registry.npmmirror.com/source-map-url@0.4.1
-      urix: registry.npmmirror.com/urix@0.1.0
-    dev: false
-
-  registry.npmmirror.com/source-map-url@0.4.1:
-    resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/source-map-url/-/source-map-url-0.4.1.tgz}
-    name: source-map-url
-    version: 0.4.1
-    deprecated: See https://github.com/lydell/source-map-url#deprecated
-    dev: false
-
-  registry.npmmirror.com/source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/source-map/-/source-map-0.5.7.tgz}
-    name: source-map
-    version: 0.5.7
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz}
-    name: source-map
-    version: 0.6.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/source-map@0.7.4:
-    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/source-map/-/source-map-0.7.4.tgz}
-    name: source-map
-    version: 0.7.4
-    engines: {node: '>= 8'}
-    dev: false
-
-  registry.npmmirror.com/spdx-correct@3.2.0:
-    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/spdx-correct/-/spdx-correct-3.2.0.tgz}
-    name: spdx-correct
-    version: 3.2.0
-    dependencies:
-      spdx-expression-parse: registry.npmmirror.com/spdx-expression-parse@3.0.1
-      spdx-license-ids: registry.npmmirror.com/spdx-license-ids@3.0.13
-
-  registry.npmmirror.com/spdx-exceptions@2.3.0:
-    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz}
-    name: spdx-exceptions
-    version: 2.3.0
-
-  registry.npmmirror.com/spdx-expression-parse@3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz}
-    name: spdx-expression-parse
-    version: 3.0.1
-    dependencies:
-      spdx-exceptions: registry.npmmirror.com/spdx-exceptions@2.3.0
-      spdx-license-ids: registry.npmmirror.com/spdx-license-ids@3.0.13
-
-  registry.npmmirror.com/spdx-license-ids@3.0.13:
-    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz}
-    name: spdx-license-ids
-    version: 3.0.13
-
-  registry.npmmirror.com/specificity@0.4.1:
-    resolution: {integrity: sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/specificity/-/specificity-0.4.1.tgz}
-    name: specificity
-    version: 0.4.1
-    hasBin: true
-    dev: false
-
-  registry.npmmirror.com/split-string@3.1.0:
-    resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/split-string/-/split-string-3.1.0.tgz}
-    name: split-string
-    version: 3.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: registry.npmmirror.com/extend-shallow@3.0.2
-    dev: false
-
-  registry.npmmirror.com/split2@0.2.1:
-    resolution: {integrity: sha512-D/oTExYAkC9nWleOCTOyNmAuzfAT/6rHGBA9LIK7FVnGo13CSvrKCUzKenwH6U1s2znY9MqH6v0UQTEDa3vJmg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/split2/-/split2-0.2.1.tgz}
-    name: split2
-    version: 0.2.1
-    dependencies:
-      through2: registry.npmmirror.com/through2@0.6.5
-    dev: false
-
   registry.npmmirror.com/split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/split/-/split-1.0.1.tgz}
     name: split
@@ -9149,60 +3399,6 @@ packages:
     dependencies:
       through: registry.npmmirror.com/through@2.3.8
     dev: true
-
-  registry.npmmirror.com/sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/sprintf-js/-/sprintf-js-1.0.3.tgz}
-    name: sprintf-js
-    version: 1.0.3
-    dev: false
-
-  registry.npmmirror.com/state-toggle@1.0.3:
-    resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/state-toggle/-/state-toggle-1.0.3.tgz}
-    name: state-toggle
-    version: 1.0.3
-    dev: false
-
-  registry.npmmirror.com/static-extend@0.1.2:
-    resolution: {integrity: sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/static-extend/-/static-extend-0.1.2.tgz}
-    name: static-extend
-    version: 0.1.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      define-property: registry.npmmirror.com/define-property@0.2.5
-      object-copy: registry.npmmirror.com/object-copy@0.1.0
-    dev: false
-
-  registry.npmmirror.com/string-width@1.0.2:
-    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string-width/-/string-width-1.0.2.tgz}
-    name: string-width
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      code-point-at: registry.npmmirror.com/code-point-at@1.1.0
-      is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@1.0.0
-      strip-ansi: registry.npmmirror.com/strip-ansi@3.0.1
-    dev: true
-
-  registry.npmmirror.com/string-width@2.1.1:
-    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string-width/-/string-width-2.1.1.tgz}
-    name: string-width
-    version: 2.1.1
-    engines: {node: '>=4'}
-    dependencies:
-      is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@2.0.0
-      strip-ansi: registry.npmmirror.com/strip-ansi@4.0.0
-    dev: true
-
-  registry.npmmirror.com/string-width@3.1.0:
-    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string-width/-/string-width-3.1.0.tgz}
-    name: string-width
-    version: 3.1.0
-    engines: {node: '>=6'}
-    dependencies:
-      emoji-regex: registry.npmmirror.com/emoji-regex@7.0.3
-      is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@2.0.0
-      strip-ansi: registry.npmmirror.com/strip-ansi@5.2.0
-    dev: false
 
   registry.npmmirror.com/string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz}
@@ -9214,103 +3410,6 @@ packages:
       is-fullwidth-code-point: registry.npmmirror.com/is-fullwidth-code-point@3.0.0
       strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
 
-  registry.npmmirror.com/string.prototype.matchall@4.0.8:
-    resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz}
-    name: string.prototype.matchall
-    version: 4.0.8
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-      get-intrinsic: registry.npmmirror.com/get-intrinsic@1.2.1
-      has-symbols: registry.npmmirror.com/has-symbols@1.0.3
-      internal-slot: registry.npmmirror.com/internal-slot@1.0.5
-      regexp.prototype.flags: registry.npmmirror.com/regexp.prototype.flags@1.5.0
-      side-channel: registry.npmmirror.com/side-channel@1.0.4
-    dev: false
-
-  registry.npmmirror.com/string.prototype.trim@1.2.7:
-    resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz}
-    name: string.prototype.trim
-    version: 1.2.7
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-    dev: false
-
-  registry.npmmirror.com/string.prototype.trimend@1.0.6:
-    resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz}
-    name: string.prototype.trimend
-    version: 1.0.6
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-    dev: false
-
-  registry.npmmirror.com/string.prototype.trimstart@1.0.6:
-    resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz}
-    name: string.prototype.trimstart
-    version: 1.0.6
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      define-properties: registry.npmmirror.com/define-properties@1.2.0
-      es-abstract: registry.npmmirror.com/es-abstract@1.21.2
-    dev: false
-
-  registry.npmmirror.com/string_decoder@0.10.31:
-    resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string_decoder/-/string_decoder-0.10.31.tgz}
-    name: string_decoder
-    version: 0.10.31
-    dev: false
-
-  registry.npmmirror.com/string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/string_decoder/-/string_decoder-1.3.0.tgz}
-    name: string_decoder
-    version: 1.3.0
-    dependencies:
-      safe-buffer: registry.npmmirror.com/safe-buffer@5.2.1
-    dev: false
-
-  registry.npmmirror.com/stringify-entities@1.3.2:
-    resolution: {integrity: sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stringify-entities/-/stringify-entities-1.3.2.tgz}
-    name: stringify-entities
-    version: 1.3.2
-    dependencies:
-      character-entities-html4: registry.npmmirror.com/character-entities-html4@1.1.4
-      character-entities-legacy: registry.npmmirror.com/character-entities-legacy@1.1.4
-      is-alphanumerical: registry.npmmirror.com/is-alphanumerical@1.0.4
-      is-hexadecimal: registry.npmmirror.com/is-hexadecimal@1.0.4
-    dev: false
-
-  registry.npmmirror.com/strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-3.0.1.tgz}
-    name: strip-ansi
-    version: 3.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: registry.npmmirror.com/ansi-regex@2.1.1
-    dev: true
-
-  registry.npmmirror.com/strip-ansi@4.0.0:
-    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-4.0.0.tgz}
-    name: strip-ansi
-    version: 4.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-regex: registry.npmmirror.com/ansi-regex@3.0.1
-    dev: true
-
-  registry.npmmirror.com/strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-5.2.0.tgz}
-    name: strip-ansi
-    version: 5.2.0
-    engines: {node: '>=6'}
-    dependencies:
-      ansi-regex: registry.npmmirror.com/ansi-regex@4.1.1
-
   registry.npmmirror.com/strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz}
     name: strip-ansi
@@ -9319,311 +3418,6 @@ packages:
     dependencies:
       ansi-regex: registry.npmmirror.com/ansi-regex@5.0.1
 
-  registry.npmmirror.com/strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-bom/-/strip-bom-3.0.0.tgz}
-    name: strip-bom
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz}
-    name: strip-final-newline
-    version: 2.0.0
-    engines: {node: '>=6'}
-    dev: true
-
-  registry.npmmirror.com/strip-indent@2.0.0:
-    resolution: {integrity: sha512-RsSNPLpq6YUL7QYy44RnPVTn/lcVZtb48Uof3X5JLbF4zD/Gs7ZFDv2HWol+leoQN2mT86LAzSshGfkTlSOpsA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-indent/-/strip-indent-2.0.0.tgz}
-    name: strip-indent
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/strip-indent@3.0.0:
-    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-indent/-/strip-indent-3.0.0.tgz}
-    name: strip-indent
-    version: 3.0.0
-    engines: {node: '>=8'}
-    dependencies:
-      min-indent: registry.npmmirror.com/min-indent@1.0.1
-
-  registry.npmmirror.com/strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz}
-    name: strip-json-comments
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmmirror.com/strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz}
-    name: strip-json-comments
-    version: 3.1.1
-    engines: {node: '>=8'}
-    dev: false
-
-  registry.npmmirror.com/style-search@0.1.0:
-    resolution: {integrity: sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/style-search/-/style-search-0.1.0.tgz}
-    name: style-search
-    version: 0.1.0
-    dev: false
-
-  registry.npmmirror.com/stylelint-config-css-modules@2.3.0(stylelint@13.13.1):
-    resolution: {integrity: sha512-nSxwaJMv9wBrTAi+O4qXubyi1AR9eB36tJpY0uaFhKgEc3fwWGUzUK1Edl8AQHAoU7wmUeKtsuYjblyRP/V7rw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-config-css-modules/-/stylelint-config-css-modules-2.3.0.tgz}
-    id: registry.npmmirror.com/stylelint-config-css-modules/2.3.0
-    name: stylelint-config-css-modules
-    version: 2.3.0
-    peerDependencies:
-      stylelint: 11.x - 14.x
-    dependencies:
-      stylelint: registry.npmmirror.com/stylelint@13.13.1
-    dev: false
-
-  registry.npmmirror.com/stylelint-config-prettier@8.0.2(stylelint@13.13.1):
-    resolution: {integrity: sha512-TN1l93iVTXpF9NJstlvP7nOu9zY2k+mN0NSFQ/VEGz15ZIP9ohdDZTtCWHs5LjctAhSAzaILULGbgiM0ItId3A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-config-prettier/-/stylelint-config-prettier-8.0.2.tgz}
-    id: registry.npmmirror.com/stylelint-config-prettier/8.0.2
-    name: stylelint-config-prettier
-    version: 8.0.2
-    engines: {node: '>= 10', npm: '>= 5'}
-    hasBin: true
-    peerDependencies:
-      stylelint: '>=11.0.0'
-    dependencies:
-      stylelint: registry.npmmirror.com/stylelint@13.13.1
-    dev: false
-
-  registry.npmmirror.com/stylelint-config-rational-order@0.1.2:
-    resolution: {integrity: sha512-Qo7ZQaihCwTqijfZg4sbdQQHtugOX/B1/fYh018EiDZHW+lkqH9uHOnsDwDPGZrYJuB6CoyI7MZh2ecw2dOkew==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-config-rational-order/-/stylelint-config-rational-order-0.1.2.tgz}
-    name: stylelint-config-rational-order
-    version: 0.1.2
-    dependencies:
-      stylelint: registry.npmmirror.com/stylelint@9.10.1
-      stylelint-order: registry.npmmirror.com/stylelint-order@2.2.1(stylelint@9.10.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/stylelint-config-recommended@3.0.0(stylelint@13.13.1):
-    resolution: {integrity: sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz}
-    id: registry.npmmirror.com/stylelint-config-recommended/3.0.0
-    name: stylelint-config-recommended
-    version: 3.0.0
-    peerDependencies:
-      stylelint: '>=10.1.0'
-    dependencies:
-      stylelint: registry.npmmirror.com/stylelint@13.13.1
-    dev: false
-
-  registry.npmmirror.com/stylelint-config-standard@20.0.0(stylelint@13.13.1):
-    resolution: {integrity: sha512-IB2iFdzOTA/zS4jSVav6z+wGtin08qfj+YyExHB3LF9lnouQht//YyB0KZq9gGz5HNPkddHOzcY8HsUey6ZUlA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-config-standard/-/stylelint-config-standard-20.0.0.tgz}
-    id: registry.npmmirror.com/stylelint-config-standard/20.0.0
-    name: stylelint-config-standard
-    version: 20.0.0
-    peerDependencies:
-      stylelint: '>=10.1.0'
-    dependencies:
-      stylelint: registry.npmmirror.com/stylelint@13.13.1
-      stylelint-config-recommended: registry.npmmirror.com/stylelint-config-recommended@3.0.0(stylelint@13.13.1)
-    dev: false
-
-  registry.npmmirror.com/stylelint-declaration-block-no-ignored-properties@2.7.0(stylelint@13.13.1):
-    resolution: {integrity: sha512-44SpI9+9Oc1ICuwwRfwS/3npQ2jPobDSTnwWdNgZGryGqQCp17CgEIWjCv1BgUOSzND3RqywNCNLKvO1AOxbfg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-declaration-block-no-ignored-properties/-/stylelint-declaration-block-no-ignored-properties-2.7.0.tgz}
-    id: registry.npmmirror.com/stylelint-declaration-block-no-ignored-properties/2.7.0
-    name: stylelint-declaration-block-no-ignored-properties
-    version: 2.7.0
-    engines: {node: '>=6'}
-    peerDependencies:
-      stylelint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
-    dependencies:
-      stylelint: registry.npmmirror.com/stylelint@13.13.1
-    dev: false
-
-  registry.npmmirror.com/stylelint-no-unsupported-browser-features@4.1.4(stylelint@13.13.1):
-    resolution: {integrity: sha512-GORR+/z4KkWP9SWO4fLmC5WAIjDClShSfwCYTuAB9cT8GE+rtOXeAqw5RyXuN9BLIBAPjeO2W7LFIrWUH8x7FA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-4.1.4.tgz}
-    id: registry.npmmirror.com/stylelint-no-unsupported-browser-features/4.1.4
-    name: stylelint-no-unsupported-browser-features
-    version: 4.1.4
-    engines: {node: '>=10'}
-    peerDependencies:
-      stylelint: '>=11.1.1'
-    dependencies:
-      doiuse: registry.npmmirror.com/doiuse@4.4.1
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      postcss: registry.npmmirror.com/postcss@8.4.25
-      stylelint: registry.npmmirror.com/stylelint@13.13.1
-    dev: false
-
-  registry.npmmirror.com/stylelint-order@2.2.1(stylelint@9.10.1):
-    resolution: {integrity: sha512-019KBV9j8qp1MfBjJuotse6MgaZqGVtXMc91GU9MsS9Feb+jYUvUU3Z8XiClqPdqJZQ0ryXQJGg3U3PcEjXwfg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-order/-/stylelint-order-2.2.1.tgz}
-    id: registry.npmmirror.com/stylelint-order/2.2.1
-    name: stylelint-order
-    version: 2.2.1
-    engines: {node: '>=6'}
-    peerDependencies:
-      stylelint: ^9.10.1 || ^10.0.0
-    dependencies:
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-sorting: registry.npmmirror.com/postcss-sorting@4.1.0
-      stylelint: registry.npmmirror.com/stylelint@9.10.1
-    dev: false
-
-  registry.npmmirror.com/stylelint-order@4.1.0(stylelint@13.13.1):
-    resolution: {integrity: sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint-order/-/stylelint-order-4.1.0.tgz}
-    id: registry.npmmirror.com/stylelint-order/4.1.0
-    name: stylelint-order
-    version: 4.1.0
-    peerDependencies:
-      stylelint: ^10.0.1 || ^11.0.0 || ^12.0.0 || ^13.0.0
-    dependencies:
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-sorting: registry.npmmirror.com/postcss-sorting@5.0.1
-      stylelint: registry.npmmirror.com/stylelint@13.13.1
-    dev: false
-
-  registry.npmmirror.com/stylelint@13.13.1:
-    resolution: {integrity: sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint/-/stylelint-13.13.1.tgz}
-    name: stylelint
-    version: 13.13.1
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dependencies:
-      '@stylelint/postcss-css-in-js': registry.npmmirror.com/@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)
-      '@stylelint/postcss-markdown': registry.npmmirror.com/@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)
-      autoprefixer: registry.npmmirror.com/autoprefixer@9.8.8
-      balanced-match: registry.npmmirror.com/balanced-match@2.0.0
-      chalk: registry.npmmirror.com/chalk@4.1.2
-      cosmiconfig: registry.npmmirror.com/cosmiconfig@7.1.0
-      debug: registry.npmmirror.com/debug@4.3.4
-      execall: registry.npmmirror.com/execall@2.0.0
-      fast-glob: registry.npmmirror.com/fast-glob@3.3.0
-      fastest-levenshtein: registry.npmmirror.com/fastest-levenshtein@1.0.16
-      file-entry-cache: registry.npmmirror.com/file-entry-cache@6.0.1
-      get-stdin: registry.npmmirror.com/get-stdin@8.0.0
-      global-modules: registry.npmmirror.com/global-modules@2.0.0
-      globby: registry.npmmirror.com/globby@11.1.0
-      globjoin: registry.npmmirror.com/globjoin@0.1.4
-      html-tags: registry.npmmirror.com/html-tags@3.3.1
-      ignore: registry.npmmirror.com/ignore@5.2.4
-      import-lazy: registry.npmmirror.com/import-lazy@4.0.0
-      imurmurhash: registry.npmmirror.com/imurmurhash@0.1.4
-      known-css-properties: registry.npmmirror.com/known-css-properties@0.21.0
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      log-symbols: registry.npmmirror.com/log-symbols@4.1.0
-      mathml-tag-names: registry.npmmirror.com/mathml-tag-names@2.1.3
-      meow: registry.npmmirror.com/meow@9.0.0
-      micromatch: registry.npmmirror.com/micromatch@4.0.5
-      normalize-selector: registry.npmmirror.com/normalize-selector@0.2.0
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-html: registry.npmmirror.com/postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
-      postcss-less: registry.npmmirror.com/postcss-less@3.1.4
-      postcss-media-query-parser: registry.npmmirror.com/postcss-media-query-parser@0.2.3
-      postcss-resolve-nested-selector: registry.npmmirror.com/postcss-resolve-nested-selector@0.1.1
-      postcss-safe-parser: registry.npmmirror.com/postcss-safe-parser@4.0.2
-      postcss-sass: registry.npmmirror.com/postcss-sass@0.4.4
-      postcss-scss: registry.npmmirror.com/postcss-scss@2.1.1
-      postcss-selector-parser: registry.npmmirror.com/postcss-selector-parser@6.0.13
-      postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
-      postcss-value-parser: registry.npmmirror.com/postcss-value-parser@4.2.0
-      resolve-from: registry.npmmirror.com/resolve-from@5.0.0
-      slash: registry.npmmirror.com/slash@3.0.0
-      specificity: registry.npmmirror.com/specificity@0.4.1
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
-      style-search: registry.npmmirror.com/style-search@0.1.0
-      sugarss: registry.npmmirror.com/sugarss@2.0.0
-      svg-tags: registry.npmmirror.com/svg-tags@1.0.0
-      table: registry.npmmirror.com/table@6.8.1
-      v8-compile-cache: registry.npmmirror.com/v8-compile-cache@2.3.0
-      write-file-atomic: registry.npmmirror.com/write-file-atomic@3.0.3
-    transitivePeerDependencies:
-      - postcss-jsx
-      - postcss-markdown
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/stylelint@9.10.1:
-    resolution: {integrity: sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/stylelint/-/stylelint-9.10.1.tgz}
-    name: stylelint
-    version: 9.10.1
-    engines: {node: '>=6'}
-    hasBin: true
-    dependencies:
-      autoprefixer: registry.npmmirror.com/autoprefixer@9.8.8
-      balanced-match: registry.npmmirror.com/balanced-match@1.0.2
-      chalk: registry.npmmirror.com/chalk@2.4.2
-      cosmiconfig: registry.npmmirror.com/cosmiconfig@5.2.1
-      debug: registry.npmmirror.com/debug@4.3.4
-      execall: registry.npmmirror.com/execall@1.0.0
-      file-entry-cache: registry.npmmirror.com/file-entry-cache@4.0.0
-      get-stdin: registry.npmmirror.com/get-stdin@6.0.0
-      global-modules: registry.npmmirror.com/global-modules@2.0.0
-      globby: registry.npmmirror.com/globby@9.2.0
-      globjoin: registry.npmmirror.com/globjoin@0.1.4
-      html-tags: registry.npmmirror.com/html-tags@2.0.0
-      ignore: registry.npmmirror.com/ignore@5.2.4
-      import-lazy: registry.npmmirror.com/import-lazy@3.1.0
-      imurmurhash: registry.npmmirror.com/imurmurhash@0.1.4
-      known-css-properties: registry.npmmirror.com/known-css-properties@0.11.0
-      leven: registry.npmmirror.com/leven@2.1.0
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      log-symbols: registry.npmmirror.com/log-symbols@2.2.0
-      mathml-tag-names: registry.npmmirror.com/mathml-tag-names@2.1.3
-      meow: registry.npmmirror.com/meow@5.0.0
-      micromatch: registry.npmmirror.com/micromatch@3.1.10
-      normalize-selector: registry.npmmirror.com/normalize-selector@0.2.0
-      pify: registry.npmmirror.com/pify@4.0.1
-      postcss: registry.npmmirror.com/postcss@7.0.39
-      postcss-html: registry.npmmirror.com/postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
-      postcss-jsx: registry.npmmirror.com/postcss-jsx@0.36.4(postcss-syntax@0.36.2)(postcss@7.0.39)
-      postcss-less: registry.npmmirror.com/postcss-less@3.1.4
-      postcss-markdown: registry.npmmirror.com/postcss-markdown@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
-      postcss-media-query-parser: registry.npmmirror.com/postcss-media-query-parser@0.2.3
-      postcss-reporter: registry.npmmirror.com/postcss-reporter@6.0.1
-      postcss-resolve-nested-selector: registry.npmmirror.com/postcss-resolve-nested-selector@0.1.1
-      postcss-safe-parser: registry.npmmirror.com/postcss-safe-parser@4.0.2
-      postcss-sass: registry.npmmirror.com/postcss-sass@0.3.5
-      postcss-scss: registry.npmmirror.com/postcss-scss@2.1.1
-      postcss-selector-parser: registry.npmmirror.com/postcss-selector-parser@3.1.2
-      postcss-syntax: registry.npmmirror.com/postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
-      postcss-value-parser: registry.npmmirror.com/postcss-value-parser@3.3.1
-      resolve-from: registry.npmmirror.com/resolve-from@4.0.0
-      signal-exit: registry.npmmirror.com/signal-exit@3.0.7
-      slash: registry.npmmirror.com/slash@2.0.0
-      specificity: registry.npmmirror.com/specificity@0.4.1
-      string-width: registry.npmmirror.com/string-width@3.1.0
-      style-search: registry.npmmirror.com/style-search@0.1.0
-      sugarss: registry.npmmirror.com/sugarss@2.0.0
-      svg-tags: registry.npmmirror.com/svg-tags@1.0.0
-      table: registry.npmmirror.com/table@5.4.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmmirror.com/sugarss@2.0.0:
-    resolution: {integrity: sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/sugarss/-/sugarss-2.0.0.tgz}
-    name: sugarss
-    version: 2.0.0
-    dependencies:
-      postcss: registry.npmmirror.com/postcss@7.0.39
-    dev: false
-
-  registry.npmmirror.com/supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-color/-/supports-color-2.0.0.tgz}
-    name: supports-color
-    version: 2.0.0
-    engines: {node: '>=0.8.0'}
-    dev: true
-
-  registry.npmmirror.com/supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-color/-/supports-color-5.5.0.tgz}
-    name: supports-color
-    version: 5.5.0
-    engines: {node: '>=4'}
-    dependencies:
-      has-flag: registry.npmmirror.com/has-flag@3.0.0
-
   registry.npmmirror.com/supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz}
     name: supports-color
@@ -9631,27 +3425,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: registry.npmmirror.com/has-flag@4.0.0
-
-  registry.npmmirror.com/supports-hyperlinks@2.3.0:
-    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz}
-    name: supports-hyperlinks
-    version: 2.3.0
-    engines: {node: '>=8'}
-    dependencies:
-      has-flag: registry.npmmirror.com/has-flag@4.0.0
-      supports-color: registry.npmmirror.com/supports-color@7.2.0
-
-  registry.npmmirror.com/supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz}
-    name: supports-preserve-symlinks-flag
-    version: 1.0.0
-    engines: {node: '>= 0.4'}
-
-  registry.npmmirror.com/svg-tags@1.0.0:
-    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/svg-tags/-/svg-tags-1.0.0.tgz}
-    name: svg-tags
-    version: 1.0.0
-    dev: false
 
   registry.npmmirror.com/swagger2openapi@7.0.4:
     resolution: {integrity: sha512-MGzJU44XSXHKxvtx/NbBnP3z5s1KzN5xhqIBERoZEKfRiZ56lNUo5TGOv0dJ8n7JGeheCeU0CydfvbSOh+DaXg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/swagger2openapi/-/swagger2openapi-7.0.4.tgz}
@@ -9686,63 +3459,15 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
-  registry.npmmirror.com/table@5.4.6:
-    resolution: {integrity: sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/table/-/table-5.4.6.tgz}
-    name: table
-    version: 5.4.6
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      ajv: registry.npmmirror.com/ajv@6.12.6
-      lodash: registry.npmmirror.com/lodash@4.17.21
-      slice-ansi: registry.npmmirror.com/slice-ansi@2.1.0
-      string-width: registry.npmmirror.com/string-width@3.1.0
-    dev: false
-
-  registry.npmmirror.com/table@6.8.1:
-    resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/table/-/table-6.8.1.tgz}
-    name: table
-    version: 6.8.1
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      ajv: registry.npmmirror.com/ajv@8.12.0
-      lodash.truncate: registry.npmmirror.com/lodash.truncate@4.4.2
-      slice-ansi: registry.npmmirror.com/slice-ansi@4.0.0
-      string-width: registry.npmmirror.com/string-width@4.2.3
-      strip-ansi: registry.npmmirror.com/strip-ansi@6.0.1
-    dev: false
-
   registry.npmmirror.com/terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/terminal-link/-/terminal-link-2.1.1.tgz}
     name: terminal-link
     version: 2.1.1
     engines: {node: '>=8'}
     dependencies:
-      ansi-escapes: registry.npmmirror.com/ansi-escapes@4.3.2
-      supports-hyperlinks: registry.npmmirror.com/supports-hyperlinks@2.3.0
+      ansi-escapes: 4.3.2
+      supports-hyperlinks: 2.3.0
     dev: true
-
-  registry.npmmirror.com/text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/text-table/-/text-table-0.2.0.tgz}
-    name: text-table
-    version: 0.2.0
-    dev: false
-
-  registry.npmmirror.com/through2@0.6.5:
-    resolution: {integrity: sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/through2/-/through2-0.6.5.tgz}
-    name: through2
-    version: 0.6.5
-    dependencies:
-      readable-stream: registry.npmmirror.com/readable-stream@1.0.34
-      xtend: registry.npmmirror.com/xtend@4.0.2
-    dev: false
-
-  registry.npmmirror.com/through2@4.0.2:
-    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/through2/-/through2-4.0.2.tgz}
-    name: through2
-    version: 4.0.2
-    dependencies:
-      readable-stream: registry.npmmirror.com/readable-stream@3.6.2
-    dev: false
 
   registry.npmmirror.com/through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/through/-/through-2.3.8.tgz}
@@ -9774,22 +3499,6 @@ packages:
       os-tmpdir: registry.npmmirror.com/os-tmpdir@1.0.2
     dev: true
 
-  registry.npmmirror.com/to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz}
-    name: to-fast-properties
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/to-object-path@0.3.0:
-    resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-object-path/-/to-object-path-0.3.0.tgz}
-    name: to-object-path
-    version: 0.3.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmmirror.com/kind-of@3.2.2
-    dev: false
-
   registry.npmmirror.com/to-readable-stream@1.0.0:
     resolution: {integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz}
     name: to-readable-stream
@@ -9804,155 +3513,28 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/to-regex-range@2.1.1:
-    resolution: {integrity: sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-regex-range/-/to-regex-range-2.1.1.tgz}
-    name: to-regex-range
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-number: registry.npmmirror.com/is-number@3.0.0
-      repeat-string: registry.npmmirror.com/repeat-string@1.6.1
-    dev: false
-
   registry.npmmirror.com/to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz}
     name: to-regex-range
     version: 5.0.1
     engines: {node: '>=8.0'}
+    requiresBuild: true
     dependencies:
       is-number: registry.npmmirror.com/is-number@7.0.0
-
-  registry.npmmirror.com/to-regex@3.0.2:
-    resolution: {integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/to-regex/-/to-regex-3.0.2.tgz}
-    name: to-regex
-    version: 3.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      define-property: registry.npmmirror.com/define-property@2.0.2
-      extend-shallow: registry.npmmirror.com/extend-shallow@3.0.2
-      regex-not: registry.npmmirror.com/regex-not@1.0.2
-      safe-regex: registry.npmmirror.com/safe-regex@1.1.0
     dev: false
-
-  registry.npmmirror.com/trim-newlines@2.0.0:
-    resolution: {integrity: sha512-MTBWv3jhVjTU7XR3IQHllbiJs8sc75a80OEhB6or/q7pLTWgQ0bMGQXXYQSrSuXe6WiKWDZ5txXY5P59a/coVA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/trim-newlines/-/trim-newlines-2.0.0.tgz}
-    name: trim-newlines
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/trim-newlines@3.0.1:
-    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/trim-newlines/-/trim-newlines-3.0.1.tgz}
-    name: trim-newlines
-    version: 3.0.1
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/trim-trailing-lines@1.1.4:
-    resolution: {integrity: sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz}
-    name: trim-trailing-lines
-    version: 1.1.4
-    dev: false
-
-  registry.npmmirror.com/trim@0.0.1:
-    resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/trim/-/trim-0.0.1.tgz}
-    name: trim
-    version: 0.0.1
-    deprecated: Use String.prototype.trim() instead
-    dev: false
-
-  registry.npmmirror.com/trough@1.0.5:
-    resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/trough/-/trough-1.0.5.tgz}
-    name: trough
-    version: 1.0.5
-    dev: false
-
-  registry.npmmirror.com/tsconfig-paths@3.14.2:
-    resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz}
-    name: tsconfig-paths
-    version: 3.14.2
-    dependencies:
-      '@types/json5': registry.npmmirror.com/@types/json5@0.0.29
-      json5: registry.npmmirror.com/json5@1.0.2
-      minimist: registry.npmmirror.com/minimist@1.2.8
-      strip-bom: registry.npmmirror.com/strip-bom@3.0.0
-    dev: false
+    optional: true
 
   registry.npmmirror.com/tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tslib/-/tslib-1.14.1.tgz}
     name: tslib
     version: 1.14.1
+    dev: true
 
   registry.npmmirror.com/tslib@2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tslib/-/tslib-2.6.0.tgz}
     name: tslib
     version: 2.6.0
     dev: true
-
-  registry.npmmirror.com/tsutils@3.21.0(typescript@4.1.3):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/tsutils/-/tsutils-3.21.0.tgz}
-    id: registry.npmmirror.com/tsutils/3.21.0
-    name: tsutils
-    version: 3.21.0
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: registry.npmmirror.com/tslib@1.14.1
-      typescript: registry.npmmirror.com/typescript@4.1.3
-    dev: false
-
-  registry.npmmirror.com/type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz}
-    name: type-check
-    version: 0.4.0
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      prelude-ls: registry.npmmirror.com/prelude-ls@1.2.1
-    dev: false
-
-  registry.npmmirror.com/type-fest@0.10.0:
-    resolution: {integrity: sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type-fest/-/type-fest-0.10.0.tgz}
-    name: type-fest
-    version: 0.10.0
-    engines: {node: '>=8'}
-    dev: true
-
-  registry.npmmirror.com/type-fest@0.18.1:
-    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type-fest/-/type-fest-0.18.1.tgz}
-    name: type-fest
-    version: 0.18.1
-    engines: {node: '>=10'}
-
-  registry.npmmirror.com/type-fest@0.20.2:
-    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz}
-    name: type-fest
-    version: 0.20.2
-    engines: {node: '>=10'}
-
-  registry.npmmirror.com/type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type-fest/-/type-fest-0.21.3.tgz}
-    name: type-fest
-    version: 0.21.3
-    engines: {node: '>=10'}
-
-  registry.npmmirror.com/type-fest@0.4.1:
-    resolution: {integrity: sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type-fest/-/type-fest-0.4.1.tgz}
-    name: type-fest
-    version: 0.4.1
-    engines: {node: '>=6'}
-    dev: true
-
-  registry.npmmirror.com/type-fest@0.6.0:
-    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type-fest/-/type-fest-0.6.0.tgz}
-    name: type-fest
-    version: 0.6.0
-    engines: {node: '>=8'}
-
-  registry.npmmirror.com/type-fest@0.8.1:
-    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type-fest/-/type-fest-0.8.1.tgz}
-    name: type-fest
-    version: 0.8.1
-    engines: {node: '>=8'}
 
   registry.npmmirror.com/type@1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/type/-/type-1.2.0.tgz}
@@ -9966,141 +3548,13 @@ packages:
     version: 2.7.2
     dev: false
 
-  registry.npmmirror.com/typed-array-length@1.0.4:
-    resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/typed-array-length/-/typed-array-length-1.0.4.tgz}
-    name: typed-array-length
-    version: 1.0.4
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      for-each: registry.npmmirror.com/for-each@0.3.3
-      is-typed-array: registry.npmmirror.com/is-typed-array@1.1.10
-    dev: false
-
-  registry.npmmirror.com/typedarray-to-buffer@3.1.5:
-    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz}
-    name: typedarray-to-buffer
-    version: 3.1.5
-    dependencies:
-      is-typedarray: registry.npmmirror.com/is-typedarray@1.0.0
-
   registry.npmmirror.com/typescript@4.1.3:
     resolution: {integrity: sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/typescript/-/typescript-4.1.3.tgz}
     name: typescript
     version: 4.1.3
     engines: {node: '>=4.2.0'}
     hasBin: true
-
-  registry.npmmirror.com/unbox-primitive@1.0.2:
-    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz}
-    name: unbox-primitive
-    version: 1.0.2
-    dependencies:
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      has-bigints: registry.npmmirror.com/has-bigints@1.0.2
-      has-symbols: registry.npmmirror.com/has-symbols@1.0.3
-      which-boxed-primitive: registry.npmmirror.com/which-boxed-primitive@1.0.2
-    dev: false
-
-  registry.npmmirror.com/unherit@1.1.3:
-    resolution: {integrity: sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unherit/-/unherit-1.1.3.tgz}
-    name: unherit
-    version: 1.1.3
-    dependencies:
-      inherits: registry.npmmirror.com/inherits@2.0.4
-      xtend: registry.npmmirror.com/xtend@4.0.2
-    dev: false
-
-  registry.npmmirror.com/unicode-canonical-property-names-ecmascript@2.0.0:
-    resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz}
-    name: unicode-canonical-property-names-ecmascript
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/unicode-match-property-ecmascript@2.0.0:
-    resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz}
-    name: unicode-match-property-ecmascript
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      unicode-canonical-property-names-ecmascript: registry.npmmirror.com/unicode-canonical-property-names-ecmascript@2.0.0
-      unicode-property-aliases-ecmascript: registry.npmmirror.com/unicode-property-aliases-ecmascript@2.1.0
-    dev: false
-
-  registry.npmmirror.com/unicode-match-property-value-ecmascript@2.1.0:
-    resolution: {integrity: sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz}
-    name: unicode-match-property-value-ecmascript
-    version: 2.1.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/unicode-property-aliases-ecmascript@2.1.0:
-    resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz}
-    name: unicode-property-aliases-ecmascript
-    version: 2.1.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmmirror.com/unified@6.2.0:
-    resolution: {integrity: sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unified/-/unified-6.2.0.tgz}
-    name: unified
-    version: 6.2.0
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@2.0.6
-      bail: registry.npmmirror.com/bail@1.0.5
-      extend: registry.npmmirror.com/extend@3.0.2
-      is-plain-obj: registry.npmmirror.com/is-plain-obj@1.1.0
-      trough: registry.npmmirror.com/trough@1.0.5
-      vfile: registry.npmmirror.com/vfile@2.3.0
-      x-is-string: registry.npmmirror.com/x-is-string@0.1.0
-    dev: false
-
-  registry.npmmirror.com/unified@7.1.0:
-    resolution: {integrity: sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unified/-/unified-7.1.0.tgz}
-    name: unified
-    version: 7.1.0
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@2.0.6
-      '@types/vfile': registry.npmmirror.com/@types/vfile@3.0.2
-      bail: registry.npmmirror.com/bail@1.0.5
-      extend: registry.npmmirror.com/extend@3.0.2
-      is-plain-obj: registry.npmmirror.com/is-plain-obj@1.1.0
-      trough: registry.npmmirror.com/trough@1.0.5
-      vfile: registry.npmmirror.com/vfile@3.0.1
-      x-is-string: registry.npmmirror.com/x-is-string@0.1.0
-    dev: false
-
-  registry.npmmirror.com/unified@9.2.2:
-    resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unified/-/unified-9.2.2.tgz}
-    name: unified
-    version: 9.2.2
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@2.0.6
-      bail: registry.npmmirror.com/bail@1.0.5
-      extend: registry.npmmirror.com/extend@3.0.2
-      is-buffer: registry.npmmirror.com/is-buffer@2.0.5
-      is-plain-obj: registry.npmmirror.com/is-plain-obj@2.1.0
-      trough: registry.npmmirror.com/trough@1.0.5
-      vfile: registry.npmmirror.com/vfile@4.2.1
-    dev: false
-
-  registry.npmmirror.com/union-value@1.0.1:
-    resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/union-value/-/union-value-1.0.1.tgz}
-    name: union-value
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-union: registry.npmmirror.com/arr-union@3.1.0
-      get-value: registry.npmmirror.com/get-value@2.0.6
-      is-extendable: registry.npmmirror.com/is-extendable@0.1.1
-      set-value: registry.npmmirror.com/set-value@2.0.1
-    dev: false
-
-  registry.npmmirror.com/uniq@1.0.1:
-    resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/uniq/-/uniq-1.0.1.tgz}
-    name: uniq
-    version: 1.0.1
-    dev: false
+    dev: true
 
   registry.npmmirror.com/unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unique-string/-/unique-string-2.0.0.tgz}
@@ -10111,104 +3565,6 @@ packages:
       crypto-random-string: registry.npmmirror.com/crypto-random-string@2.0.0
     dev: true
 
-  registry.npmmirror.com/unist-util-find-all-after@1.0.5:
-    resolution: {integrity: sha512-lWgIc3rrTMTlK1Y0hEuL+k+ApzFk78h+lsaa2gHf63Gp5Ww+mt11huDniuaoq1H+XMK2lIIjjPkncxXcDp3QDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.5.tgz}
-    name: unist-util-find-all-after
-    version: 1.0.5
-    dependencies:
-      unist-util-is: registry.npmmirror.com/unist-util-is@3.0.0
-    dev: false
-
-  registry.npmmirror.com/unist-util-find-all-after@3.0.2:
-    resolution: {integrity: sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz}
-    name: unist-util-find-all-after
-    version: 3.0.2
-    dependencies:
-      unist-util-is: registry.npmmirror.com/unist-util-is@4.1.0
-    dev: false
-
-  registry.npmmirror.com/unist-util-is@3.0.0:
-    resolution: {integrity: sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-is/-/unist-util-is-3.0.0.tgz}
-    name: unist-util-is
-    version: 3.0.0
-    dev: false
-
-  registry.npmmirror.com/unist-util-is@4.1.0:
-    resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-is/-/unist-util-is-4.1.0.tgz}
-    name: unist-util-is
-    version: 4.1.0
-    dev: false
-
-  registry.npmmirror.com/unist-util-remove-position@1.1.4:
-    resolution: {integrity: sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz}
-    name: unist-util-remove-position
-    version: 1.1.4
-    dependencies:
-      unist-util-visit: registry.npmmirror.com/unist-util-visit@1.4.1
-    dev: false
-
-  registry.npmmirror.com/unist-util-stringify-position@1.1.2:
-    resolution: {integrity: sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz}
-    name: unist-util-stringify-position
-    version: 1.1.2
-    dev: false
-
-  registry.npmmirror.com/unist-util-stringify-position@2.0.3:
-    resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz}
-    name: unist-util-stringify-position
-    version: 2.0.3
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@2.0.6
-    dev: false
-
-  registry.npmmirror.com/unist-util-stringify-position@4.0.0:
-    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz}
-    name: unist-util-stringify-position
-    version: 4.0.0
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@3.0.0
-    dev: false
-
-  registry.npmmirror.com/unist-util-visit-parents@2.1.2:
-    resolution: {integrity: sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz}
-    name: unist-util-visit-parents
-    version: 2.1.2
-    dependencies:
-      unist-util-is: registry.npmmirror.com/unist-util-is@3.0.0
-    dev: false
-
-  registry.npmmirror.com/unist-util-visit@1.4.1:
-    resolution: {integrity: sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz}
-    name: unist-util-visit
-    version: 1.4.1
-    dependencies:
-      unist-util-visit-parents: registry.npmmirror.com/unist-util-visit-parents@2.1.2
-    dev: false
-
-  registry.npmmirror.com/unset-value@1.0.0:
-    resolution: {integrity: sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/unset-value/-/unset-value-1.0.0.tgz}
-    name: unset-value
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      has-value: registry.npmmirror.com/has-value@0.3.1
-      isobject: registry.npmmirror.com/isobject@3.0.1
-    dev: false
-
-  registry.npmmirror.com/update-browserslist-db@1.0.11(browserslist@4.21.9):
-    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz}
-    id: registry.npmmirror.com/update-browserslist-db/1.0.11
-    name: update-browserslist-db
-    version: 1.0.11
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: registry.npmmirror.com/browserslist@4.21.9
-      escalade: registry.npmmirror.com/escalade@3.1.1
-      picocolors: registry.npmmirror.com/picocolors@1.0.0
-    dev: false
-
   registry.npmmirror.com/update-notifier@5.1.0:
     resolution: {integrity: sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/update-notifier/-/update-notifier-5.1.0.tgz}
     name: update-notifier
@@ -10216,35 +3572,20 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       boxen: registry.npmmirror.com/boxen@5.1.2
-      chalk: registry.npmmirror.com/chalk@4.1.2
+      chalk: 4.1.2
       configstore: registry.npmmirror.com/configstore@5.0.1
       has-yarn: registry.npmmirror.com/has-yarn@2.1.0
-      import-lazy: registry.npmmirror.com/import-lazy@2.1.0
+      import-lazy: 2.1.0
       is-ci: registry.npmmirror.com/is-ci@2.0.0
       is-installed-globally: registry.npmmirror.com/is-installed-globally@0.4.0
       is-npm: registry.npmmirror.com/is-npm@5.0.0
       is-yarn-global: registry.npmmirror.com/is-yarn-global@0.3.0
       latest-version: registry.npmmirror.com/latest-version@5.1.0
       pupa: registry.npmmirror.com/pupa@2.1.1
-      semver: registry.npmmirror.com/semver@7.5.4
+      semver: 7.5.4
       semver-diff: registry.npmmirror.com/semver-diff@3.1.1
       xdg-basedir: registry.npmmirror.com/xdg-basedir@4.0.0
     dev: true
-
-  registry.npmmirror.com/uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz}
-    name: uri-js
-    version: 4.4.1
-    dependencies:
-      punycode: registry.npmmirror.com/punycode@2.3.0
-    dev: false
-
-  registry.npmmirror.com/urix@0.1.0:
-    resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/urix/-/urix-0.1.0.tgz}
-    name: urix
-    version: 0.1.0
-    deprecated: Please see https://github.com/lydell/urix#deprecated
-    dev: false
 
   registry.npmmirror.com/url-parse-lax@3.0.0:
     resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz}
@@ -10255,39 +3596,12 @@ packages:
       prepend-http: registry.npmmirror.com/prepend-http@2.0.0
     dev: true
 
-  registry.npmmirror.com/use@3.1.1:
-    resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/use/-/use-3.1.1.tgz}
-    name: use
-    version: 3.1.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmmirror.com/util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz}
-    name: util-deprecate
-    version: 1.0.2
-    dev: false
-
-  registry.npmmirror.com/v8-compile-cache@2.3.0:
-    resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz}
-    name: v8-compile-cache
-    version: 2.3.0
-    dev: false
-
   registry.npmmirror.com/vali-date@1.0.0:
     resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vali-date/-/vali-date-1.0.0.tgz}
     name: vali-date
     version: 1.0.0
     engines: {node: '>=0.10.0'}
     dev: true
-
-  registry.npmmirror.com/validate-npm-package-license@3.0.4:
-    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz}
-    name: validate-npm-package-license
-    version: 3.0.4
-    dependencies:
-      spdx-correct: registry.npmmirror.com/spdx-correct@3.2.0
-      spdx-expression-parse: registry.npmmirror.com/spdx-expression-parse@3.0.1
 
   registry.npmmirror.com/validate-npm-package-name@3.0.0:
     resolution: {integrity: sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz}
@@ -10297,122 +3611,13 @@ packages:
       builtins: registry.npmmirror.com/builtins@1.0.3
     dev: true
 
-  registry.npmmirror.com/vfile-location@2.0.6:
-    resolution: {integrity: sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vfile-location/-/vfile-location-2.0.6.tgz}
-    name: vfile-location
-    version: 2.0.6
-    dev: false
-
-  registry.npmmirror.com/vfile-message@1.1.1:
-    resolution: {integrity: sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vfile-message/-/vfile-message-1.1.1.tgz}
-    name: vfile-message
-    version: 1.1.1
-    dependencies:
-      unist-util-stringify-position: registry.npmmirror.com/unist-util-stringify-position@1.1.2
-    dev: false
-
-  registry.npmmirror.com/vfile-message@2.0.4:
-    resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vfile-message/-/vfile-message-2.0.4.tgz}
-    name: vfile-message
-    version: 2.0.4
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@2.0.6
-      unist-util-stringify-position: registry.npmmirror.com/unist-util-stringify-position@2.0.3
-    dev: false
-
-  registry.npmmirror.com/vfile-message@4.0.2:
-    resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.2.tgz}
-    name: vfile-message
-    version: 4.0.2
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@3.0.0
-      unist-util-stringify-position: registry.npmmirror.com/unist-util-stringify-position@4.0.0
-    dev: false
-
-  registry.npmmirror.com/vfile@2.3.0:
-    resolution: {integrity: sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vfile/-/vfile-2.3.0.tgz}
-    name: vfile
-    version: 2.3.0
-    dependencies:
-      is-buffer: registry.npmmirror.com/is-buffer@1.1.6
-      replace-ext: registry.npmmirror.com/replace-ext@1.0.0
-      unist-util-stringify-position: registry.npmmirror.com/unist-util-stringify-position@1.1.2
-      vfile-message: registry.npmmirror.com/vfile-message@1.1.1
-    dev: false
-
-  registry.npmmirror.com/vfile@3.0.1:
-    resolution: {integrity: sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vfile/-/vfile-3.0.1.tgz}
-    name: vfile
-    version: 3.0.1
-    dependencies:
-      is-buffer: registry.npmmirror.com/is-buffer@2.0.5
-      replace-ext: registry.npmmirror.com/replace-ext@1.0.0
-      unist-util-stringify-position: registry.npmmirror.com/unist-util-stringify-position@1.1.2
-      vfile-message: registry.npmmirror.com/vfile-message@1.1.1
-    dev: false
-
-  registry.npmmirror.com/vfile@4.2.1:
-    resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/vfile/-/vfile-4.2.1.tgz}
-    name: vfile
-    version: 4.2.1
-    dependencies:
-      '@types/unist': registry.npmmirror.com/@types/unist@2.0.6
-      is-buffer: registry.npmmirror.com/is-buffer@2.0.5
-      unist-util-stringify-position: registry.npmmirror.com/unist-util-stringify-position@2.0.3
-      vfile-message: registry.npmmirror.com/vfile-message@2.0.4
-    dev: false
-
-  registry.npmmirror.com/which-boxed-primitive@1.0.2:
-    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz}
-    name: which-boxed-primitive
-    version: 1.0.2
-    dependencies:
-      is-bigint: registry.npmmirror.com/is-bigint@1.0.4
-      is-boolean-object: registry.npmmirror.com/is-boolean-object@1.1.2
-      is-number-object: registry.npmmirror.com/is-number-object@1.0.7
-      is-string: registry.npmmirror.com/is-string@1.0.7
-      is-symbol: registry.npmmirror.com/is-symbol@1.0.4
-    dev: false
-
-  registry.npmmirror.com/which-typed-array@1.1.9:
-    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/which-typed-array/-/which-typed-array-1.1.9.tgz}
-    name: which-typed-array
-    version: 1.1.9
-    engines: {node: '>= 0.4'}
-    dependencies:
-      available-typed-arrays: registry.npmmirror.com/available-typed-arrays@1.0.5
-      call-bind: registry.npmmirror.com/call-bind@1.0.2
-      for-each: registry.npmmirror.com/for-each@0.3.3
-      gopd: registry.npmmirror.com/gopd@1.0.1
-      has-tostringtag: registry.npmmirror.com/has-tostringtag@1.0.0
-      is-typed-array: registry.npmmirror.com/is-typed-array@1.1.10
-    dev: false
-
-  registry.npmmirror.com/which@1.3.1:
-    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/which/-/which-1.3.1.tgz}
-    name: which
-    version: 1.3.1
-    hasBin: true
-    dependencies:
-      isexe: registry.npmmirror.com/isexe@2.0.0
-    dev: false
-
-  registry.npmmirror.com/which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/which/-/which-2.0.2.tgz}
-    name: which
-    version: 2.0.2
-    engines: {node: '>= 8'}
-    hasBin: true
-    dependencies:
-      isexe: registry.npmmirror.com/isexe@2.0.0
-
   registry.npmmirror.com/widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/widest-line/-/widest-line-3.1.0.tgz}
     name: widest-line
     version: 3.1.0
     engines: {node: '>=8'}
     dependencies:
-      string-width: registry.npmmirror.com/string-width@4.2.3
+      string-width: 4.2.3
     dev: true
 
   registry.npmmirror.com/wrap-ansi@3.0.1:
@@ -10421,8 +3626,8 @@ packages:
     version: 3.0.1
     engines: {node: '>=4'}
     dependencies:
-      string-width: registry.npmmirror.com/string-width@2.1.1
-      strip-ansi: registry.npmmirror.com/strip-ansi@4.0.0
+      string-width: 2.1.1
+      strip-ansi: 4.0.0
     dev: true
 
   registry.npmmirror.com/wrap-ansi@7.0.0:
@@ -10439,30 +3644,6 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz}
     name: wrappy
     version: 1.0.2
-
-  registry.npmmirror.com/write-file-atomic@3.0.3:
-    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz}
-    name: write-file-atomic
-    version: 3.0.3
-    dependencies:
-      imurmurhash: registry.npmmirror.com/imurmurhash@0.1.4
-      is-typedarray: registry.npmmirror.com/is-typedarray@1.0.0
-      signal-exit: registry.npmmirror.com/signal-exit@3.0.7
-      typedarray-to-buffer: registry.npmmirror.com/typedarray-to-buffer@3.1.5
-
-  registry.npmmirror.com/write@1.0.3:
-    resolution: {integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/write/-/write-1.0.3.tgz}
-    name: write
-    version: 1.0.3
-    engines: {node: '>=4'}
-    dependencies:
-      mkdirp: registry.npmmirror.com/mkdirp@0.5.6
-    dev: false
-
-  registry.npmmirror.com/x-is-string@0.1.0:
-    resolution: {integrity: sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/x-is-string/-/x-is-string-0.1.0.tgz}
-    name: x-is-string
-    version: 0.1.0
     dev: false
 
   registry.npmmirror.com/xdg-basedir@4.0.0:
@@ -10472,13 +3653,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  registry.npmmirror.com/xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/xtend/-/xtend-4.0.2.tgz}
-    name: xtend
-    version: 4.0.2
-    engines: {node: '>=0.4'}
-    dev: false
-
   registry.npmmirror.com/y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz}
     name: y18n
@@ -10486,29 +3660,11 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  registry.npmmirror.com/yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yallist/-/yallist-3.1.1.tgz}
-    name: yallist
-    version: 3.1.1
-    dev: false
-
-  registry.npmmirror.com/yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yallist/-/yallist-4.0.0.tgz}
-    name: yallist
-    version: 4.0.0
-
   registry.npmmirror.com/yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz}
     name: yaml
     version: 1.10.2
     engines: {node: '>= 6'}
-
-  registry.npmmirror.com/yargs-parser@10.1.0:
-    resolution: {integrity: sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs-parser/-/yargs-parser-10.1.0.tgz}
-    name: yargs-parser
-    version: 10.1.0
-    dependencies:
-      camelcase: registry.npmmirror.com/camelcase@4.1.0
     dev: false
 
   registry.npmmirror.com/yargs-parser@20.2.9:
@@ -10516,6 +3672,7 @@ packages:
     name: yargs-parser
     version: 20.2.9
     engines: {node: '>=10'}
+    dev: false
 
   registry.npmmirror.com/yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz}
@@ -10559,9 +3716,4 @@ packages:
     name: yocto-queue
     version: 0.1.0
     engines: {node: '>=10'}
-
-  registry.npmmirror.com/zwitch@1.0.5:
-    resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/zwitch/-/zwitch-1.0.5.tgz}
-    name: zwitch
-    version: 1.0.5
-    dev: false
+    dev: true

--- a/src/mockGenerator.ts
+++ b/src/mockGenerator.ts
@@ -1,10 +1,10 @@
 import Mock from 'mockjs';
 import fs from 'fs';
-import {prettierFile, writeFile} from './util';
-import {dirname, join} from 'path';
+import { prettierFile, writeFile } from './util';
+import { dirname, join } from 'path';
 import OpenAPIParserMock from './openAPIParserMock/index';
 import Log from './log';
-import pinyin from "tiny-pinyin";
+import pinyin from 'tiny-pinyin';
 
 Mock.Random.extend({
   country() {
@@ -123,7 +123,7 @@ const genMockData = (example: string) => {
     }, {});
 };
 
-const genByTemp = ( {
+const genByTemp = ({
   method,
   path,
   parameters,
@@ -132,7 +132,14 @@ const genByTemp = ( {
 }: {
   method: string;
   path: string;
-  parameters: { name: string, in: string, description: string, required: boolean, schema: {type: string}, example: string}[];
+  parameters: {
+    name: string;
+    in: string;
+    description: string;
+    required: boolean;
+    schema: { type: string };
+    example: string;
+  }[];
   status: string;
   data: string;
 }) => {
@@ -140,12 +147,12 @@ const genByTemp = ( {
     return '';
   }
 
-  let securityPath = path
-  parameters?.forEach(item => {
-    if (item.in === "path"){
-      securityPath = securityPath.replace(`{${item.name}}`, `:${item.name}`)
+  let securityPath = path;
+  parameters?.forEach((item) => {
+    if (item.in === 'path') {
+      securityPath = securityPath.replace(`{${item.name}}`, `:${item.name}`);
     }
-  })
+  });
 
   return `'${method.toUpperCase()} ${securityPath}': (req: Request, res: Response) => {
     res.status(${status}).send(${data});
@@ -180,7 +187,7 @@ const mockGenerator = async ({ openAPI, mockFolder }: genMockDataServerConfig) =
           path.replace('/', '').split('/')[1]
         )?.replace(/[^\w^\s^\u4e00-\u9fa5]/gi, '');
         if (/[\u3220-\uFA29]/.test(conte)) {
-          conte = pinyin.convertToPinyin(conte, '', true)
+          conte = pinyin.convertToPinyin(conte, '', true);
         }
         if (!conte) {
           return;

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,8 +6,6 @@ import path from 'path';
 import fs from 'fs';
 import { camelCase, upperFirst } from 'lodash';
 
-const { prettier: defaultPrettierOptions } = require('@umijs/fabric');
-
 export const getAbsolutePath = (filePath: string) => {
   if (filePath && !path.isAbsolute(filePath)) {
     return path.join(process.cwd(), filePath);
@@ -27,12 +25,11 @@ export const prettierFile = (content: string): [string, boolean] => {
   let hasError = false;
   try {
     const prettier = require('prettier');
+
+    const prettierOptions = prettier.resolveConfig.sync(process.cwd());
     result = prettier.format(content, {
-      singleQuote: true,
-      trailingComma: 'all',
-      printWidth: 100,
       parser: 'typescript',
-      ...defaultPrettierOptions,
+      ...prettierOptions,
     });
   } catch (error) {
     hasError = true;


### PR DESCRIPTION
当前项目生成文件时，使用的 prettier 配置来自于 ```@umijs/fabric```，导致两个小问题：
1. 默认的 prettier 配置与引用项目实际使用的配置可能不符，需要二次格式化；
2. 导致较多的次级依赖，比如vscode 项目打开时，始终提示stylelint 13 升级14 的警告；

该PR移除了 ```@umijs/fabric```依赖，将其prettier配置部分添加到项目的.prettierrc.js配置文件中；生成文件时，加载工作目录下的 prettier 配置，对生成的文件进行格式化。