### PR TITLE
fix: 修复未传入 authorization 时引发的报错

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,9 +167,9 @@ export const getSchema = async (schemaPath: string, authorization?: string) => {
       const agent = new protocol.Agent({
         rejectUnauthorized: false,
       });
-      const headers = {
+      const headers = authorization ? {
         authorization,
-      };
+      } : {};
       const json = await fetch(schemaPath, { agent, headers }).then((rest) => rest.json());
       return json;
     } catch (error) {


### PR DESCRIPTION
处理 TypeError: Cannot read properties of undefined (reading 'version') 报错，https://github.com/umijs/umi/issues/11998