### PR TITLE
feat:支持按tag将d.ts分散到多个文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ npm run openapi2ts
 | dataFields | No | Data fields in response | string[] | - |
 | isCamelCase | No | Use camelCase for files and functions | boolean | true |
 | declareType | No | Interface declaration type | type/interface | type |
+| splitDeclare | No | Generate a separate .d.ts file for each tag group. | boolean | - |
 
 ### Custom Hooks
 
@@ -170,6 +171,7 @@ npm run openapi2ts
 | dataFields | 否 | response 中数据字段 | string[] | - |
 | isCamelCase | 否 | 小驼峰命名文件和请求函数 | boolean | true |
 | declareType | 否 | interface 声明类型 | type/interface | type |
+| splitDeclare | 否 | 每个tag组一个独立的.d.ts. | boolean | - |
 
 ### 自定义钩子
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,8 @@ export type GenerateServiceProps = {
      */
     msw?: boolean;
   };
+  /**切割类型声明文件,默认为false*/
+  splitDeclare?:boolean
 };
 
 const converterSwaggerToOpenApi = (swagger: any) => {

--- a/test/test.js
+++ b/test/test.js
@@ -138,5 +138,11 @@ const gen = async () => {
       // msw: true,
     },
   });
+
+  await openAPI.generateService({
+    schemaPath: `${__dirname}/example-files/swagger-splitdeclare.json`,
+    serversPath: './splitDeclare',
+    splitDeclare:true
+  });
 };
 gen();


### PR DESCRIPTION
当项目模块很多，多人协作开发时，每次合并types.d.ts都有一堆的冲突需要合并，因此增加一个选项，可以按tags切割声明文件。